### PR TITLE
Add example of autogenerated `code` element reading from file with ppx-blob

### DIFF
--- a/example/esy.json
+++ b/example/esy.json
@@ -2,9 +2,7 @@
   "name": "app",
   "version": "0.0.1",
   "license": "MIT",
-  "esy": {
-    "build": ["refmterr dune build ./src/App.bc.js"]
-  },
+  "esy": { "build": [ "refmterr dune build ./src/App.bc.js" ] },
   "scripts": {
     "build:watch": "refmterr dune build ./src/App.bc.js -w",
     "build:prod": "refmterr dune build --profile=prod ./src/App.bc.js",
@@ -18,17 +16,20 @@
     "@opam/js_of_ocaml": "~3.4.0",
     "@opam/js_of_ocaml-lwt": "~3.4.0",
     "@opam/js_of_ocaml-ppx": "~3.4.0",
-    "ocaml": "~4.8.0",
-    "refmterr": "*",
+    "@opam/ppx_blob": "0.4.0",
+    "jsoo-react-esy": "^0.0.1",
     "jsoo-react-ppx-esy": "^0.0.1",
-    "jsoo-react-esy": "^0.0.1"
+    "ocaml": "~4.8.0",
+    "refmterr": "*"
   },
   "devDependencies": { "ocaml": "~4.8.0" },
   "resolutions": {
     "jsoo-react-ppx-esy": "link-dev:../ppx",
     "jsoo-react-esy": "link-dev:../lib",
     "@opam/js_of_ocaml": "ocsigen/js_of_ocaml:js_of_ocaml.opam#0bf16c4",
-    "@opam/js_of_ocaml-lwt": "ocsigen/js_of_ocaml:js_of_ocaml-lwt.opam#0bf16c4",
-    "@opam/js_of_ocaml-ppx": "ocsigen/js_of_ocaml:js_of_ocaml-ppx.opam#0bf16c4"
+    "@opam/js_of_ocaml-lwt":
+      "ocsigen/js_of_ocaml:js_of_ocaml-lwt.opam#0bf16c4",
+    "@opam/js_of_ocaml-ppx":
+      "ocsigen/js_of_ocaml:js_of_ocaml-ppx.opam#0bf16c4"
   }
 }

--- a/example/esy.lock/index.json
+++ b/example/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "83d7f05fcdd3871985b29c047af1f98c",
+  "checksum": "815b9404057e2c16c653966d9dbd118e",
   "root": "app@link-dev:./esy.json",
   "node": {
     "refmterr@3.2.2@d41d8cd9": {
@@ -16,7 +16,7 @@
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@reason-native/pastel@0.2.1@d41d8cd9",
         "@reason-native/console@0.1.0@d41d8cd9",
-        "@opam/re@opam:1.9.0@fc2ceb05", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:1.11.3@9894df55",
         "@opam/atdgen@opam:2.0.0@5d912e07",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
       ],
@@ -79,6 +79,7 @@
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "jsoo-react-ppx-esy@link-dev:../ppx",
         "jsoo-react-esy@link-dev:../lib",
+        "@opam/ppx_blob@opam:0.4.0@88e42e0d",
         "@opam/js_of_ocaml-ppx@github:ocsigen/js_of_ocaml:js_of_ocaml-ppx.opam#0bf16c4@d41d8cd9",
         "@opam/js_of_ocaml-lwt@github:ocsigen/js_of_ocaml:js_of_ocaml-lwt.opam#0bf16c4@d41d8cd9",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#0bf16c4@d41d8cd9",
@@ -169,7 +170,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -199,7 +200,7 @@
         "@opam/uucp@opam:12.0.0@b7d4c3df", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -229,7 +230,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
         "@opam/uchar@opam:0.0.2@c8218eea", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -255,13 +256,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/tyxml@opam:4.3.0@9dca4c30": {
-      "id": "@opam/tyxml@opam:4.3.0@9dca4c30",
+    "@opam/tyxml@opam:4.3.0@c1da25f1": {
+      "id": "@opam/tyxml@opam:4.3.0@c1da25f1",
       "name": "@opam/tyxml",
       "version": "opam:4.3.0",
       "source": {
@@ -279,12 +280,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
-        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.9.0@fc2ceb05",
+        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.9.0@d4d5e13d",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
-        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.9.0@fc2ceb05",
+        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.9.0@d4d5e13d",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
@@ -307,11 +308,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@427a2331"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
       ]
     },
     "@opam/stdio@opam:v0.12.0@04b3b004": {
@@ -385,8 +386,8 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/result@opam:1.4@6fb665c3": {
-      "id": "@opam/result@opam:1.4@6fb665c3",
+    "@opam/result@opam:1.4@dc720aef": {
+      "id": "@opam/result@opam:1.4@dc720aef",
       "name": "@opam/result",
       "version": "opam:1.4",
       "source": {
@@ -410,8 +411,8 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/re@opam:1.9.0@fc2ceb05": {
-      "id": "@opam/re@opam:1.9.0@fc2ceb05",
+    "@opam/re@opam:1.9.0@d4d5e13d": {
+      "id": "@opam/re@opam:1.9.0@d4d5e13d",
       "name": "@opam/re",
       "version": "opam:1.9.0",
       "source": {
@@ -455,18 +456,18 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/stdio@opam:v0.12.0@04b3b004",
-        "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
-        "@opam/ocaml-compiler-libs@opam:v0.12.0@692d9405",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
+        "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/base@opam:v0.12.2@4eee02b5",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/stdio@opam:v0.12.0@04b3b004",
-        "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
-        "@opam/ocaml-compiler-libs@opam:v0.12.0@692d9405",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
+        "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d",
         "@opam/dune@opam:1.11.3@9894df55", "@opam/base@opam:v0.12.2@4eee02b5"
       ]
     },
@@ -489,17 +490,17 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/ppx_derivers@opam:1.2.1@aee9c3db": {
-      "id": "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
+    "@opam/ppx_derivers@opam:1.2.1@ecf0aa45": {
+      "id": "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
       "name": "@opam/ppx_derivers",
       "version": "opam:1.2.1",
       "source": {
@@ -523,6 +524,34 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
+    "@opam/ppx_blob@opam:0.4.0@88e42e0d": {
+      "id": "@opam/ppx_blob@opam:0.4.0@88e42e0d",
+      "name": "@opam/ppx_blob",
+      "version": "opam:0.4.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/b9/b952544785ab6236bb099740d522cc3d#md5:b952544785ab6236bb099740d522cc3d",
+          "archive:https://github.com/johnwhitington/ppx_blob/releases/download/0.4.0/ppx_blob-0.4.0.tbz#md5:b952544785ab6236bb099740d522cc3d"
+        ],
+        "opam": {
+          "name": "ppx_blob",
+          "version": "0.4.0",
+          "path": "esy.lock/opam/ppx_blob.0.4.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.8.1000@d41d8cd9",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
+        "@opam/jbuilder@opam:transition@58bdfe0a",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.8.1000@d41d8cd9",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d"
+      ]
+    },
     "@opam/odoc@opam:1.4.1@7b0020a6": {
       "id": "@opam/odoc@opam:1.4.1@7b0020a6",
       "name": "@opam/odoc",
@@ -541,8 +570,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/tyxml@opam:4.3.0@9dca4c30",
-        "@opam/result@opam:1.4@6fb665c3", "@opam/fpath@opam:0.7.2@45477b93",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/tyxml@opam:4.3.0@c1da25f1",
+        "@opam/result@opam:1.4@dc720aef", "@opam/fpath@opam:0.7.2@45477b93",
         "@opam/dune@opam:1.11.3@9894df55", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/astring@opam:0.8.3@4e5e17d5",
@@ -576,7 +605,7 @@
       ],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -607,12 +636,12 @@
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
         "@opam/uuseg@opam:12.0.0@bf82c4c7",
-        "@opam/stdio@opam:v0.12.0@04b3b004", "@opam/re@opam:1.9.0@fc2ceb05",
+        "@opam/stdio@opam:v0.12.0@04b3b004", "@opam/re@opam:1.9.0@d4d5e13d",
         "@opam/odoc@opam:1.4.1@7b0020a6",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.11.3@9894df55",
         "@opam/cmdliner@opam:1.0.4@93208aac",
-        "@opam/bisect_ppx@opam:1.4.1@68dd08e4",
+        "@opam/bisect_ppx@opam:1.4.1@e75b441f",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base@opam:v0.12.2@4eee02b5",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -620,12 +649,12 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
         "@opam/uuseg@opam:12.0.0@bf82c4c7",
-        "@opam/stdio@opam:v0.12.0@04b3b004", "@opam/re@opam:1.9.0@fc2ceb05",
+        "@opam/stdio@opam:v0.12.0@04b3b004", "@opam/re@opam:1.9.0@d4d5e13d",
         "@opam/odoc@opam:1.4.1@7b0020a6",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.11.3@9894df55",
         "@opam/cmdliner@opam:1.0.4@93208aac",
-        "@opam/bisect_ppx@opam:1.4.1@68dd08e4",
+        "@opam/bisect_ppx@opam:1.4.1@e75b441f",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base@opam:v0.12.2@4eee02b5"
       ]
@@ -654,13 +683,13 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/conf-m4@opam:1@da6f4f44",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/conf-m4@opam:1@3b2b148a",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/ocamlbuild@opam:0.14.0@427a2331": {
-      "id": "@opam/ocamlbuild@opam:0.14.0@427a2331",
+    "@opam/ocamlbuild@opam:0.14.0@6ac75d03": {
+      "id": "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
       "name": "@opam/ocamlbuild",
       "version": "opam:0.14.0",
       "source": {
@@ -686,8 +715,8 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334": {
-      "id": "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+    "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d": {
+      "id": "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
       "name": "@opam/ocaml-migrate-parsetree",
       "version": "opam:1.4.0",
       "source": {
@@ -704,30 +733,30 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/ocaml-compiler-libs@opam:v0.12.0@692d9405": {
-      "id": "@opam/ocaml-compiler-libs@opam:v0.12.0@692d9405",
+    "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d": {
+      "id": "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d",
       "name": "@opam/ocaml-compiler-libs",
-      "version": "opam:v0.12.0",
+      "version": "opam:v0.12.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/33/3351925ed99be59829641d2044fc80c0#md5:3351925ed99be59829641d2044fc80c0",
-          "archive:https://github.com/janestreet/ocaml-compiler-libs/archive/v0.12.0.tar.gz#md5:3351925ed99be59829641d2044fc80c0"
+          "archive:https://opam.ocaml.org/cache/md5/2f/2f929af7c764a3f681a5671f271210c4#md5:2f929af7c764a3f681a5671f271210c4",
+          "archive:https://github.com/janestreet/ocaml-compiler-libs/archive/v0.12.1.tar.gz#md5:2f929af7c764a3f681a5671f271210c4"
         ],
         "opam": {
           "name": "ocaml-compiler-libs",
-          "version": "v0.12.0",
-          "path": "esy.lock/opam/ocaml-compiler-libs.v0.12.0"
+          "version": "v0.12.1",
+          "path": "esy.lock/opam/ocaml-compiler-libs.v0.12.1"
         }
       },
       "overrides": [],
@@ -739,8 +768,8 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/mmap@opam:1.1.0@7bef1e51": {
-      "id": "@opam/mmap@opam:1.1.0@7bef1e51",
+    "@opam/mmap@opam:1.1.0@b85334ff": {
+      "id": "@opam/mmap@opam:1.1.0@b85334ff",
       "name": "@opam/mmap",
       "version": "opam:1.1.0",
       "source": {
@@ -808,7 +837,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
@@ -832,9 +861,9 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/result@opam:1.4@6fb665c3",
+        "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@7bef1e51", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55",
         "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084",
@@ -842,9 +871,9 @@
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/result@opam:1.4@6fb665c3",
+        "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@7bef1e51", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/js_of_ocaml-ppx@github:ocsigen/js_of_ocaml:js_of_ocaml-ppx.opam#0bf16c4@d41d8cd9": {
@@ -862,14 +891,14 @@
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#0bf16c4@d41d8cd9",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#0bf16c4@d41d8cd9"
       ]
     },
@@ -941,14 +970,14 @@
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406"
       ]
     },
@@ -986,13 +1015,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#0bf16c4@d41d8cd9",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/js_of_ocaml@github:ocsigen/js_of_ocaml:js_of_ocaml.opam#0bf16c4@d41d8cd9"
       ]
     },
@@ -1015,14 +1044,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
-        "@opam/result@opam:1.4@6fb665c3",
+        "@opam/result@opam:1.4@dc720aef",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/astring@opam:0.8.3@4e5e17d5",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/astring@opam:0.8.3@4e5e17d5"
       ]
     },
@@ -1110,8 +1139,8 @@
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/conf-m4@opam:1@da6f4f44": {
-      "id": "@opam/conf-m4@opam:1@da6f4f44",
+    "@opam/conf-m4@opam:1@3b2b148a": {
+      "id": "@opam/conf-m4@opam:1@3b2b148a",
       "name": "@opam/conf-m4",
       "version": "opam:1",
       "source": {
@@ -1149,8 +1178,8 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/bisect_ppx@opam:1.4.1@68dd08e4": {
-      "id": "@opam/bisect_ppx@opam:1.4.1@68dd08e4",
+    "@opam/bisect_ppx@opam:1.4.1@e75b441f": {
+      "id": "@opam/bisect_ppx@opam:1.4.1@e75b441f",
       "name": "@opam/bisect_ppx",
       "version": "opam:1.4.1",
       "source": {
@@ -1169,7 +1198,7 @@
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1177,7 +1206,7 @@
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
@@ -1396,7 +1425,7 @@
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1430,9 +1459,9 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/merlin-extend@opam:0.5@a5dd7d4b",
         "@opam/menhir@opam:20190626@bbeb8953",
         "@opam/dune@opam:1.11.3@9894df55"

--- a/example/esy.lock/opam/bisect_ppx.1.4.1/opam
+++ b/example/esy.lock/opam/bisect_ppx.1.4.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 
 synopsis: "Code coverage for OCaml"
-license: "MPL2"
+license: "MPL-2.0"
 homepage: "https://github.com/aantron/bisect_ppx"
 doc: "https://github.com/aantron/bisect_ppx"
 bug-reports: "https://github.com/aantron/bisect_ppx/issues"

--- a/example/esy.lock/opam/conf-m4.1/opam
+++ b/example/esy.lock/opam/conf-m4.1/opam
@@ -3,7 +3,7 @@ maintainer: "tim@gfxmonk.net"
 homepage: "http://www.gnu.org/software/m4/m4.html"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "GNU Project"
-license: "GPL-3"
+license: "GPL-3.0-only"
 build: [["sh" "-exc" "echo | m4"]]
 depexts: [
   ["m4"] {os-family = "debian"}

--- a/example/esy.lock/opam/mmap.1.1.0/opam
+++ b/example/esy.lock/opam/mmap.1.1.0/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/mirage/mmap"
 bug-reports: "https://github.com/mirage/mmap/issues"
 doc: "https://mirage.github.io/mmap/"
 dev-repo: "git+https://github.com/mirage/mmap.git"
-license: "LGPL 2.1 with linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/example/esy.lock/opam/ocaml-compiler-libs.v0.12.1/opam
+++ b/example/esy.lock/opam/ocaml-compiler-libs.v0.12.1/opam
@@ -10,14 +10,14 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.1"}
-  "dune" {>= "1.0"}
+  "dune" {>= "1.5.1"}
 ]
 synopsis: "OCaml compiler libraries repackaged"
 description: """
 This packages exposes the OCaml compiler libraries repackages under
-the toplevel names Ocaml_common, Ocaml_bytecomp, ..."""
+the toplevel names Ocaml_common, Ocaml_bytecomp, Ocaml_optcomp, ..."""
 url {
   src:
-    "https://github.com/janestreet/ocaml-compiler-libs/archive/v0.12.0.tar.gz"
-  checksum: "md5=3351925ed99be59829641d2044fc80c0"
+    "https://github.com/janestreet/ocaml-compiler-libs/archive/v0.12.1.tar.gz"
+  checksum: "md5=2f929af7c764a3f681a5671f271210c4"
 }

--- a/example/esy.lock/opam/ocaml-migrate-parsetree.1.4.0/opam
+++ b/example/esy.lock/opam/ocaml-migrate-parsetree.1.4.0/opam
@@ -4,7 +4,7 @@ authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
   "Jérémie Dimino <jeremie@dimino.org>"
 ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
 bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"

--- a/example/esy.lock/opam/ocamlbuild.0.14.0/opam
+++ b/example/esy.lock/opam/ocamlbuild.0.14.0/opam
@@ -3,7 +3,7 @@ maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
 authors: ["Nicolas Pouillard" "Berke Durak"]
 homepage: "https://github.com/ocaml/ocamlbuild/"
 bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
 build: [

--- a/example/esy.lock/opam/ppx_blob.0.4.0/opam
+++ b/example/esy.lock/opam/ppx_blob.0.4.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "git+https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "jbuilder" {build}
+  "ocaml-migrate-parsetree"
+  "alcotest" {with-test}
+]
+synopsis: "Include a file as a string at compile time"
+description:
+  "ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob \"filename\"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions."
+url {
+  src:
+    "https://github.com/johnwhitington/ppx_blob/releases/download/0.4.0/ppx_blob-0.4.0.tbz"
+  checksum: "md5=b952544785ab6236bb099740d522cc3d"
+}

--- a/example/esy.lock/opam/ppx_derivers.1.2.1/opam
+++ b/example/esy.lock/opam/ppx_derivers.1.2.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "jeremie@dimino.org"
 authors: ["Jérémie Dimino"]
-license: "BSD3"
+license: "BSD-3-Clause"
 homepage: "https://github.com/ocaml-ppx/ppx_derivers"
 bug-reports: "https://github.com/ocaml-ppx/ppx_derivers/issues"
 dev-repo: "git://github.com/ocaml-ppx/ppx_derivers.git"

--- a/example/esy.lock/opam/re.1.9.0/opam
+++ b/example/esy.lock/opam/re.1.9.0/opam
@@ -8,7 +8,7 @@ authors: [
   "Rudi Grinberg"
   "Gabriel Radanne"
 ]
-license: "LGPL-2.0 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/ocaml-re"
 bug-reports: "https://github.com/ocaml/ocaml-re/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml-re.git"

--- a/example/esy.lock/opam/result.1.4/opam
+++ b/example/esy.lock/opam/result.1.4/opam
@@ -4,7 +4,7 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"
-license: "BSD3"
+license: "BSD-3-Clause"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"

--- a/example/esy.lock/opam/tyxml.4.3.0/opam
+++ b/example/esy.lock/opam/tyxml.4.3.0/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/ocsigen/tyxml/"
 bug-reports: "https://github.com/ocsigen/tyxml/issues"
 doc: "https://ocsigen.org/tyxml/manual/"
 dev-repo: "git+https://github.com/ocsigen/tyxml.git"
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 
 build: [
   ["dune" "subst"] {pinned}

--- a/example/src/App.re
+++ b/example/src/App.re
@@ -6,16 +6,37 @@ let reason =
     <> div <div key="second" /> </>
   </GreetingReason>;
 
+let s = React.string;
+
 let main =
   <div className="medium-container">
-    <h1 className="hello"> {"OCaml component" |> React.string} </h1>
+    <h1 className="hello"> {"OCaml component" |> s} </h1>
     caml
-    <h1> {"Reason component" |> React.string} </h1>
+    <h1> {"Reason component" |> s} </h1>
     reason
-    <h1> {"Refs" |> React.string} </h1>
+    <h1> {"Refs" |> s} </h1>
     <Refs />
-    <h1 key="h1"> {"Interface files" |> React.string} </h1>
-    <Interface key="inter" title="Hi from a component with an interface file"> React.null </Interface>
+    <h1 key="h1"> {"Interface files" |> s} </h1>
+    <Interface key="inter" title="Hi from a component with an interface file">
+      React.null
+    </Interface>
+    <h1 key="h1"> {"Integration with ppxs" |> s} </h1>
+    <p>
+      {"The following code is being read from one of the files in the project: "
+       |> s}
+      <code> {"Interface.re" |> s} </code>
+      {"." |> s}
+    </p>
+    <p>
+      {"It gets rendered via " |> s}
+      <a href="https://github.com/johnwhitington/ppx_blob" target="_blank">
+        {"ppx_blob" |> s}
+      </a>
+      {" by calling " |> s}
+      <code> {"<Code text=[%blob \"Interface.re\"] />" |> s} </code>
+      {":" |> s}
+    </p>
+    <Code text=[%blob "Interface.re"] />
   </div>;
 
 ReactDOM.renderToElementWithId(main, "app");

--- a/example/src/Code.re
+++ b/example/src/Code.re
@@ -1,0 +1,4 @@
+[@react.component]
+let make = (~text) => {
+  <pre> <code> {text |> React.string} </code> </pre>;
+};

--- a/example/src/Interface.re
+++ b/example/src/Interface.re
@@ -1,13 +1,15 @@
+let s = React.string;
+
 [@react.component]
 let make = (~title, ~children) => {
   <div>
-    <span> {React.string(title)} </span>
+    <span> {title |> s} </span>
     children
-    <br/>
-    <br/>
+    <br />
+    <br />
     <blockquote>
-      <p> {"Keep it secret. Keep it safe." |> React.string} </p>
-      <cite> {"Gandalf the Gray" |> React.string} </cite>
+      <p> {"Keep it secret. Keep it safe." |> s} </p>
+      <cite> {"Gandalf the Gray" |> s} </cite>
     </blockquote>
   </div>;
 };

--- a/example/src/dune
+++ b/example/src/dune
@@ -1,6 +1,5 @@
 (executable
  (name App)
  (libraries js_of_ocaml-lwt jsoo-react-esy)
- (js_of_ocaml (flags (--pretty)))
  (preprocess
-  (pps jsoo-react-ppx js_of_ocaml-ppx)))
+  (pps ppx_blob jsoo-react-ppx js_of_ocaml-ppx)))

--- a/lib/ReactDOM.mli
+++ b/lib/ReactDOM.mli
@@ -50,6 +50,7 @@ val domProps :
   ?className:string ->
   ?href:string ->
   ?onClick:(ReactEvent.Mouse.t -> unit) ->
+  ?target:string ->
   unit -> domProps
   [@@js.builder]
 


### PR DESCRIPTION
A small experiment to "inject" code to a `Code` component at build time through a ppx.

Looks like this:

<img width="700" alt="image" src="https://user-images.githubusercontent.com/220424/64826669-b692f700-d5c1-11e9-9fb7-de41fe2a3dbd.png">
