### PR TITLE
CI: Update setup-ocaml to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,8 @@ jobs:
       - name: Build
         run: make build
 
-      # Formatting is broken in ci for some reason
-      # - name: Check formatting
-      #   run: make format
+      - name: Check formatting
+        run: make format
 
       - name: "Install npm packages for tests"
         run: yarn install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-version:
-          - 4.13.0
+          - 4.10.0
 
     steps:
       - name: Checkout code
@@ -38,14 +38,9 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           opam install . --deps-only --with-doc --with-test
           opam install ocamlformat
-
-      - name: Upgrade dependencies
-        run: opam upgrade --fixup
-        if: steps.cache-opam.outputs.cache-hit == 'true'
 
       - name: Build
         run: make build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
 
 jobs:
   build:
@@ -16,26 +21,16 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-version:
-          - 4.10.0
+          - 4.13.0
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Retrieve opam cache
-        uses: actions/cache@v2
-        if: runner.os != 'Windows'
-        id: cache-opam
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
         with:
-          path: ~/.opam
-          key: v1-${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{ hashFiles('jsoo-react.opam') }}
-          restore-keys: |
-            v1-${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{ hashFiles('jsoo-react.opam') }}
-
-      - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
-        with:
-          ocaml-version: ${{ matrix.ocaml-version }}
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       - name: Use Node 12
         uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
 
       - name: Use Node 12
         uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          dune-cache: true
+          dune-cache: ${{ matrix.os != 'macos-latest' }}
 
       - name: Use Node 12
         uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        ocaml-version:
-          - 4.10.0
+        ocaml-compiler:
+          - 4.10.2
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
What title says. 

See related PR: https://github.com/ocaml/setup-ocaml/pull/66.

Biggest improvements are that windows caching actually works. Also, macOS build is fixed (it was failing for some reason as it was not able to find `reason` or other commands).

The downside is that dependencies builds are not cached, so ubuntu build takes now ~4min instead of ~1.  But I still think it's worth it, as we simplify cache handling and support more platforms so full build takes shorter and is more reliable. Also, upgrades to new versions of `setup-ocaml` will be easier. See related issue for caching deps: https://github.com/ocaml/setup-ocaml/issues/159.