### PR TITLE
replace {dev} with :with-test

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -33,12 +33,12 @@
   (js_of_ocaml-ppx :with-test)
   (conf-npm :with-test)
 
-  ;; Dev dependencies
-  (ocamlformat :dev)
-  (reason :dev)
+  ;; Dev dependencies, using with-test so that consumers don't install them (until package is released in opam)
+  (ocamlformat :with-test)
+  (reason :with-test)
 
-  ;; Example dependencies
-  (ppx_blob :dev)
-  (js_of_ocaml-lwt :dev)
+  ;; Example dependencies, using with-test so that consumers don't install them (until package is released in opam)
+  (ppx_blob :with-test)
+  (js_of_ocaml-lwt :with-test)
 
 ))

--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -16,10 +16,10 @@ depends: [
   "webtest-js" {with-test}
   "js_of_ocaml-ppx" {with-test}
   "conf-npm" {with-test}
-  "ocamlformat" {dev}
-  "reason" {dev}
-  "ppx_blob" {dev}
-  "js_of_ocaml-lwt" {dev}
+  "ocamlformat" {with-test}
+  "reason" {with-test}
+  "ppx_blob" {with-test}
+  "js_of_ocaml-lwt" {with-test}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
When this package is added as a dependency of another project, because it has not been published to opam, the behavior of `dev` variable is to become true and so dev dependencies will get installed as well. In jsoo-react case, this means `reason` gets installed, which means trouble with recent OCaml versions like 4.13.1.

From [opam docs](https://opam.ocaml.org/doc/Manual.html#Package-variables):

> dev: true if this is a development package, i.e. it was not built from a release archive

From @aantron in Discord:

> yeah it seems that its best to use it for things that are actually necessary for the build of an unreleased package specifically, which is few things in ocaml these days (nothing for most projects), and is probably bad form

Ideally, there'd be a `with-dev` flag, but it doesn't seem to exist. So for now, i'm (ab)using `with-test` for this.