### PR TITLE
Create a test case for capturing error messages at build(ppx)-time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,7 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      - name: Run error message test
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: make test-error-msg

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ dev: ## Build in watch mode
 	$(DUNE) build -w @@default
 
 test: ## Run the unit tests
-	$(DUNE) build @runtest --no-buffer
+	$(DUNE) build @runtest --diff-command "git --no-pager diff --no-index --color=never -u --minimal"
 
 test-promote: ## Updates snapshots and promotes it to correct
 	$(DUNE) build @runtest --auto-promote

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,17 @@ dev: ## Build in watch mode
 	$(DUNE) build -w @@default
 
 test: ## Run the unit tests
-	$(DUNE) build @runtest --diff-command "git --no-pager diff --no-index --color=never -u --minimal"
+	$(DUNE) build @runtest
 
 test-promote: ## Updates snapshots and promotes it to correct
-	$(DUNE) build @runtest --auto-promote
+	$(DUNE) build @runtest
+
+# This is a separate command to run this tests conditionaly on CI, currently the dune setup with (bash "! ./%{main} %{input}")) fails in Windows. We skip it on Windows.
+test-error-msg: ## Run the unit tests for error messages
+	$(DUNE) build @error-msg --diff-command "git --no-pager diff --no-index --color=never -u --minimal"
+
+test-error-msg-promote: ## Update snapshots and promotes it to correct only the unit tests for error messages
+	$(DUNE) build @error-msg --diff-command "git --no-pager diff --no-index --color=never -u --minimal"
 
 deps: $(opam_file) ## Alias to update the opam file and install the needed deps
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ dev: ## Build in watch mode
 	$(DUNE) build -w @@default
 
 test: ## Run the unit tests
-	$(DUNE) build @runtest
+	$(DUNE) build @runtest --no-buffer
 
 test-promote: ## Updates snapshots and promotes it to correct
 	$(DUNE) build @runtest --auto-promote

--- a/ppx/test/dune
+++ b/ppx/test/dune
@@ -17,6 +17,7 @@
    (run refmt --parse=re --print=ml %{deps}))))
 
 (rule
+ (alias error-msg)
  (targets element_attribute_error.result)
  (deps
   (:main ./main.exe)
@@ -24,7 +25,7 @@
  (action
   (with-stderr-to
    %{targets}
-   (system "! ./%{main} %{input}"))))
+   (bash "! ./%{main} %{input}"))))
 
 (rule
  (targets pp_ocaml.result)
@@ -37,5 +38,4 @@
  (action
   (progn
    (diff pp_reason.expected pp_reason.result)
-   (diff pp_ocaml.expected pp_ocaml.result)
-   (diff element_attribute_error.expected element_attribute_error.result))))
+   (diff pp_ocaml.expected pp_ocaml.result))))

--- a/ppx/test/dune
+++ b/ppx/test/dune
@@ -19,12 +19,12 @@
 (rule
  (targets element_attribute_error.actual)
  (deps
-  (:pp ./main.exe)
+  (:main ./main.exe)
   (:input element_attribute_error.ml))
  (action
   (with-stderr-to
    %{targets}
-   (bash "! ./%{pp} %{input}"))))
+   (bash "! ./%{main} %{input}"))))
 
 (rule
  (targets pp_ocaml.result)

--- a/ppx/test/dune
+++ b/ppx/test/dune
@@ -17,6 +17,16 @@
    (run refmt --parse=re --print=ml %{deps}))))
 
 (rule
+ (targets element_attribute_error.actual)
+ (deps
+  (:pp ./main.exe)
+  (:input element_attribute_error.ml))
+ (action
+  (with-stderr-to
+   %{targets}
+   (bash "! ./%{pp} %{input}"))))
+
+(rule
  (targets pp_ocaml.result)
  (deps input_ocaml.ml)
  (action
@@ -31,3 +41,8 @@
  (alias runtest)
  (action
   (diff pp_ocaml.expected pp_ocaml.result)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff element_attribute_error.expected element_attribute_error.actual)))

--- a/ppx/test/dune
+++ b/ppx/test/dune
@@ -17,7 +17,7 @@
    (run refmt --parse=re --print=ml %{deps}))))
 
 (rule
- (targets element_attribute_error.actual)
+ (targets element_attribute_error.result)
  (deps
   (:main ./main.exe)
   (:input element_attribute_error.ml))
@@ -38,4 +38,4 @@
   (progn
    (diff pp_reason.expected pp_reason.result)
    (diff pp_ocaml.expected pp_ocaml.result)
-   (diff element_attribute_error.expected element_attribute_error.actual))))
+   (diff element_attribute_error.expected element_attribute_error.result))))

--- a/ppx/test/dune
+++ b/ppx/test/dune
@@ -35,14 +35,7 @@
 (rule
  (alias runtest)
  (action
-  (diff pp_reason.expected pp_reason.result)))
-
-(rule
- (alias runtest)
- (action
-  (diff pp_ocaml.expected pp_ocaml.result)))
-
-(rule
- (alias runtest)
- (action
-  (diff element_attribute_error.expected element_attribute_error.actual)))
+  (progn
+   (diff pp_reason.expected pp_reason.result)
+   (diff pp_ocaml.expected pp_ocaml.result)
+   (diff element_attribute_error.expected element_attribute_error.actual))))

--- a/ppx/test/dune
+++ b/ppx/test/dune
@@ -24,7 +24,7 @@
  (action
   (with-stderr-to
    %{targets}
-   (bash "! ./%{main} %{input}"))))
+   (system "! ./%{main} %{input}"))))
 
 (rule
  (targets pp_ocaml.result)

--- a/ppx/test/element_attribute_error.expected
+++ b/ppx/test/element_attribute_error.expected
@@ -1,0 +1,4 @@
+[1mFile "element_attribute_error.ml", line 3, characters 24-38[0m:
+3 | let%component make () = div ~lola:1 ()
+                            [1;31m^^^^^^^^^^^^^^[0m
+[1;31mError[0m: prop 'lola' isn't a valid prop for a 'div'

--- a/ppx/test/element_attribute_error.expected
+++ b/ppx/test/element_attribute_error.expected
@@ -1,4 +1,4 @@
-[1mFile "element_attribute_error.ml", line 3, characters 24-38[0m:
+File "element_attribute_error.ml", line 3, characters 24-38:
 3 | let%component make () = div ~lola:1 ()
-                            [1;31m^^^^^^^^^^^^^^[0m
-[1;31mError[0m: prop 'lola' isn't a valid prop for a 'div'
+                            ^^^^^^^^^^^^^^
+Error: prop 'lola' isn't a valid prop for a 'div'

--- a/ppx/test/element_attribute_error.ml
+++ b/ppx/test/element_attribute_error.ml
@@ -1,0 +1,3 @@
+[@@@react.dom]
+
+let%component make () = div ~lola:1 ()


### PR DESCRIPTION
This test ensures that our error remains the same during new iterations. The test ensures that the ppx checks the validity of HTML attributes based on the HTML tag, since these operations happen at build-time we can run the ppx and capture it's stderr output and diff it against a snapshot.

With this method, we can't ensure that the type-checker works thought. There are methods to run the type-checker for example I'm doing it in styled-ppx https://github.com/davesnx/styled-ppx/blob/main/packages/ppx/test/native/Static_test.re and https://github.com/davesnx/styled-ppx/blob/main/packages/ppx/test/native/dune. We could look into those closely.

The PR merges all runtest into one action, to review the capturing error check: [`e549642` (#87)](https://github.com/ml-in-barcelona/jsoo-react/pull/87/commits/e549642d31a6459f728ce9a7620a0770d090bd2e)