### PR TITLE
Remove filtering of optional props in make_js_props_obj

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test: ## Run the unit tests
 	$(DUNE) build @runtest
 
 test-promote: ## Updates snapshots and promotes it to correct
-	$(DUNE) build @runtest
+	$(DUNE) build @runtest --auto-promote
 
 # This is a separate command to run this tests conditionaly on CI, currently the dune setup with (bash "! ./%{main} %{input}")) fails in Windows. We skip it on Windows.
 test-error-msg: ## Run the unit tests for error messages

--- a/ppx/test/input_ocaml.ml
+++ b/ppx/test/input_ocaml.ml
@@ -15,3 +15,5 @@ let%component make ~children:kids = div ~id:"foo" ~children:kids ()
 
 let%component make ~children:(first, second) () =
   div ~children:[first; second] ()
+
+let%component make ?(name = "") = div ~children:[name] ()

--- a/ppx/test/input_reason.re
+++ b/ppx/test/input_reason.re
@@ -177,3 +177,8 @@ let randomElement = <text dx="1 2" dy="3 4" />;
 let make = (~name, ~isDisabled=?, ~onClick=?) => {
   <button name ?onClick disabled=isDisabled />;
 };
+
+[@react.component]
+let make = (~name="joe") => {
+  <div> {Printf.sprintf("`name` is %s", name) |> React.string} </div>;
+};

--- a/ppx/test/pp_ocaml.expected
+++ b/ppx/test/pp_ocaml.expected
@@ -11,13 +11,13 @@ let make =
         fun () ->
           let open Js_of_ocaml.Js.Unsafe in
             obj
-              ((([|(Option.map
-                      (fun raw ->
-                         ("key", (inject (Js_of_ocaml.Js.string raw)))) key);(
-                   Option.map (fun raw -> ("name", (inject raw))) name)|] |>
-                   Array.to_list)
-                  |> (List.filter_map (fun x -> x)))
-                 |> Array.of_list) in
+              [|("key",
+                  (inject
+                     (Js_of_ocaml.Js.Optdef.option
+                        (Option.map Js_of_ocaml.Js.string key))));("name",
+                                                                    (
+                                                                    inject
+                                                                    name))|] in
   let make =
     ((fun ?(name= "") ->
         React.Dom.createDOMElementVariadic "div"
@@ -67,12 +67,13 @@ let make =
         fun () ->
           let open Js_of_ocaml.Js.Unsafe in
             obj
-              ((([|(Option.map
-                      (fun raw ->
-                         ("key", (inject (Js_of_ocaml.Js.string raw)))) key);(
-                   Some ("children", (inject children)))|] |> Array.to_list)
-                  |> (List.filter_map (fun x -> x)))
-                 |> Array.of_list) in
+              [|("key",
+                  (inject
+                     (Js_of_ocaml.Js.Optdef.option
+                        (Option.map Js_of_ocaml.Js.string key))));("children",
+                                                                    (
+                                                                    inject
+                                                                    children))|] in
   let make =
     ((fun ~children:(first, second) ->
         React.Dom.createDOMElementVariadic "div"
@@ -112,12 +113,13 @@ let make =
         fun () ->
           let open Js_of_ocaml.Js.Unsafe in
             obj
-              ((([|(Option.map
-                      (fun raw ->
-                         ("key", (inject (Js_of_ocaml.Js.string raw)))) key);(
-                   Some ("children", (inject children)))|] |> Array.to_list)
-                  |> (List.filter_map (fun x -> x)))
-                 |> Array.of_list) in
+              [|("key",
+                  (inject
+                     (Js_of_ocaml.Js.Optdef.option
+                        (Option.map Js_of_ocaml.Js.string key))));("children",
+                                                                    (
+                                                                    inject
+                                                                    children))|] in
   let make =
     ((fun ~children:kids ->
         React.Dom.createDOMElementVariadic "div"
@@ -157,12 +159,13 @@ let make =
         fun () ->
           let open Js_of_ocaml.Js.Unsafe in
             obj
-              ((([|(Option.map
-                      (fun raw ->
-                         ("key", (inject (Js_of_ocaml.Js.string raw)))) key);(
-                   Some ("children", (inject children)))|] |> Array.to_list)
-                  |> (List.filter_map (fun x -> x)))
-                 |> Array.of_list) in
+              [|("key",
+                  (inject
+                     (Js_of_ocaml.Js.Optdef.option
+                        (Option.map Js_of_ocaml.Js.string key))));("children",
+                                                                    (
+                                                                    inject
+                                                                    children))|] in
   let make =
     ((fun ~children:(first, second) ->
         fun () ->
@@ -187,3 +190,41 @@ let make =
   fun ~children ->
     fun ?key ->
       fun () -> React.createElement make (make_props ?key ~children ())
+let make =
+  let make_props
+    : ?name:'name ->
+        ?key:string ->
+          unit ->
+            < name: 'name option Js_of_ocaml.Js.readonly_prop   > 
+              Js_of_ocaml.Js.t
+    =
+    fun ?name ->
+      fun ?key ->
+        fun () ->
+          let open Js_of_ocaml.Js.Unsafe in
+            obj
+              [|("key",
+                  (inject
+                     (Js_of_ocaml.Js.Optdef.option
+                        (Option.map Js_of_ocaml.Js.string key))));("name",
+                                                                    (
+                                                                    inject
+                                                                    name))|] in
+  let make =
+    ((fun ?(name= "") ->
+        React.Dom.createDOMElementVariadic "div"
+          ~props:(Js_of_ocaml.Js.Unsafe.obj [||] : React.Dom.domProps) 
+          [name])
+    [@warning "-16"]) in
+  let make
+    (Props :
+      < name: 'name option Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t)
+    =
+    make
+      ?name:(fun (type res) -> fun (type a0) ->
+               fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                 fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                   -> (Js_of_ocaml.Js.Unsafe.get a0 "name" : res)
+               (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
+  fun ?name ->
+    fun ?key -> fun () -> React.createElement make (make_props ?key ?name ())

--- a/ppx/test/pp_reason.expected
+++ b/ppx/test/pp_reason.expected
@@ -11,13 +11,13 @@ let make =
         fun () ->
           let open Js_of_ocaml.Js.Unsafe in
             obj
-              ((([|(Option.map
-                      (fun raw ->
-                         ("key", (inject (Js_of_ocaml.Js.string raw)))) key);(
-                   Option.map (fun raw -> ("name", (inject raw))) name)|] |>
-                   Array.to_list)
-                  |> (List.filter_map (fun x -> x)))
-                 |> Array.of_list) in
+              [|("key",
+                  (inject
+                     (Js_of_ocaml.Js.Optdef.option
+                        (Option.map Js_of_ocaml.Js.string key))));("name",
+                                                                    (
+                                                                    inject
+                                                                    name))|] in
   let make =
     ((fun ?(name= (("")[@reason.raw_literal ""])) ->
         ((React.Fragment.make
@@ -65,13 +65,12 @@ let make =
           fun () ->
             let open Js_of_ocaml.Js.Unsafe in
               obj
-                ((([|(Option.map
-                        (fun raw ->
-                           ("key", (inject (Js_of_ocaml.Js.string raw)))) key);(
-                     Some ("b", (inject b)));(Some ("a", (inject a)))|] |>
-                     Array.to_list)
-                    |> (List.filter_map (fun x -> x)))
-                   |> Array.of_list) in
+                [|("key",
+                    (inject
+                       (Js_of_ocaml.Js.Optdef.option
+                          (Option.map Js_of_ocaml.Js.string key))));("b",
+                                                                    (inject b));
+                  ("a", (inject a))|] in
   let make =
     ((fun ~a ->
         ((fun ~b ->
@@ -136,15 +135,11 @@ module Bar =
               fun () ->
                 let open Js_of_ocaml.Js.Unsafe in
                   obj
-                    ((([|(Option.map
-                            (fun raw ->
-                               ("key", (inject (Js_of_ocaml.Js.string raw))))
-                            key);(Some ("b", (inject b)));(Some
-                                                             ("a",
-                                                               (inject a)))|]
-                         |> Array.to_list)
-                        |> (List.filter_map (fun x -> x)))
-                       |> Array.of_list) in
+                    [|("key",
+                        (inject
+                           (Js_of_ocaml.Js.Optdef.option
+                              (Option.map Js_of_ocaml.Js.string key))));
+                      ("b", (inject b));("a", (inject a))|] in
       let make =
         ((fun ~a ->
             ((fun ~b ->
@@ -200,15 +195,11 @@ module Bar =
               fun () ->
                 let open Js_of_ocaml.Js.Unsafe in
                   obj
-                    ((([|(Option.map
-                            (fun raw ->
-                               ("key", (inject (Js_of_ocaml.Js.string raw))))
-                            key);(Some ("b", (inject b)));(Some
-                                                             ("a",
-                                                               (inject a)))|]
-                         |> Array.to_list)
-                        |> (List.filter_map (fun x -> x)))
-                       |> Array.of_list) in
+                    [|("key",
+                        (inject
+                           (Js_of_ocaml.Js.Optdef.option
+                              (Option.map Js_of_ocaml.Js.string key))));
+                      ("b", (inject b));("a", (inject a))|] in
       let component =
         ((fun ~a ->
             ((fun ~b ->
@@ -270,15 +261,11 @@ module Func(M:X_int) =
               fun () ->
                 let open Js_of_ocaml.Js.Unsafe in
                   obj
-                    ((([|(Option.map
-                            (fun raw ->
-                               ("key", (inject (Js_of_ocaml.Js.string raw))))
-                            key);(Some ("b", (inject b)));(Some
-                                                             ("a",
-                                                               (inject a)))|]
-                         |> Array.to_list)
-                        |> (List.filter_map (fun x -> x)))
-                       |> Array.of_list) in
+                    [|("key",
+                        (inject
+                           (Js_of_ocaml.Js.Optdef.option
+                              (Option.map Js_of_ocaml.Js.string key))));
+                      ("b", (inject b));("a", (inject a))|] in
       let make =
         ((fun ~a ->
             ((fun ~b ->
@@ -329,14 +316,11 @@ module ForwardRef =
             fun () ->
               let open Js_of_ocaml.Js.Unsafe in
                 obj
-                  ((([|(Option.map (fun raw -> ("ref", (inject raw))) ref);(
-                       Option.map
-                         (fun raw ->
-                            ("key", (inject (Js_of_ocaml.Js.string raw))))
-                         key)|]
-                       |> Array.to_list)
-                      |> (List.filter_map (fun x -> x)))
-                     |> Array.of_list) in
+                  [|("ref", (inject (Js_of_ocaml.Js.Optdef.option ref)));
+                    ("key",
+                      (inject
+                         (Js_of_ocaml.Js.Optdef.option
+                            (Option.map Js_of_ocaml.Js.string key))))|] in
       let make =
         ((fun theRef ->
             React.Dom.createDOMElementVariadic "div"
@@ -371,13 +355,11 @@ module Memo =
             fun () ->
               let open Js_of_ocaml.Js.Unsafe in
                 obj
-                  ((([|(Option.map
-                          (fun raw ->
-                             ("key", (inject (Js_of_ocaml.Js.string raw))))
-                          key);(Some ("a", (inject a)))|]
-                       |> Array.to_list)
-                      |> (List.filter_map (fun x -> x)))
-                     |> Array.of_list) in
+                  [|("key",
+                      (inject
+                         (Js_of_ocaml.Js.Optdef.option
+                            (Option.map Js_of_ocaml.Js.string key))));
+                    ("a", (inject a))|] in
       let make =
         ((fun ~a ->
             ((React.Dom.createDOMElementVariadic "div"
@@ -420,13 +402,11 @@ module MemoCustomCompareProps =
             fun () ->
               let open Js_of_ocaml.Js.Unsafe in
                 obj
-                  ((([|(Option.map
-                          (fun raw ->
-                             ("key", (inject (Js_of_ocaml.Js.string raw))))
-                          key);(Some ("a", (inject a)))|]
-                       |> Array.to_list)
-                      |> (List.filter_map (fun x -> x)))
-                     |> Array.of_list) in
+                  [|("key",
+                      (inject
+                         (Js_of_ocaml.Js.Optdef.option
+                            (Option.map Js_of_ocaml.Js.string key))));
+                    ("a", (inject a))|] in
       let make =
         ((fun ~a ->
             ((React.Dom.createDOMElementVariadic "div"
@@ -627,15 +607,13 @@ let make =
           fun () ->
             let open Js_of_ocaml.Js.Unsafe in
               obj
-                ((([|(Option.map
-                        (fun raw ->
-                           ("key", (inject (Js_of_ocaml.Js.string raw)))) key);(
-                     Some ("children", (inject children)));(Some
-                                                              ("title",
-                                                                (inject title)))|]
-                     |> Array.to_list)
-                    |> (List.filter_map (fun x -> x)))
-                   |> Array.of_list) in
+                [|("key",
+                    (inject
+                       (Js_of_ocaml.Js.Optdef.option
+                          (Option.map Js_of_ocaml.Js.string key))));("children",
+                                                                    (inject
+                                                                    children));
+                  ("title", (inject title))|] in
   let make =
     ((fun ~title ->
         ((fun ~children ->
@@ -705,13 +683,13 @@ let make =
           fun () ->
             let open Js_of_ocaml.Js.Unsafe in
               obj
-                ((([|(Option.map (fun raw -> ("ref", (inject raw))) ref);(
-                     Option.map
-                       (fun raw ->
-                          ("key", (inject (Js_of_ocaml.Js.string raw)))) key);(
-                     Some ("children", (inject children)))|] |> Array.to_list)
-                    |> (List.filter_map (fun x -> x)))
-                   |> Array.of_list) in
+                [|("ref", (inject (Js_of_ocaml.Js.Optdef.option ref)));
+                  ("key",
+                    (inject
+                       (Js_of_ocaml.Js.Optdef.option
+                          (Option.map Js_of_ocaml.Js.string key))));("children",
+                                                                    (inject
+                                                                    children))|] in
   let make =
     ((fun ~children ->
         ((fun ref ->
@@ -852,20 +830,13 @@ let make =
             fun () ->
               let open Js_of_ocaml.Js.Unsafe in
                 obj
-                  ((([|(Option.map
-                          (fun raw ->
-                             ("key", (inject (Js_of_ocaml.Js.string raw))))
-                          key);(Option.map
-                                  (fun raw -> ("onClick", (inject raw)))
-                                  onClick);(Option.map
-                                              (fun raw ->
-                                                 ("isDisabled", (inject raw)))
-                                              isDisabled);(Some
-                                                             ("name",
-                                                               (inject name)))|]
-                       |> Array.to_list)
-                      |> (List.filter_map (fun x -> x)))
-                     |> Array.of_list) in
+                  [|("key",
+                      (inject
+                         (Js_of_ocaml.Js.Optdef.option
+                            (Option.map Js_of_ocaml.Js.string key))));
+                    ("onClick", (inject onClick));("isDisabled",
+                                                    (inject isDisabled));
+                    ("name", (inject name))|] in
   let make =
     ((fun ~name ->
         ((fun ?isDisabled ->
@@ -928,3 +899,45 @@ let make =
           fun () ->
             React.createElement make
               (make_props ?key ?onClick ?isDisabled ~name ())
+let make =
+  let make_props
+    : ?name:'name ->
+        ?key:string ->
+          unit ->
+            < name: 'name option Js_of_ocaml.Js.readonly_prop   > 
+              Js_of_ocaml.Js.t
+    =
+    fun ?name ->
+      fun ?key ->
+        fun () ->
+          let open Js_of_ocaml.Js.Unsafe in
+            obj
+              [|("key",
+                  (inject
+                     (Js_of_ocaml.Js.Optdef.option
+                        (Option.map Js_of_ocaml.Js.string key))));("name",
+                                                                    (
+                                                                    inject
+                                                                    name))|] in
+  let make =
+    ((fun ?(name= (("joe")[@reason.raw_literal "joe"])) ->
+        ((React.Dom.createDOMElementVariadic "div"
+            ~props:(Js_of_ocaml.Js.Unsafe.obj [||] : React.Dom.domProps)
+            [(((Printf.sprintf (("`name` is %s")
+                  [@reason.raw_literal "`name` is %s"]) name)
+                 |> React.string)
+            [@reason.preserve_braces ])])
+        [@reason.preserve_braces ]))
+    [@warning "-16"]) in
+  let make
+    (Props :
+      < name: 'name option Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t)
+    =
+    make
+      ?name:(fun (type res) -> fun (type a0) ->
+               fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                 fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                   -> (Js_of_ocaml.Js.Unsafe.get a0 "name" : res)
+               (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
+  fun ?name ->
+    fun ?key -> fun () -> React.createElement make (make_props ?key ?name ())

--- a/test/test_jsoo_react.re
+++ b/test/test_jsoo_react.re
@@ -71,6 +71,27 @@ let testKeys = () =>
     );
   });
 
+let testOptionalProps = () => {
+  module OptProps = {
+    [@react.component]
+    let make = (~name="joe") => {
+      <div> {Printf.sprintf("`name` is %s", name) |> React.string} </div>;
+    };
+  };
+  withContainer(c => {
+    act(() => {React.Dom.render(<OptProps />, Html.element(c))});
+    assert_equal(
+      c##.textContent,
+      Js.Opt.return(Js.string("`name` is joe")),
+    );
+    act(() => {React.Dom.render(<OptProps name="jane" />, Html.element(c))});
+    assert_equal(
+      c##.textContent,
+      Js.Opt.return(Js.string("`name` is jane")),
+    );
+  });
+};
+
 let testContext = () => {
   module DummyContext = {
     let context = React.createContext("foo");
@@ -762,6 +783,7 @@ let basic =
     "testDom" >:: testDom,
     "testReact" >:: testReact,
     "testKey" >:: testKeys,
+    "testOptionalProps" >:: testOptionalProps,
   ];
 
 let context = "context" >::: ["testContext" >:: testContext];


### PR DESCRIPTION
Fixes #83.

Optional props passed to uppercase components should be left as they are, no conversion to `Js.Optdef.t` required. The only exceptions are `key` and `ref` which are read by React.js.

Previous implementation led to bugs when using optional prop + default value, where the component would receive `undefined` when some value was passed (see added tests in  test suite).