### PR TITLE
Allow `string option` transformations for native elements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ dev: ## Build in watch mode
 test: ## Run the unit tests
 	$(DUNE) build @runtest
 
+test-watch: ## Run the unit tests in watch mode
+	$(DUNE) build @runtest -w
+
 test-promote: ## Updates snapshots and promotes it to correct
 	$(DUNE) build @runtest --auto-promote
 

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -440,7 +440,7 @@ let rec makeFunsForMakePropsBody list args =
 let makeAttributeValue ~loc ~isOptional (type_ : Html.attributeType) value =
   match (type_, isOptional) with
   | String, true ->
-      [%expr Js_of_ocaml.Js.string ([%e value] : string option)]
+      [%expr Option.map Js_of_ocaml.Js.string ([%e value] : string option)]
   | String, false ->
       [%expr Js_of_ocaml.Js.string ([%e value] : string)]
   | Int, false ->

--- a/ppx/test/input_ocaml.ml
+++ b/ppx/test/input_ocaml.ml
@@ -17,3 +17,5 @@ let%component make ~children:(first, second) () =
   div ~children:[first; second] ()
 
 let%component make ?(name = "") = div ~children:[name] ()
+
+let%component make () = a ?href:(Some "https://opam.ocaml.org") ()

--- a/ppx/test/pp_ocaml.expected
+++ b/ppx/test/pp_ocaml.expected
@@ -228,3 +228,24 @@ let make =
                (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
   fun ?name ->
     fun ?key -> fun () -> React.createElement make (make_props ?key ?name ())
+let make =
+  let make_props : ?key:string -> unit -> <  >  Js_of_ocaml.Js.t =
+    fun ?key ->
+      fun () ->
+        let open Js_of_ocaml.Js.Unsafe in
+          obj
+            [|("key",
+                (inject
+                   (Js_of_ocaml.Js.Optdef.option
+                      (Option.map Js_of_ocaml.Js.string key))))|] in
+  let make () =
+    React.Dom.createDOMElementVariadic "a"
+      ~props:(Js_of_ocaml.Js.Unsafe.obj
+                [|("href",
+                    (Js_of_ocaml.Js.Unsafe.inject
+                       (Js_of_ocaml.Js.Optdef.option
+                          (Option.map Js_of_ocaml.Js.string
+                             (Some "https://opam.ocaml.org" : string option)))))|] : 
+      React.Dom.domProps) [] in
+  let make (Props : <  >  Js_of_ocaml.Js.t) = make () in
+  fun ?key -> fun () -> React.createElement make (make_props ?key ())

--- a/test/test_jsoo_react.re
+++ b/test/test_jsoo_react.re
@@ -92,6 +92,32 @@ let testOptionalProps = () => {
   });
 };
 
+let testOptionalAttributes = () => {
+  module LinkWithMaybeHref = {
+    [@react.component]
+    let make = (~href) => <a ?href />;
+  };
+
+  withContainer(c => {
+    act(() =>
+      React.Dom.render(<LinkWithMaybeHref href=None />, Html.element(c))
+    );
+    assert_equal(c##.innerHTML, Js.string("<a></a>"));
+    act(() =>
+      React.Dom.render(
+        <LinkWithMaybeHref href={Some("https://google.es")} />,
+        Html.element(c),
+      )
+    );
+
+    printInnerHTML(c);
+    assert_equal(
+      c##.innerHTML,
+      Js.string({|<a href="https://google.es"></a>|}),
+    );
+  });
+};
+
 let testContext = () => {
   module DummyContext = {
     let context = React.createContext("foo");
@@ -784,6 +810,7 @@ let basic =
     "testReact" >:: testReact,
     "testKey" >:: testKeys,
     "testOptionalProps" >:: testOptionalProps,
+    "testOptionalAttributes" >:: testOptionalAttributes,
   ];
 
 let context = "context" >::: ["testContext" >:: testContext];

--- a/test/test_jsoo_react.re
+++ b/test/test_jsoo_react.re
@@ -71,7 +71,7 @@ let testKeys = () =>
     );
   });
 
-let testOptionalProps = () => {
+let testOptionalPropsUppercase = () => {
   module OptProps = {
     [@react.component]
     let make = (~name="joe") => {
@@ -92,7 +92,7 @@ let testOptionalProps = () => {
   });
 };
 
-let testOptionalAttributes = () => {
+let testOptionalPropsLowercase = () => {
   module LinkWithMaybeHref = {
     [@react.component]
     let make = (~href) => <a ?href />;
@@ -809,8 +809,8 @@ let basic =
     "testDom" >:: testDom,
     "testReact" >:: testReact,
     "testKey" >:: testKeys,
-    "testOptionalProps" >:: testOptionalProps,
-    "testOptionalAttributes" >:: testOptionalAttributes,
+    "testOptionalPropsUppercase" >:: testOptionalPropsUppercase,
+    "testOptionalPropsLowercase" >:: testOptionalPropsLowercase,
   ];
 
 let context = "context" >::: ["testContext" >:: testContext];


### PR DESCRIPTION
This PR fixes a remaining bug for optional parameters, from https://github.com/ml-in-barcelona/jsoo-react/issues/81#issuecomment-1002261158

Was introduced by https://github.com/ml-in-barcelona/jsoo-react/pull/84.



