### PR TITLE
Keep useReducer dispatch and useState updater refs constant

### DIFF
--- a/lib/core.mli
+++ b/lib/core.mli
@@ -522,21 +522,40 @@ val useMemo7 : (unit -> 'value) -> 'a * 'b * 'c * 'd * 'e * 'f * 'g -> 'value
 
 val useState : (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
   [@@js.custom
-    val useState_internal :
-      Imports.react -> (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
-      [@@js.call "useState"]
+    let (useState_internal :
+             Imports.react
+          -> (unit -> 'state)
+          -> 'state * (('state -> 'state) -> unit) ) =
+     fun (react : Imports.react) (init : unit -> 'state) ->
+      let result =
+        Ojs.call
+          (Imports.react_to_js react)
+          "useState"
+          [|Ojs.fun_to_js 1 (fun _ -> Obj.magic (init ()))|]
+      in
+      (Obj.magic (Ojs.array_get result 0), Obj.magic (Ojs.array_get result 1))
 
     let useState initial = useState_internal Imports.react initial]
 
 val useReducer :
   ('state -> 'action -> 'state) -> 'state -> 'state * ('action -> unit)
   [@@js.custom
-    val useReducer_internal :
-         Imports.react
-      -> ('state -> 'action -> 'state)
-      -> 'state
-      -> 'state * ('action -> unit)
-      [@@js.call "useReducer"]
+    let (useReducer_internal :
+             Imports.react
+          -> ('state -> 'action -> 'state)
+          -> 'state
+          -> 'state * ('action -> unit) ) =
+     fun (react : Imports.react) (reducer : 'state -> 'action -> 'state)
+         (init : 'state) ->
+      let result =
+        Ojs.call
+          (Imports.react_to_js react)
+          "useReducer"
+          [| Ojs.fun_to_js 2 (fun (state : Ojs.t) (action : Ojs.t) ->
+                 Obj.magic (reducer (Obj.magic state) (Obj.magic action)) )
+           ; Obj.magic init |]
+      in
+      (Obj.magic (Ojs.array_get result 0), Obj.magic (Ojs.array_get result 1))
 
     let useReducer reducer initial =
       useReducer_internal Imports.react reducer initial]
@@ -547,13 +566,25 @@ val useReducerWithMapState :
   -> ('initialState -> 'state)
   -> 'state * ('action -> unit)
   [@@js.custom
-    val useReducerWithMapState_internal :
-         Imports.react
-      -> ('state -> 'action -> 'state)
-      -> 'initialState
-      -> ('initialState -> 'state)
-      -> 'state * ('action -> unit)
-      [@@js.call "useReducer"]
+    let (useReducerWithMapState_internal :
+             Imports.react
+          -> ('state -> 'action -> 'state)
+          -> 'initialState
+          -> ('initialState -> 'state)
+          -> 'state * ('action -> unit) ) =
+     fun (react : Imports.react) (reducer : 'state -> 'action -> 'state)
+         (init : 'initialState) (map_state : 'initialState -> 'state) ->
+      let result =
+        Ojs.call
+          (Imports.react_to_js react)
+          "useReducer"
+          [| Ojs.fun_to_js 2 (fun (state : Ojs.t) (action : Ojs.t) ->
+                 Obj.magic (reducer (Obj.magic state) (Obj.magic action)) )
+           ; Obj.magic init
+           ; Ojs.fun_to_js 1 (fun (state : Ojs.t) ->
+                 Obj.magic (map_state (Obj.magic state)) ) |]
+      in
+      (Obj.magic (Ojs.array_get result 0), Obj.magic (Ojs.array_get result 1))
 
     let useReducerWithMapState reducer initial mapper =
       useReducerWithMapState_internal Imports.react reducer initial mapper]


### PR DESCRIPTION
Fixes #100.

The fix consist mostly on inlining the previously generated code by gen_js_api and removing the wrapping over the following functions:
- The updater returned in the 2nd position of the tuple in `useState`
- The dispatch returned in 2nd position of the tuple in `useReducer`

Both functions can take only 1 argument, so I don't see any reason why the currying handling is needed in these case.

Added some tests for this as well as a base test for `useState`, which was not existent.