### PR TITLE
Remove React.list

### DIFF
--- a/example/src/Main.re
+++ b/example/src/Main.re
@@ -132,20 +132,21 @@ let make = () => {
       <h2 className="title"> {"jsoo-react" |> s} </h2>
       <nav className="menu">
         <ul>
-          {examples
-           |> List.map(e => {
-                <li key={e.path}>
-                  <a
-                    href={e.path}
-                    onClick={event => {
-                      React.Event.Mouse.preventDefault(event);
-                      React.Router.push(e.path);
-                    }}>
-                    {e.title |> s}
-                  </a>
-                </li>
-              })
-           |> React.list}
+          ...{
+               examples
+               |> List.map(e => {
+                    <li key={e.path}>
+                      <a
+                        href={e.path}
+                        onClick={event => {
+                          React.Event.Mouse.preventDefault(event);
+                          React.Router.push(e.path);
+                        }}>
+                        {e.title |> s}
+                      </a>
+                    </li>
+                  })
+             }
         </ul>
       </nav>
     </div>

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -12,8 +12,6 @@ val int : int -> element [@@js.cast]
 
 val float : float -> element [@@js.cast]
 
-val list : element list -> element [@@js.cast]
-
 [@@@js.stop]
 
 type 'a option_undefined = 'a option
@@ -631,54 +629,55 @@ module Children : sig
 
   let children_internal = children_internal' Imports.react]
 
-  val map : element -> (element -> element) -> element
+  val map : element list -> (element -> element) -> element
     [@@js.custom
-      val map_internal : Ojs.t -> element -> (element -> element) -> element
+      val map_internal :
+        Ojs.t -> element list -> (element -> element) -> element
         [@@js.call "map"]
 
       let map element mapper = map_internal children_internal element mapper]
 
-  val mapWithIndex : element -> (element -> int -> element) -> element
+  val mapWithIndex : element list -> (element -> int -> element) -> element
     [@@js.custom
       val mapWithIndex_internal :
-        Ojs.t -> element -> (element -> int -> element) -> element
+        Ojs.t -> element list -> (element -> int -> element) -> element
         [@@js.call "map"]
 
       let mapWithIndex element mapper =
         mapWithIndex_internal children_internal element mapper]
 
-  val forEach : element -> (element -> unit) -> unit
+  val forEach : element list -> (element -> unit) -> unit
     [@@js.custom
-      val forEach_internal : Ojs.t -> element -> (element -> unit) -> unit
+      val forEach_internal : Ojs.t -> element list -> (element -> unit) -> unit
         [@@js.call "forEach"]
 
       let forEach element iterator =
         forEach_internal children_internal element iterator]
 
-  val forEachWithIndex : element -> (element -> int -> unit) -> unit
+  val forEachWithIndex : element list -> (element -> int -> unit) -> unit
     [@@js.custom
       val forEachWithIndex_internal :
-        Ojs.t -> element -> (element -> int -> unit) -> unit
+        Ojs.t -> element list -> (element -> int -> unit) -> unit
         [@@js.call "forEach"]
 
       let forEachWithIndex element iterator =
         forEachWithIndex_internal children_internal element iterator]
 
-  val count : element -> int
+  val count : element list -> int
     [@@js.custom
-      val count_internal : Ojs.t -> element -> int [@@js.call "count"]
+      val count_internal : Ojs.t -> element list -> int [@@js.call "count"]
 
       let count element = count_internal children_internal element]
 
-  val only : element -> element
+  val only : element list -> element
     [@@js.custom
-      val only_internal : Ojs.t -> element -> element [@@js.call "only"]
+      val only_internal : Ojs.t -> element list -> element [@@js.call "only"]
 
       let only element = only_internal children_internal element]
 
-  val toArray : element -> element array
+  val toArray : element list -> element array
     [@@js.custom
-      val toArray_internal : Ojs.t -> element -> element array
+      val toArray_internal : Ojs.t -> element list -> element array
         [@@js.call "toArray"]
 
       let toArray element = toArray_internal children_internal element]

--- a/test/test_jsoo_react.re
+++ b/test/test_jsoo_react.re
@@ -780,17 +780,19 @@ let testWithId = () => {
   module WithTestId = {
     [@react.component]
     let make = (~id, ~children, ()) =>
-      React.cloneElement(
-        children,
-        Js.Unsafe.obj([|
-          ("data-testid", Js.Unsafe.inject(Js.string(id))),
-        |]),
+      React.Children.map(children, child =>
+        React.cloneElement(
+          child,
+          Js.Unsafe.obj([|
+            ("data-testid", Js.Unsafe.inject(Js.string(id))),
+          |]),
+        )
       );
   };
   withContainer(c => {
     act(() => {
       React.Dom.render(
-        WithTestId.make(~id="feed-toggle", ~children=<div />, ()),
+        WithTestId.make(~id="feed-toggle", ~children=[<div />], ()),
         Html.element(c),
       )
     });

--- a/test/test_jsoo_react.re
+++ b/test/test_jsoo_react.re
@@ -56,11 +56,10 @@ let testKeys = () =>
     act(() => {
       React.Dom.render(
         <div>
-          {List.map(
-             str => <div key=str> {str |> React.string} </div>,
-             ["a", "b"],
-           )
-           |> React.list}
+          ...{List.map(
+            str => <div key=str> {str |> React.string} </div>,
+            ["a", "b"],
+          )}
         </div>,
         Html.element(c),
       )
@@ -644,7 +643,7 @@ let testChildrenMapWithIndex = () => {
     [@react.component]
     let make = (~children, ()) => {
       <div>
-        {React.Children.mapWithIndex(React.list(children), (element, index) => {
+        {React.Children.mapWithIndex(children, (element, index) => {
            React.cloneElement(
              element,
              Js_of_ocaml.Js.Unsafe.(
@@ -777,6 +776,31 @@ let testAliasedChildren = () => {
   });
 };
 
+let testWithId = () => {
+  module WithTestId = {
+    [@react.component]
+    let make = (~id, ~children, ()) =>
+      React.cloneElement(
+        children,
+        Js.Unsafe.obj([|
+          ("data-testid", Js.Unsafe.inject(Js.string(id))),
+        |]),
+      );
+  };
+  withContainer(c => {
+    act(() => {
+      React.Dom.render(
+        WithTestId.make(~id="feed-toggle", ~children=<div />, ()),
+        Html.element(c),
+      )
+    });
+    assert_equal(
+      c##.innerHTML,
+      Js.string("<div data-testid=\"feed-toggle\"></div>"),
+    );
+  });
+};
+
 let basic =
   "basic"
   >::: [
@@ -831,6 +855,7 @@ let children =
     "mapWithIndex" >:: testChildrenMapWithIndex,
     "nonListChildren" >:: testNonListChildren,
     "aliasedChildren" >:: testAliasedChildren,
+    "testWithId" >:: testWithId,
   ];
 
 let fragments =


### PR DESCRIPTION
After the OCaml syntax improvements were added, the "magic" that used to happen when creating elements either with a list or a single element was removed (see 
https://github.com/ml-in-barcelona/jsoo-react/pull/67#issuecomment-981052219).

As part of this change, there is no need to do conversions to list:
- if multiple elements have to be returned from a component, they can be wrapped with a fragment
- if some component needs to process a list of children, the `...` operator can be used

Besides this, `React.list` would lead to issues when used with `cloneElement`, e.g. `React.cloneElement(React.list(children),...)`.

It was confusing to keep `React.list` around, so removing it should make everything clearer. This requires some changes in the signatures of `React.Children` functions.