### PR TITLE
chore(deps): open jsoo constraint to 3.11.0

### DIFF
--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ml-in-barcelona/jsoo-react/issues"
 depends: [
   "dune" {>= "2.7" & >= "2" & < "3"}
   "ocaml" {>= "4.10.0" & < "4.14.0"}
-  "js_of_ocaml" {>= "3.8.0" & < "3.11.0"}
+  "js_of_ocaml" {>= "3.8.0" & <= "3.11.0"}
   "gen_js_api" {>= "1.0.8" & < "1.1.0"}
   "ppxlib" {>= "0.23.0"}
   "webtest" {with-test}


### PR DESCRIPTION
It doesn't seem as if jsoo uses semver in the conventional way as 3.11.0 [doesn't contain any breaking changes](https://github.com/ocsigen/js_of_ocaml/blob/master/CHANGES.md#3110-2021-10-06---lille). 

I was having some versioning conflicts in a project I was trying to use jsoo-react on, this should help fix that :)