### PR TITLE
fix build & test instructions in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,10 @@
 
 - Install opam: https://opam.ocaml.org/doc/Install.html
 - Create local switch by running `make init` (this step will take a few minutes, as it will build whole OCaml compiler)
-- Install deps with `opam install . --deps-only --with-test`
 - Build with `make`
-- Run tests with `make test`
+- Run tests with 
+  - Install test dependencies with `(cd test; yarn)`
+  - `make test`
 
 It is recommended to run `git config --local core.hooksPath .githooks/` to make sure git hooks run,
 otherwise you could get CI errors due to formatting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 - Install opam: https://opam.ocaml.org/doc/Install.html
 - Create local switch by running `make init` (this step will take a few minutes, as it will build whole OCaml compiler)
-- Build with `make`
+- Build with `make build`
 - Run tests with 
   - Install test dependencies with `(cd test; yarn)`
   - `make test`


### PR DESCRIPTION
- `opam install ...` is already done by `make init`
- `make` does nothing, do `make build` instead
- JS dependencies in `test` must be installed before running `make test`