### PR TITLE
PoC: automatic js ffi conversion of external props

### DIFF
--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -593,6 +593,16 @@ let make_external_js_props_obj ~loc named_arg_list =
           , inject
               (Js_of_ocaml.Js.Optdef.option
                  (Option.map Js_of_ocaml.Js.bool [%e id]) )]
+    | Labelled l, Some [%type: [%t? _] array] ->
+        [%expr
+          [%e Exp.constant ~loc (Const.string l)]
+          , inject (Js_of_ocaml.Js.array [%e id])]
+    | Optional l, Some [%type: [%t? _] array] ->
+        [%expr
+          [%e Exp.constant ~loc (Const.string l)]
+          , inject
+              (Js_of_ocaml.Js.Optdef.option
+                 (Option.map Js_of_ocaml.Js.array [%e id]) )]
     | Labelled l, _ ->
         [%expr [%e Exp.constant ~loc (Const.string l)], inject [%e id]]
     | Optional l, _ ->

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -573,6 +573,10 @@ let make_external_js_props_obj ~loc named_arg_list =
     let label_str = Str_label.str label in
     let id = Exp.ident ~loc {txt= Lident label_str; loc} in
     match (label, typ) with
+    | Labelled "children", Some [%type: React.element list] ->
+        [%expr
+          [%e Exp.constant ~loc (Const.string label_str)]
+          , inject (Js_of_ocaml.Js.array (Array.of_list [%e id]))]
     | Labelled l, Some [%type: string] ->
         [%expr
           [%e Exp.constant ~loc (Const.string l)]

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -583,6 +583,16 @@ let make_external_js_props_obj ~loc named_arg_list =
           , inject
               (Js_of_ocaml.Js.Optdef.option
                  (Option.map Js_of_ocaml.Js.string [%e id]) )]
+    | Labelled l, Some [%type: bool] ->
+        [%expr
+          [%e Exp.constant ~loc (Const.string l)]
+          , inject (Js_of_ocaml.Js.bool [%e id])]
+    | Optional l, Some [%type: bool] ->
+        [%expr
+          [%e Exp.constant ~loc (Const.string l)]
+          , inject
+              (Js_of_ocaml.Js.Optdef.option
+                 (Option.map Js_of_ocaml.Js.bool [%e id]) )]
     | Labelled l, _ ->
         [%expr [%e Exp.constant ~loc (Const.string l)], inject [%e id]]
     | Optional l, _ ->

--- a/ppx/test/input_ocaml.ml
+++ b/ppx/test/input_ocaml.ml
@@ -25,3 +25,6 @@ external%component make : name:Js.js_string Js.t -> React.element
 
 external%component make : ?name:Js.js_string Js.t -> React.element
   = "require(\"my-react-library\").MyReactComponent"
+
+external%component make : names:string array -> React.element
+  = "require(\"my-react-library\").MyReactComponent"

--- a/ppx/test/pp_ocaml.expected
+++ b/ppx/test/pp_ocaml.expected
@@ -304,3 +304,35 @@ let make =
           (Js_of_ocaml.Js.Unsafe.js_expr
              "require(\"my-react-library\").MyReactComponent")
           (make_props ?key ?name ())
+let make =
+  let make_props
+    : names:string array ->
+        ?key:string ->
+          unit ->
+            < names: string array Js_of_ocaml.Js.readonly_prop   > 
+              Js_of_ocaml.Js.t
+    =
+    fun ~names ->
+      fun ?key ->
+        fun () ->
+          let open Js_of_ocaml.Js.Unsafe in
+            obj
+              [|("key",
+                  (inject
+                     (Js_of_ocaml.Js.Optdef.option
+                        (Option.map Js_of_ocaml.Js.string key))));("names",
+                                                                    (
+                                                                    inject
+                                                                    ((fun v
+                                                                    ->
+                                                                    Js_of_ocaml.Js.array
+                                                                    (Array.map
+                                                                    Js_of_ocaml.Js.string
+                                                                    v)) names)))|] in
+  fun ~names ->
+    fun ?key ->
+      fun () ->
+        React.createElement
+          (Js_of_ocaml.Js.Unsafe.js_expr
+             "require(\"my-react-library\").MyReactComponent")
+          (make_props ?key ~names ())

--- a/ppx/test/pp_reason.expected
+++ b/ppx/test/pp_reason.expected
@@ -131,7 +131,8 @@ module External =
                         (inject
                            (Js_of_ocaml.Js.Optdef.option
                               (Option.map Js_of_ocaml.Js.string key))));
-                      ("b", (inject b));("a", (inject a))|] in
+                      ("b", (inject (Js_of_ocaml.Js.string b)));("a",
+                                                                  (inject a))|] in
       fun ~a ->
         fun ~b ->
           fun ?key ->

--- a/test/external.js
+++ b/test/external.js
@@ -1,8 +1,13 @@
 const React = require("react");
 
 function Greeting({
-  name
+  name,
+  strong,
 }) {
+  var name = strong === true
+      ? React.createElement("strong", null, name)
+      : name;
+
   return React.createElement("span", null, "Hey ", name);
 }
 

--- a/test/external.js
+++ b/test/external.js
@@ -21,5 +21,13 @@ function GreetingChildren({
 
 exports.GreetingChildren = GreetingChildren;
 
+function Greetings({
+  names
+}) {
+  return React.createElement("span", null, "Hey ", names.join(", "));
+}
+
+exports.Greetings = Greetings;
+
 // React.forwardRef is a non-function wrapper component, at least at time of writing
 exports.NonFunctionGreeting = React.forwardRef(Greeting);

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -960,6 +960,37 @@ let testExternalOptionalStringArg = () => {
   });
 };
 
+let testExternalBoolArg = () => {
+  module JsComp = {
+    [@react.component]
+    external make: (~name: string, ~strong: bool) => React.element =
+      {|require("./external").Greeting|};
+  };
+  withContainer(c => {
+    act(() => {
+      React.Dom.render(<JsComp name="John" strong=false />, Html.element(c))
+    });
+    assert_equal(c##.innerHTML, Js.string("<span>Hey John</span>"));
+  });
+};
+
+let testExternalOptionalBoolArg = () => {
+  module JsComp = {
+    [@react.component]
+    external make: (~name: string=?, ~strong: bool=?) => React.element =
+      {|require("./external").Greeting|};
+  };
+  withContainer(c => {
+    act(() => {
+      React.Dom.render(<JsComp name="John" strong=true />, Html.element(c))
+    });
+    assert_equal(
+      c##.innerHTML,
+      Js.string("<span>Hey <strong>John</strong></span>"),
+    );
+  });
+};
+
 let testAliasedChildren = () => {
   module AliasedChildrenComponent = {
     [@react.component]
@@ -1097,6 +1128,8 @@ let externals =
     "optional-arg" >:: testExternalOptionalArg,
     "string-arg" >:: testExternalStringArg,
     "optional-string-arg" >:: testExternalOptionalStringArg,
+    "bool-arg" >:: testExternalBoolArg,
+    "optional-bool-arg" >:: testExternalOptionalBoolArg,
   ];
 
 let suite =

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -913,13 +913,11 @@ let testExternalChildren = () => {
 let testExternalNonFunction = () => {
   module JsComp = {
     [@react.component]
-    external make: (~name: Js.t(Js.js_string)) => React.element =
+    external make: (~name: string) => React.element =
       {|require("./external").NonFunctionGreeting|};
   };
   withContainer(c => {
-    act(() => {
-      React.Dom.render(<JsComp name={Js.string("John")} />, Html.element(c))
-    });
+    act(() => {React.Dom.render(<JsComp name="John" />, Html.element(c))});
     assert_equal(c##.innerHTML, Js.string("<span>Hey John</span>"));
   });
 };
@@ -934,6 +932,30 @@ let testExternalOptionalArg = () => {
     act(() => {
       React.Dom.render(<JsComp name={Js.string("John")} />, Html.element(c))
     });
+    assert_equal(c##.innerHTML, Js.string("<span>Hey John</span>"));
+  });
+};
+
+let testExternalStringArg = () => {
+  module JsComp = {
+    [@react.component]
+    external make: (~name: string) => React.element =
+      {|require("./external").Greeting|};
+  };
+  withContainer(c => {
+    act(() => {React.Dom.render(<JsComp name="John" />, Html.element(c))});
+    assert_equal(c##.innerHTML, Js.string("<span>Hey John</span>"));
+  });
+};
+
+let testExternalOptionalStringArg = () => {
+  module JsComp = {
+    [@react.component]
+    external make: (~name: string=?) => React.element =
+      {|require("./external").Greeting|};
+  };
+  withContainer(c => {
+    act(() => {React.Dom.render(<JsComp name="John" />, Html.element(c))});
     assert_equal(c##.innerHTML, Js.string("<span>Hey John</span>"));
   });
 };
@@ -1073,6 +1095,8 @@ let externals =
     "children" >:: testExternalChildren,
     "non-function" >:: testExternalNonFunction,
     "optional-arg" >:: testExternalOptionalArg,
+    "string-arg" >:: testExternalStringArg,
+    "optional-string-arg" >:: testExternalOptionalStringArg,
   ];
 
 let suite =

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -893,16 +893,13 @@ let testExternals = () => {
 let testExternalChildren = () => {
   module JsComp = {
     [@react.component]
-    external make:
-      (~children: Js.t(Js.js_array(React.element))) => React.element =
+    external make: (~children: list(React.element)) => React.element =
       {|require("./external").GreetingChildren|};
   };
   withContainer(c => {
     act(() => {
       React.Dom.render(
-        <JsComp>
-          ...{Js.array([|<em> {React.string("John")} </em>|])}
-        </JsComp>,
+        <JsComp> <em> {React.string("John")} </em> </JsComp>,
         Html.element(c),
       )
     });

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -1022,6 +1022,26 @@ let testExternalOptionalArrayArg = () => {
   });
 };
 
+let testExternalSecondOrderArgConversion = () => {
+  module JsComp = {
+    [@react.component]
+    external make: (~names: array(string)=?) => React.element =
+      {|require("./external").Greetings|};
+  };
+  withContainer(c => {
+    act(() => {
+      React.Dom.render(
+        <JsComp names=[|"John", "Jerry", "Fred"|] />,
+        Html.element(c),
+      )
+    });
+    assert_equal(
+      c##.innerHTML,
+      Js.string("<span>Hey John, Jerry, Fred</span>"),
+    );
+  });
+};
+
 let testAliasedChildren = () => {
   module AliasedChildrenComponent = {
     [@react.component]
@@ -1163,6 +1183,7 @@ let externals =
     "optional-bool-arg" >:: testExternalOptionalBoolArg,
     "array-arg" >:: testExternalArrayArg,
     "optional-array-arg" >:: testExternalOptionalArrayArg,
+    "second-order-arg-conversion" >:: testExternalSecondOrderArgConversion,
   ];
 
 let suite =

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -991,6 +991,40 @@ let testExternalOptionalBoolArg = () => {
   });
 };
 
+let testExternalArrayArg = () => {
+  module JsComp = {
+    [@react.component]
+    external make: (~children: array(React.element)) => React.element =
+      {|require("./external").GreetingChildren|};
+  };
+  withContainer(c => {
+    act(() => {
+      React.Dom.render(
+        <JsComp> ...[|<em> {React.string("John")} </em>|] </JsComp>,
+        Html.element(c),
+      )
+    });
+    assert_equal(c##.innerHTML, Js.string("<span>Hey <em>John</em></span>"));
+  });
+};
+
+let testExternalOptionalArrayArg = () => {
+  module JsComp = {
+    [@react.component]
+    external make: (~children: array(React.element)=?) => React.element =
+      {|require("./external").GreetingChildren|};
+  };
+  withContainer(c => {
+    act(() => {
+      React.Dom.render(
+        <JsComp> ...[|<em> {React.string("John")} </em>|] </JsComp>,
+        Html.element(c),
+      )
+    });
+    assert_equal(c##.innerHTML, Js.string("<span>Hey <em>John</em></span>"));
+  });
+};
+
 let testAliasedChildren = () => {
   module AliasedChildrenComponent = {
     [@react.component]
@@ -1130,6 +1164,8 @@ let externals =
     "optional-string-arg" >:: testExternalOptionalStringArg,
     "bool-arg" >:: testExternalBoolArg,
     "optional-bool-arg" >:: testExternalOptionalBoolArg,
+    "array-arg" >:: testExternalArrayArg,
+    "optional-array-arg" >:: testExternalOptionalArrayArg,
   ];
 
 let suite =


### PR DESCRIPTION
For the purpose of discussion first of all, this is a proof of concept of one approach to add support for automatic conversion of a select few native types to their js equivalents for props on external component definitions (as briefly discussed [here](https://github.com/ml-in-barcelona/jsoo-react/pull/106#issuecomment-1021309799)).

The currently implemented conversions are:

- `string` -> `Js.js_string Js.t`
- `bool` -> `bool Js.t`
- `'a array` -> `'a Js.js_array Js.t` where `'a` will also be recursively converted
- `React.element list` -> `React.element Js.js_array Js.t` (in order for JSX children to work as expected, unsure if it should convert lists in general)

Everything else will be passed on as-is, which means you can still use `Js.js_string Js.t` directly, for example, and have it work as expected.

Beware, however, that this is just a syntactic rewrite. It doesn't actually know what the types are, so if they're aliased, shadowed or qualified in some unexpected way, this will break. It's very unlikely that this will happen with such fundamental types though. And in most cases you should get reasonable errors. Because the wrapping is done using non-polymorphic functions it will tell you exactly what it expects. The cases where it doesn't is if you expect conversion, but it doesn't, since then it'll just pass the value on to JavaScript where it will result in strange things happening, as is the norm over in untyped JS-land.