### PR TITLE
fix(ppx): Ensure we pass rec_flag on value_binding

### DIFF
--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -1148,13 +1148,13 @@ let jsxMapper () =
           (transformComponentDefinition ~inside_component:true mapper)
           structure returnStructures
     (* let component = ... *)
-    | {pstr_loc; pstr_desc= Pstr_value (_rec_flag, value_bindings)} ->
+    | {pstr_loc; pstr_desc= Pstr_value (rec_flag, value_bindings)} ->
         let bindings =
           List.map
             (process_value_binding ~pstr_loc ~inside_component ~mapper)
             value_bindings
         in
-        [{pstr_loc; pstr_desc= Pstr_value (Nonrecursive, bindings)}]
+        [{pstr_loc; pstr_desc= Pstr_value (rec_flag, bindings)}]
         @ returnStructures
     | structure ->
         structure :: returnStructures

--- a/ppx/test/input_ocaml.ml
+++ b/ppx/test/input_ocaml.ml
@@ -1,3 +1,8 @@
+(* ppx shoudn't transform this *)
+let rec pp_user = 2
+
+(* let%component *)
+
 let%component make ?(name = "") = div [||] [React.string ("Hello " ^ name)]
 
 let%component make ~children:(first, second) = div [||] [first; second]

--- a/ppx/test/pp_ocaml.expected
+++ b/ppx/test/pp_ocaml.expected
@@ -1,3 +1,4 @@
+let rec pp_user = 2
 let make =
   let make_props
     : ?name:'name ->


### PR DESCRIPTION
This PR ensures that `rec_flag` is being passed to the generated value_binding while transforming `let component` with `[@react.component]`.

Fixes #132.