### PR TITLE
ppx: fix bug on externals

### DIFF
--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -990,15 +990,15 @@ let jsxMapper () =
             ; pval_attributes
             ; pval_type
             ; pval_prim } } -> (
-      match pval_prim with
-      | [] | _ :: _ :: _ ->
-          Location.raise_errorf ~loc:pval_loc
-            "jsoo-react: externals only allow single primitive declarations"
-      | [pval_prim] -> (
-        match (List.partition hasAttr pval_attributes, inside_component) with
-        | ([], _), false ->
-            structure :: returnStructures
-        | (_ :: _, rest_attrs), _ | (_, rest_attrs), true ->
+      match (inside_component, List.partition hasAttr pval_attributes) with
+      | false, ([], _) ->
+          structure :: returnStructures
+      | true, (_, rest_attrs) | _, (_ :: _, rest_attrs) -> (
+        match pval_prim with
+        | [] | _ :: _ :: _ ->
+            Location.raise_errorf ~loc:pval_loc
+              "jsoo-react: externals only allow single primitive declarations"
+        | [pval_prim] ->
             let rec get_prop_types types {ptyp_loc; ptyp_desc} =
               match ptyp_desc with
               | Ptyp_arrow

--- a/ppx/test/input_ocaml.ml
+++ b/ppx/test/input_ocaml.ml
@@ -1,5 +1,8 @@
-(* ppx shoudn't transform this *)
+(* ppx should not transform this *)
 let rec pp_user = 2
+
+(* ppx should not error on unrelated primitives with [] as pval_prim *)
+type t = string [@@foo val f : int]
 
 (* let%component *)
 

--- a/ppx/test/pp_ocaml.expected
+++ b/ppx/test/pp_ocaml.expected
@@ -1,4 +1,5 @@
 let rec pp_user = 2
+type t = string[@@foo external f : int]
 let make =
   let make_props
     : ?name:'name ->


### PR DESCRIPTION
Small bugfix for a specific case where the ppx was too eagerly checking for `pval_prim` with just one value, even in extension nodes that were not using `component`.