### PR TITLE
Convert API to snake case

### DIFF
--- a/example/src/App.re
+++ b/example/src/App.re
@@ -1,1 +1,1 @@
-React.Dom.renderToElementWithId(<Main />, "app");
+React.Dom.render_to_element_with_id(<Main />, "app");

--- a/example/src/Click.re
+++ b/example/src/Click.re
@@ -8,7 +8,7 @@ let reducer = (state, action) =>
 
 [@react.component]
 let make = () => {
-  let (state, dispatch) = React.useReducer(reducer, []);
+  let (state, dispatch) = React.use_reducer(reducer, []);
   <div
     style=React.Dom.Style.(make([|color("#ff5544"), fontSize("68px")|]))
     onClick={event => {

--- a/example/src/Code.re
+++ b/example/src/Code.re
@@ -5,7 +5,7 @@ open Html;
 [@react.component]
 let make = (~text) => {
   let codeRef = React.useRef(Js.null);
-  React.useEffect(() => {
+  React.use_effect(() => {
     switch (codeRef |> React.Ref.current |> Js.Opt.to_option) {
     | Some(el) => Js.Unsafe.global##.Prism##highlightElement(el)
     | None => ()

--- a/example/src/Code.re
+++ b/example/src/Code.re
@@ -4,7 +4,7 @@ open Html;
 
 [@react.component]
 let make = (~text) => {
-  let codeRef = React.useRef(Js.null);
+  let codeRef = React.use_ref(Js.null);
   React.use_effect(() => {
     switch (codeRef |> React.Ref.current |> Js.Opt.to_option) {
     | Some(el) => Js.Unsafe.global##.Prism##highlightElement(el)
@@ -13,6 +13,8 @@ let make = (~text) => {
     None;
   });
   <pre className="language-reason">
-    <code ref_={React.Dom.Ref.domRef(codeRef)}> {text |> React.string} </code>
+    <code ref_={React.Dom.Ref.dom_ref(codeRef)}>
+      {text |> React.string}
+    </code>
   </pre>;
 };

--- a/example/src/EffectsAndState.re
+++ b/example/src/EffectsAndState.re
@@ -19,7 +19,7 @@ let space = {
 [@react.component]
 let make = (~name="Billy", ~children=?) => {
   let (count, setCount) = React.use_state(() => 0);
-  let (state, dispatch) = React.useReducer(reducer, 0);
+  let (state, dispatch) = React.use_reducer(reducer, 0);
 
   <div>
     <UseEffect count />

--- a/example/src/EffectsAndState.re
+++ b/example/src/EffectsAndState.re
@@ -18,7 +18,7 @@ let space = {
 
 [@react.component]
 let make = (~name="Billy", ~children=?) => {
-  let (count, setCount) = React.useState(() => 0);
+  let (count, setCount) = React.use_state(() => 0);
   let (state, dispatch) = React.useReducer(reducer, 0);
 
   <div>

--- a/example/src/Events.re
+++ b/example/src/Events.re
@@ -16,8 +16,8 @@ module Title = {
 
 [@react.component]
 let make = () => {
-  let (coords, setCoords) = React.useState(() => {x: 0, y: 0});
-  let (inputText, setInputText) = React.useState(() => "");
+  let (coords, setCoords) = React.use_state(() => {x: 0, y: 0});
+  let (inputText, setInputText) = React.use_state(() => "");
   <div>
     <h5> {"text input via \"onChange\"" |> React.string} </h5>
     <input

--- a/example/src/Events.re
+++ b/example/src/Events.re
@@ -30,7 +30,7 @@ let make = () => {
     <h5> {"form submission via \"onSubmit\"" |> React.string} </h5>
     <form
       onSubmit={event => {
-        React.Event.Form.preventDefault(event);
+        React.Event.Form.prevent_default(event);
         switch (Window.get) {
         | None => ()
         | Some(w) =>
@@ -45,7 +45,7 @@ let make = () => {
           let value = React.Event.Form.target(event) |> Window.value;
           setInputText(_ => value);
         }}
-        style=React.Dom.Style.(make([|marginRight("15px")|]))
+        style=React.Dom.Style.(make([|margin_right("15px")|]))
         value=inputText
       />
       <button type_="submit"> {"submit dis" |> React.string} </button>
@@ -55,7 +55,8 @@ let make = () => {
       <img
         src="https://cdn.glitch.com/ed95e263-69d5-4c3b-aed2-d85713f4aef9%2Fdoggo.jpeg?v=1563384185147"
         onMouseMove={event => {
-          let (x, y) = React.Event.Mouse.(screenX(event), screenY(event));
+          let (x, y) =
+            React.Event.Mouse.(screen_x(event), screen_y(event));
           setCoords(_ => {{x, y}});
         }}
       />

--- a/example/src/Main.re
+++ b/example/src/Main.re
@@ -138,7 +138,7 @@ let examples = [
 
 [@react.component]
 let make = () => {
-  let url = React.Router.useUrl();
+  let url = React.Router.use_url();
 
   <div className="flex-container">
     <div className="sidebar">
@@ -152,7 +152,7 @@ let make = () => {
                       <a
                         href={e.path}
                         onClick={event => {
-                          React.Event.Mouse.preventDefault(event);
+                          React.Event.Mouse.prevent_default(event);
                           React.Router.push(e.path);
                         }}>
                         {e.title |> s}

--- a/example/src/Refs.re
+++ b/example/src/Refs.re
@@ -6,7 +6,7 @@ open Html;
 module FancyLink = {
   [@react.component]
   let make =
-    React.Dom.forwardRef((~href, ~repo, ref) =>
+    React.Dom.forward_ref((~href, ~repo, ref) =>
       <a ref_=ref href className="FancyLink"> {repo |> React.string} </a>
     );
 };
@@ -16,7 +16,7 @@ let make = () => {
   let (show, setShow) = React.use_state(() => true);
   /* You can now get a ref directly to the DOM button: */
   let ref =
-    React.Dom.Ref.callbackDomRef(ref => {
+    React.Dom.Ref.callback_dom_ref(ref => {
       Console.log(Js.string("Ref is:"));
       Console.log(ref);
     });
@@ -24,7 +24,7 @@ let make = () => {
     <button
       key="toggle"
       onClick={_ => setShow(s => !s)}
-      style=React.Dom.Style.(make([|marginRight("15px")|]))>
+      style=React.Dom.Style.(make([|margin_right("15px")|]))>
       {"Toggle fancy link" |> React.string}
     </button>
     {show

--- a/example/src/Refs.re
+++ b/example/src/Refs.re
@@ -13,7 +13,7 @@ module FancyLink = {
 
 [@react.component]
 let make = () => {
-  let (show, setShow) = React.useState(() => true);
+  let (show, setShow) = React.use_state(() => true);
   /* You can now get a ref directly to the DOM button: */
   let ref =
     React.Dom.Ref.callbackDomRef(ref => {

--- a/example/src/UseEffect.re
+++ b/example/src/UseEffect.re
@@ -29,8 +29,8 @@ let make = (~count) => {
     [|count|],
   );
 
-  React.useLayoutEffect(() => {
-    Console.log("useLayoutEffect: component updated");
+  React.use_layout_effect(() => {
+    Console.log("use_layout_effect: component updated");
     None;
   });
 

--- a/example/src/UseEffect.re
+++ b/example/src/UseEffect.re
@@ -5,7 +5,7 @@ open Html;
 [@react.component]
 let make = (~count) => {
   open Js_of_ocaml_lwt;
-  React.useEffect1(
+  React.use_effect1(
     () => {
       open Lwt;
       open Lwt_js;

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -634,19 +634,19 @@ module Context : sig
   end
 end
 
-val createContext : 'a -> 'a Context.t
+val create_context : 'a -> 'a Context.t
   [@@js.custom
-    val createContext_internal : Imports.react -> 'a -> 'a Context.t
+    val create_context_internal : Imports.react -> 'a -> 'a Context.t
       [@@js.call "createContext"]
 
-    let createContext value = createContext_internal Imports.react value]
+    let create_context value = create_context_internal Imports.react value]
 
-val useContext : 'value Context.t -> 'value
+val use_context : 'value Context.t -> 'value
   [@@js.custom
-    val useContext_internal : Imports.react -> 'a Context.t -> 'a
+    val use_context_internal : Imports.react -> 'a Context.t -> 'a
       [@@js.call "useContext"]
 
-    let useContext ctx = useContext_internal Imports.react ctx]
+    let use_context ctx = use_context_internal Imports.react ctx]
 
 module Children : sig
   [@@@js.implem

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -600,22 +600,22 @@ module Ref : sig
 
   val current : 'value t -> 'value [@@js.get "current"]
 
-  val setCurrent : 'value t -> 'value -> unit [@@js.set "current"]
+  val set_current : 'value t -> 'value -> unit [@@js.set "current"]
 end
 
-val useRef : 'value -> 'value Ref.t
+val use_ref : 'value -> 'value Ref.t
   [@@js.custom
-    val useRef_internal : Imports.react -> 'value -> 'value Ref.t
+    val use_ref_internal : Imports.react -> 'value -> 'value Ref.t
       [@@js.call "useRef"]
 
-    let useRef value = useRef_internal Imports.react value]
+    let use_ref value = use_ref_internal Imports.react value]
 
-val createRef : unit -> 'a js_nullable Ref.t
+val create_ref : unit -> 'a js_nullable Ref.t
   [@@js.custom
-    val createRef_internal : Imports.react -> unit -> 'a js_nullable Ref.t
+    val create_ref_internal : Imports.react -> unit -> 'a js_nullable Ref.t
       [@@js.call "createRef"]
 
-    let createRef () = createRef_internal Imports.react ()]
+    let create_ref () = create_ref_internal Imports.react ()]
 
 module Context : sig
   type 'props t

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -626,11 +626,11 @@ module Context : sig
     val make :
       'props t -> value:'props -> children:element list -> unit -> element
       [@@js.custom
-        let makeProps value =
+        let make_props value =
           Js_of_ocaml.Js.Unsafe.(obj [|("value", inject value)|])
 
         let make context ~value ~children () =
-          create_element_variadic (provider context) (makeProps value) children]
+          create_element_variadic (provider context) (make_props value) children]
   end
 end
 
@@ -720,7 +720,7 @@ module Fragment : sig
 
       let fragment_internal = fragment_internal' Imports.react
 
-      let makeProps ?key () =
+      let make_props ?key () =
         match key with
         | Some k ->
             Js_of_ocaml.Js.Unsafe.(obj [|("key", inject k)|])
@@ -730,7 +730,7 @@ module Fragment : sig
       let make ~children ?key () =
         create_element_variadic
           (to_component fragment_internal)
-          (makeProps ?key ()) children]
+          (make_props ?key ()) children]
 end
 
 (* TODO: add key: https://reactjs.org/docs/fragments.html#keyed-fragments

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -211,121 +211,121 @@ val use_effect7 :
     let use_effect7 callback watchlist =
       use_effect7_internal Imports.react callback watchlist]
 
-val useLayoutEffect : (unit -> (unit -> unit) option_undefined) -> unit
+val use_layout_effect : (unit -> (unit -> unit) option_undefined) -> unit
   [@@js.custom
-    val useLayoutEffect_internal :
+    val use_layout_effect_internal :
       Imports.react -> (unit -> (unit -> unit) option_undefined) -> unit
       [@@js.call "useLayoutEffect"]
 
-    let useLayoutEffect callback =
-      useLayoutEffect_internal Imports.react callback]
+    let use_layout_effect callback =
+      use_layout_effect_internal Imports.react callback]
 
-val useLayoutEffect0 : (unit -> (unit -> unit) option_undefined) -> unit
+val use_layout_effect0 : (unit -> (unit -> unit) option_undefined) -> unit
   [@@js.custom
-    val useLayoutEffect0_internal :
+    val use_layout_effect0_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> Ojs.t array
       -> unit
       [@@js.call "useLayoutEffect"]
 
-    let useLayoutEffect0 callback =
-      useLayoutEffect0_internal Imports.react callback [||]]
+    let use_layout_effect0 callback =
+      use_layout_effect0_internal Imports.react callback [||]]
 
-val useLayoutEffect1 :
+val use_layout_effect1 :
   (unit -> (unit -> unit) option_undefined) -> 'a array -> unit
   [@@js.custom
-    val useLayoutEffect1_internal :
+    val use_layout_effect1_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a array
       -> unit
       [@@js.call "useLayoutEffect"]
 
-    let useLayoutEffect1 callback watchlist =
-      useLayoutEffect1_internal Imports.react callback watchlist]
+    let use_layout_effect1 callback watchlist =
+      use_layout_effect1_internal Imports.react callback watchlist]
 
-val useLayoutEffect2 :
+val use_layout_effect2 :
   (unit -> (unit -> unit) option_undefined) -> 'a * 'b -> unit
   [@@js.custom
-    val useLayoutEffect2_internal :
+    val use_layout_effect2_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b
       -> unit
       [@@js.call "useLayoutEffect"]
 
-    let useLayoutEffect2 callback watchlist =
-      useLayoutEffect2_internal Imports.react callback watchlist]
+    let use_layout_effect2 callback watchlist =
+      use_layout_effect2_internal Imports.react callback watchlist]
 
-val useLayoutEffect3 :
+val use_layout_effect3 :
   (unit -> (unit -> unit) option_undefined) -> 'a * 'b * 'c -> unit
   [@@js.custom
-    val useLayoutEffect3_internal :
+    val use_layout_effect3_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b * 'c
       -> unit
       [@@js.call "useLayoutEffect"]
 
-    let useLayoutEffect3 callback watchlist =
-      useLayoutEffect3_internal Imports.react callback watchlist]
+    let use_layout_effect3 callback watchlist =
+      use_layout_effect3_internal Imports.react callback watchlist]
 
-val useLayoutEffect4 :
+val use_layout_effect4 :
   (unit -> (unit -> unit) option_undefined) -> 'a * 'b * 'c * 'd -> unit
   [@@js.custom
-    val useLayoutEffect4_internal :
+    val use_layout_effect4_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b * 'c * 'd
       -> unit
       [@@js.call "useLayoutEffect"]
 
-    let useLayoutEffect4 callback watchlist =
-      useLayoutEffect4_internal Imports.react callback watchlist]
+    let use_layout_effect4 callback watchlist =
+      use_layout_effect4_internal Imports.react callback watchlist]
 
-val useLayoutEffect5 :
+val use_layout_effect5 :
   (unit -> (unit -> unit) option_undefined) -> 'a * 'b * 'c * 'd * 'e -> unit
   [@@js.custom
-    val useLayoutEffect5_internal :
+    val use_layout_effect5_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b * 'c * 'd * 'e
       -> unit
       [@@js.call "useLayoutEffect"]
 
-    let useLayoutEffect5 callback watchlist =
-      useLayoutEffect5_internal Imports.react callback watchlist]
+    let use_layout_effect5 callback watchlist =
+      use_layout_effect5_internal Imports.react callback watchlist]
 
-val useLayoutEffect6 :
+val use_layout_effect6 :
      (unit -> (unit -> unit) option_undefined)
   -> 'a * 'b * 'c * 'd * 'e * 'f
   -> unit
   [@@js.custom
-    val useLayoutEffect6_internal :
+    val use_layout_effect6_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b * 'c * 'd * 'e * 'f
       -> unit
       [@@js.call "useLayoutEffect"]
 
-    let useLayoutEffect6 callback watchlist =
-      useLayoutEffect6_internal Imports.react callback watchlist]
+    let use_layout_effect6 callback watchlist =
+      use_layout_effect6_internal Imports.react callback watchlist]
 
-val useLayoutEffect7 :
+val use_layout_effect7 :
      (unit -> (unit -> unit) option_undefined)
   -> 'a * 'b * 'c * 'd * 'e * 'f * 'g
   -> unit
   [@@js.custom
-    val useLayoutEffect7_internal :
+    val use_layout_effect7_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b * 'c * 'd * 'e * 'f * 'g
       -> unit
       [@@js.call "useLayoutEffect"]
 
-    let useLayoutEffect7 callback watchlist =
-      useLayoutEffect7_internal Imports.react callback watchlist]
+    let use_layout_effect7 callback watchlist =
+      use_layout_effect7_internal Imports.react callback watchlist]
 
 val useCallback : ('input, 'output) callback -> ('input, 'output) callback
   [@@js.custom

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -327,9 +327,9 @@ val use_layout_effect7 :
     let use_layout_effect7 callback watchlist =
       use_layout_effect7_internal Imports.react callback watchlist]
 
-val useCallback : ('input, 'output) callback -> ('input, 'output) callback
+val use_callback : ('input, 'output) callback -> ('input, 'output) callback
   [@@js.custom
-    val useCallback_internal :
+    val use_callback_internal :
          Imports.react
       -> ('input, 'output) callback
       -> 'a array option_undefined
@@ -338,108 +338,108 @@ val useCallback : ('input, 'output) callback -> ('input, 'output) callback
       -> ('input, 'output) callback
       [@@js.call "useCallback"]
 
-    let useCallback cb = useCallback_internal Imports.react cb None]
+    let use_callback cb = use_callback_internal Imports.react cb None]
 
-val useCallback0 : ('input, 'output) callback -> ('input, 'output) callback
+val use_callback0 : ('input, 'output) callback -> ('input, 'output) callback
   [@@js.custom
-    let useCallback0 f = useCallback_internal Imports.react f (Some [||])]
+    let use_callback0 f = use_callback_internal Imports.react f (Some [||])]
 
-val useCallback1 :
+val use_callback1 :
   ('input, 'output) callback -> 'a array -> ('input, 'output) callback
   [@@js.custom
-    val useCallback1_internal :
+    val use_callback1_internal :
          Imports.react
       -> ('input, 'output) callback
       -> 'a array
       -> ('input, 'output) callback
       [@@js.call "useCallback"]
 
-    let useCallback1 callback watchlist =
-      useCallback1_internal Imports.react callback watchlist]
+    let use_callback1 callback watchlist =
+      use_callback1_internal Imports.react callback watchlist]
 
-val useCallback2 :
+val use_callback2 :
   ('input, 'output) callback -> 'a * 'b -> ('input, 'output) callback
   [@@js.custom
-    val useCallback2_internal :
+    val use_callback2_internal :
          Imports.react
       -> ('input, 'output) callback
       -> 'a * 'b
       -> ('input, 'output) callback
       [@@js.call "useCallback"]
 
-    let useCallback2 callback watchlist =
-      useCallback2_internal Imports.react callback watchlist]
+    let use_callback2 callback watchlist =
+      use_callback2_internal Imports.react callback watchlist]
 
-val useCallback3 :
+val use_callback3 :
   ('input, 'output) callback -> 'a * 'b * 'c -> ('input, 'output) callback
   [@@js.custom
-    val useCallback3_internal :
+    val use_callback3_internal :
          Imports.react
       -> ('input, 'output) callback
       -> 'a * 'b * 'c
       -> ('input, 'output) callback
       [@@js.call "useCallback"]
 
-    let useCallback3 callback watchlist =
-      useCallback3_internal Imports.react callback watchlist]
+    let use_callback3 callback watchlist =
+      use_callback3_internal Imports.react callback watchlist]
 
-val useCallback4 :
+val use_callback4 :
   ('input, 'output) callback -> 'a * 'b * 'c * 'd -> ('input, 'output) callback
   [@@js.custom
-    val useCallback4_internal :
+    val use_callback4_internal :
          Imports.react
       -> ('input, 'output) callback
       -> 'a * 'b * 'c * 'd
       -> ('input, 'output) callback
       [@@js.call "useCallback"]
 
-    let useCallback4 callback watchlist =
-      useCallback4_internal Imports.react callback watchlist]
+    let use_callback4 callback watchlist =
+      use_callback4_internal Imports.react callback watchlist]
 
-val useCallback5 :
+val use_callback5 :
      ('input, 'output) callback
   -> 'a * 'b * 'c * 'd * 'e
   -> ('input, 'output) callback
   [@@js.custom
-    val useCallback5_internal :
+    val use_callback5_internal :
          Imports.react
       -> ('input, 'output) callback
       -> 'a * 'b * 'c * 'd * 'e
       -> ('input, 'output) callback
       [@@js.call "useCallback"]
 
-    let useCallback5 callback watchlist =
-      useCallback5_internal Imports.react callback watchlist]
+    let use_callback5 callback watchlist =
+      use_callback5_internal Imports.react callback watchlist]
 
-val useCallback6 :
+val use_callback6 :
      ('input, 'output) callback
   -> 'a * 'b * 'c * 'd * 'e * 'f
   -> ('input, 'output) callback
   [@@js.custom
-    val useCallback6_internal :
+    val use_callback6_internal :
          Imports.react
       -> ('input, 'output) callback
       -> 'a * 'b * 'c * 'd * 'e * 'f
       -> ('input, 'output) callback
       [@@js.call "useCallback"]
 
-    let useCallback6 callback watchlist =
-      useCallback6_internal Imports.react callback watchlist]
+    let use_callback6 callback watchlist =
+      use_callback6_internal Imports.react callback watchlist]
 
-val useCallback7 :
+val use_callback7 :
      ('input, 'output) callback
   -> 'a * 'b * 'c * 'd * 'e * 'f * 'g
   -> ('input, 'output) callback
   [@@js.custom
-    val useCallback7_internal :
+    val use_callback7_internal :
          Imports.react
       -> ('input, 'output) callback
       -> 'a * 'b * 'c * 'd * 'e * 'f * 'g
       -> ('input, 'output) callback
       [@@js.call "useCallback"]
 
-    let useCallback7 callback watchlist =
-      useCallback7_internal Imports.react callback watchlist]
+    let use_callback7 callback watchlist =
+      use_callback7_internal Imports.react callback watchlist]
 
 val useMemo : (unit -> 'value) -> 'value
   [@@js.custom

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -735,14 +735,14 @@ end
 
 (* TODO: add key: https://reactjs.org/docs/fragments.html#keyed-fragments
    Although Reason parser doesn't support it so that's a requirement before adding it here *)
-val createFragment : element list -> element
+val create_fragment : element list -> element
   [@@js.custom
-    val createFragment_internal :
+    val create_fragment_internal :
       Imports.react -> Ojs.t -> Ojs.t -> (element list[@js.variadic]) -> element
       [@@js.call "createElement"]
 
-    let createFragment l =
-      createFragment_internal Imports.react Fragment.fragment_internal Ojs.null
+    let create_fragment l =
+      create_fragment_internal Imports.react Fragment.fragment_internal Ojs.null
         l]
 
 val memo : 'props component -> 'props component

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -535,10 +535,10 @@ val use_state : (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
 
     let use_state initial = use_state_internal Imports.react initial]
 
-val useReducer :
+val use_reducer :
   ('state -> 'action -> 'state) -> 'state -> 'state * ('action -> unit)
   [@@js.custom
-    let (useReducer_internal :
+    let (use_reducer_internal :
              Imports.react
           -> ('state -> 'action -> 'state)
           -> 'state
@@ -555,16 +555,16 @@ val useReducer :
       in
       (Obj.magic (Ojs.array_get result 0), Obj.magic (Ojs.array_get result 1))
 
-    let useReducer reducer initial =
-      useReducer_internal Imports.react reducer initial]
+    let use_reducer reducer initial =
+      use_reducer_internal Imports.react reducer initial]
 
-val useReducerWithMapState :
+val use_reducer_with_map_state :
      ('state -> 'action -> 'state)
   -> 'initialState
   -> ('initialState -> 'state)
   -> 'state * ('action -> unit)
   [@@js.custom
-    let (useReducerWithMapState_internal :
+    let (use_reducer_with_map_state_internal :
              Imports.react
           -> ('state -> 'action -> 'state)
           -> 'initialState
@@ -584,8 +584,8 @@ val useReducerWithMapState :
       in
       (Obj.magic (Ojs.array_get result 0), Obj.magic (Ojs.array_get result 1))
 
-    let useReducerWithMapState reducer initial mapper =
-      useReducerWithMapState_internal Imports.react reducer initial mapper]
+    let use_reducer_with_map_state reducer initial mapper =
+      use_reducer_with_map_state_internal Imports.react reducer initial mapper]
 
 module Ref : sig
   type 'value t

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -518,9 +518,9 @@ val use_memo7 : (unit -> 'value) -> 'a * 'b * 'c * 'd * 'e * 'f * 'g -> 'value
     let use_memo7 callback watchlist =
       use_memo7_internal Imports.react callback watchlist]
 
-val useState : (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
+val use_state : (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
   [@@js.custom
-    let (useState_internal :
+    let (use_state_internal :
              Imports.react
           -> (unit -> 'state)
           -> 'state * (('state -> 'state) -> unit) ) =
@@ -533,7 +533,7 @@ val useState : (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
       in
       (Obj.magic (Ojs.array_get result 0), Obj.magic (Ojs.array_get result 1))
 
-    let useState initial = useState_internal Imports.react initial]
+    let use_state initial = use_state_internal Imports.react initial]
 
 val useReducer :
   ('state -> 'action -> 'state) -> 'state -> 'state * ('action -> unit)

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -441,82 +441,82 @@ val use_callback7 :
     let use_callback7 callback watchlist =
       use_callback7_internal Imports.react callback watchlist]
 
-val useMemo : (unit -> 'value) -> 'value
+val use_memo : (unit -> 'value) -> 'value
   [@@js.custom
-    val useMemo_internal :
+    val use_memo_internal :
       Imports.react -> (unit -> 'value) -> 'any array option_undefined -> 'value
       [@@js.call "useMemo"]
 
-    let useMemo f = useMemo_internal Imports.react f None]
+    let use_memo f = use_memo_internal Imports.react f None]
 
-val useMemo0 : (unit -> 'value) -> 'value
-  [@@js.custom let useMemo0 f = useMemo_internal Imports.react f (Some [||])]
+val use_memo0 : (unit -> 'value) -> 'value
+  [@@js.custom let use_memo0 f = use_memo_internal Imports.react f (Some [||])]
 
-val useMemo1 : (unit -> 'value) -> 'a array -> 'value
+val use_memo1 : (unit -> 'value) -> 'a array -> 'value
   [@@js.custom
-    val useMemo1_internal :
+    val use_memo1_internal :
       Imports.react -> (unit -> 'value) -> 'a array -> 'value
       [@@js.call "useMemo"]
 
-    let useMemo1 callback watchlist =
-      useMemo1_internal Imports.react callback watchlist]
+    let use_memo1 callback watchlist =
+      use_memo1_internal Imports.react callback watchlist]
 
-val useMemo2 : (unit -> 'value) -> 'a * 'b -> 'value
+val use_memo2 : (unit -> 'value) -> 'a * 'b -> 'value
   [@@js.custom
-    val useMemo2_internal :
+    val use_memo2_internal :
       Imports.react -> (unit -> 'value) -> 'a * 'b -> 'value
       [@@js.call "useMemo"]
 
-    let useMemo2 callback watchlist =
-      useMemo2_internal Imports.react callback watchlist]
+    let use_memo2 callback watchlist =
+      use_memo2_internal Imports.react callback watchlist]
 
-val useMemo3 : (unit -> 'value) -> 'a * 'b * 'c -> 'value
+val use_memo3 : (unit -> 'value) -> 'a * 'b * 'c -> 'value
   [@@js.custom
-    val useMemo3_internal :
+    val use_memo3_internal :
       Imports.react -> (unit -> 'value) -> 'a * 'b * 'c -> 'value
       [@@js.call "useMemo"]
 
-    let useMemo3 callback watchlist =
-      useMemo3_internal Imports.react callback watchlist]
+    let use_memo3 callback watchlist =
+      use_memo3_internal Imports.react callback watchlist]
 
-val useMemo4 : (unit -> 'value) -> 'a * 'b * 'c * 'd -> 'value
+val use_memo4 : (unit -> 'value) -> 'a * 'b * 'c * 'd -> 'value
   [@@js.custom
-    val useMemo4_internal :
+    val use_memo4_internal :
       Imports.react -> (unit -> 'value) -> 'a * 'b * 'c * 'd -> 'value
       [@@js.call "useMemo"]
 
-    let useMemo4 callback watchlist =
-      useMemo4_internal Imports.react callback watchlist]
+    let use_memo4 callback watchlist =
+      use_memo4_internal Imports.react callback watchlist]
 
-val useMemo5 : (unit -> 'value) -> 'a * 'b * 'c * 'd * 'e -> 'value
+val use_memo5 : (unit -> 'value) -> 'a * 'b * 'c * 'd * 'e -> 'value
   [@@js.custom
-    val useMemo5_internal :
+    val use_memo5_internal :
       Imports.react -> (unit -> 'value) -> 'a * 'b * 'c * 'd * 'e -> 'value
       [@@js.call "useMemo"]
 
-    let useMemo5 callback watchlist =
-      useMemo5_internal Imports.react callback watchlist]
+    let use_memo5 callback watchlist =
+      use_memo5_internal Imports.react callback watchlist]
 
-val useMemo6 : (unit -> 'value) -> 'a * 'b * 'c * 'd * 'e * 'f -> 'value
+val use_memo6 : (unit -> 'value) -> 'a * 'b * 'c * 'd * 'e * 'f -> 'value
   [@@js.custom
-    val useMemo6_internal :
+    val use_memo6_internal :
       Imports.react -> (unit -> 'value) -> 'a * 'b * 'c * 'd * 'e * 'f -> 'value
       [@@js.call "useMemo"]
 
-    let useMemo6 callback watchlist =
-      useMemo6_internal Imports.react callback watchlist]
+    let use_memo6 callback watchlist =
+      use_memo6_internal Imports.react callback watchlist]
 
-val useMemo7 : (unit -> 'value) -> 'a * 'b * 'c * 'd * 'e * 'f * 'g -> 'value
+val use_memo7 : (unit -> 'value) -> 'a * 'b * 'c * 'd * 'e * 'f * 'g -> 'value
   [@@js.custom
-    val useMemo7_internal :
+    val use_memo7_internal :
          Imports.react
       -> (unit -> 'value)
       -> 'a * 'b * 'c * 'd * 'e * 'f * 'g
       -> 'value
       [@@js.call "useMemo"]
 
-    let useMemo7 callback watchlist =
-      useMemo7_internal Imports.react callback watchlist]
+    let use_memo7 callback watchlist =
+      use_memo7_internal Imports.react callback watchlist]
 
 val useState : (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
   [@@js.custom

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -662,31 +662,31 @@ module Children : sig
 
       let map element mapper = map_internal children_internal element mapper]
 
-  val mapWithIndex : element list -> (element -> int -> element) -> element
+  val map_with_index : element list -> (element -> int -> element) -> element
     [@@js.custom
-      val mapWithIndex_internal :
+      val map_with_index_internal :
         Ojs.t -> element list -> (element -> int -> element) -> element
         [@@js.call "map"]
 
-      let mapWithIndex element mapper =
-        mapWithIndex_internal children_internal element mapper]
+      let map_with_index element mapper =
+        map_with_index_internal children_internal element mapper]
 
-  val forEach : element list -> (element -> unit) -> unit
+  val for_each : element list -> (element -> unit) -> unit
     [@@js.custom
-      val forEach_internal : Ojs.t -> element list -> (element -> unit) -> unit
+      val for_each_internal : Ojs.t -> element list -> (element -> unit) -> unit
         [@@js.call "forEach"]
 
-      let forEach element iterator =
-        forEach_internal children_internal element iterator]
+      let for_each element iterator =
+        for_each_internal children_internal element iterator]
 
-  val forEachWithIndex : element list -> (element -> int -> unit) -> unit
+  val for_each_with_index : element list -> (element -> int -> unit) -> unit
     [@@js.custom
-      val forEachWithIndex_internal :
+      val for_each_with_index_internal :
         Ojs.t -> element list -> (element -> int -> unit) -> unit
         [@@js.call "forEach"]
 
-      let forEachWithIndex element iterator =
-        forEachWithIndex_internal children_internal element iterator]
+      let for_each_with_index element iterator =
+        for_each_with_index_internal children_internal element iterator]
 
   val count : element list -> int
     [@@js.custom
@@ -700,12 +700,12 @@ module Children : sig
 
       let only element = only_internal children_internal element]
 
-  val toArray : element list -> element array
+  val to_array : element list -> element array
     [@@js.custom
-      val toArray_internal : Ojs.t -> element list -> element array
+      val to_array_internal : Ojs.t -> element list -> element array
         [@@js.call "toArray"]
 
-      let toArray element = toArray_internal children_internal element]
+      let to_array element = to_array_internal children_internal element]
 end
 
 module Fragment : sig

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -765,4 +765,5 @@ val memo_custom_compare_props :
     let memo_custom_compare_props component compare =
       memo_custom_compare_props_internal Imports.react component compare]
 
-val setDisplayName : 'props component -> string -> unit [@@js.set "displayName"]
+val set_display_name : 'props component -> string -> unit
+  [@@js.set "displayName"]

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -91,13 +91,13 @@ val create_element_variadic :
     let create_element_variadic component props elements =
       create_element_variadic_internal Imports.react component props elements]
 
-val cloneElement : element -> 'props -> element
+val clone_element : element -> 'props -> element
   [@@js.custom
-    val cloneElement_internal : Imports.react -> element -> 'a -> element
+    val clone_element_internal : Imports.react -> element -> 'a -> element
       [@@js.call "cloneElement"]
 
-    let cloneElement element props =
-      cloneElement_internal Imports.react element props]
+    let clone_element element props =
+      clone_element_internal Imports.react element props]
 
 val useEffect : (unit -> (unit -> unit) option_undefined) -> unit
   [@@js.custom

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -99,117 +99,117 @@ val clone_element : element -> 'props -> element
     let clone_element element props =
       clone_element_internal Imports.react element props]
 
-val useEffect : (unit -> (unit -> unit) option_undefined) -> unit
+val use_effect : (unit -> (unit -> unit) option_undefined) -> unit
   [@@js.custom
-    val useEffect_internal :
+    val use_effect_internal :
       Imports.react -> (unit -> (unit -> unit) option_undefined) -> unit
       [@@js.call "useEffect"]
 
-    let useEffect callback = useEffect_internal Imports.react callback]
+    let use_effect callback = use_effect_internal Imports.react callback]
 
-val useEffect0 : (unit -> (unit -> unit) option_undefined) -> unit
+val use_effect0 : (unit -> (unit -> unit) option_undefined) -> unit
   [@@js.custom
-    val useEffect0_internal :
+    val use_effect0_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> Ojs.t array
       -> unit
       [@@js.call "useEffect"]
 
-    let useEffect0 callback = useEffect0_internal Imports.react callback [||]]
+    let use_effect0 callback = use_effect0_internal Imports.react callback [||]]
 
-val useEffect1 : (unit -> (unit -> unit) option_undefined) -> 'a array -> unit
+val use_effect1 : (unit -> (unit -> unit) option_undefined) -> 'a array -> unit
   [@@js.custom
-    val useEffect1_internal :
+    val use_effect1_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a array
       -> unit
       [@@js.call "useEffect"]
 
-    let useEffect1 callback watchlist =
-      useEffect1_internal Imports.react callback watchlist]
+    let use_effect1 callback watchlist =
+      use_effect1_internal Imports.react callback watchlist]
 
-val useEffect2 : (unit -> (unit -> unit) option_undefined) -> 'a * 'b -> unit
+val use_effect2 : (unit -> (unit -> unit) option_undefined) -> 'a * 'b -> unit
   [@@js.custom
-    val useEffect2_internal :
+    val use_effect2_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b
       -> unit
       [@@js.call "useEffect"]
 
-    let useEffect2 callback watchlist =
-      useEffect2_internal Imports.react callback watchlist]
+    let use_effect2 callback watchlist =
+      use_effect2_internal Imports.react callback watchlist]
 
-val useEffect3 :
+val use_effect3 :
   (unit -> (unit -> unit) option_undefined) -> 'a * 'b * 'c -> unit
   [@@js.custom
-    val useEffect3_internal :
+    val use_effect3_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b * 'c
       -> unit
       [@@js.call "useEffect"]
 
-    let useEffect3 callback watchlist =
-      useEffect3_internal Imports.react callback watchlist]
+    let use_effect3 callback watchlist =
+      use_effect3_internal Imports.react callback watchlist]
 
-val useEffect4 :
+val use_effect4 :
   (unit -> (unit -> unit) option_undefined) -> 'a * 'b * 'c * 'd -> unit
   [@@js.custom
-    val useEffect4_internal :
+    val use_effect4_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b * 'c * 'd
       -> unit
       [@@js.call "useEffect"]
 
-    let useEffect4 callback watchlist =
-      useEffect4_internal Imports.react callback watchlist]
+    let use_effect4 callback watchlist =
+      use_effect4_internal Imports.react callback watchlist]
 
-val useEffect5 :
+val use_effect5 :
   (unit -> (unit -> unit) option_undefined) -> 'a * 'b * 'c * 'd * 'e -> unit
   [@@js.custom
-    val useEffect5_internal :
+    val use_effect5_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b * 'c * 'd * 'e
       -> unit
       [@@js.call "useEffect"]
 
-    let useEffect5 callback watchlist =
-      useEffect5_internal Imports.react callback watchlist]
+    let use_effect5 callback watchlist =
+      use_effect5_internal Imports.react callback watchlist]
 
-val useEffect6 :
+val use_effect6 :
      (unit -> (unit -> unit) option_undefined)
   -> 'a * 'b * 'c * 'd * 'e * 'f
   -> unit
   [@@js.custom
-    val useEffect6_internal :
+    val use_effect6_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b * 'c * 'd * 'e * 'f
       -> unit
       [@@js.call "useEffect"]
 
-    let useEffect6 callback watchlist =
-      useEffect6_internal Imports.react callback watchlist]
+    let use_effect6 callback watchlist =
+      use_effect6_internal Imports.react callback watchlist]
 
-val useEffect7 :
+val use_effect7 :
      (unit -> (unit -> unit) option_undefined)
   -> 'a * 'b * 'c * 'd * 'e * 'f * 'g
   -> unit
   [@@js.custom
-    val useEffect7_internal :
+    val use_effect7_internal :
          Imports.react
       -> (unit -> (unit -> unit) option_undefined)
       -> 'a * 'b * 'c * 'd * 'e * 'f * 'g
       -> unit
       [@@js.call "useEffect"]
 
-    let useEffect7 callback watchlist =
-      useEffect7_internal Imports.react callback watchlist]
+    let use_effect7 callback watchlist =
+      use_effect7_internal Imports.react callback watchlist]
 
 val useLayoutEffect : (unit -> (unit -> unit) option_undefined) -> unit
   [@@js.custom

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -752,17 +752,17 @@ val memo : 'props component -> 'props component
 
     let memo component = memo_internal Imports.react component]
 
-val memoCustomCompareProps :
+val memo_custom_compare_props :
   'props component -> ('props -> 'props -> bool) -> 'props component
   [@@js.custom
-    val memoCustomCompareProps_internal :
+    val memo_custom_compare_props_internal :
          Imports.react
       -> 'props component
       -> ('props -> 'props -> bool)
       -> 'props component
       [@@js.call "memo"]
 
-    let memoCustomCompareProps component compare =
-      memoCustomCompareProps_internal Imports.react component compare]
+    let memo_custom_compare_props component compare =
+      memo_custom_compare_props_internal Imports.react component compare]
 
 val setDisplayName : 'props component -> string -> unit [@@js.set "displayName"]

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -69,18 +69,18 @@ let callback_to_js _ cb = cb
 
 let callback_of_js _ js = js]
 
-val createElement : 'props component -> 'props -> element
+val create_element : 'props component -> 'props -> element
   [@@js.custom
-    val createElement_internal : Imports.react -> 'a component -> 'a -> element
+    val create_element_internal : Imports.react -> 'a component -> 'a -> element
       [@@js.call "createElement"]
 
-    let createElement component props =
-      createElement_internal Imports.react component props]
+    let create_element component props =
+      create_element_internal Imports.react component props]
 
-val createElementVariadic :
+val create_element_variadic :
   'props component -> 'props -> element list -> element
   [@@js.custom
-    val createElementVariadic_internal :
+    val create_element_variadic_internal :
          Imports.react
       -> 'props component
       -> 'props
@@ -88,8 +88,8 @@ val createElementVariadic :
       -> element
       [@@js.call "createElement"]
 
-    let createElementVariadic component props elements =
-      createElementVariadic_internal Imports.react component props elements]
+    let create_element_variadic component props elements =
+      create_element_variadic_internal Imports.react component props elements]
 
 val cloneElement : element -> 'props -> element
   [@@js.custom
@@ -630,7 +630,7 @@ module Context : sig
           Js_of_ocaml.Js.Unsafe.(obj [|("value", inject value)|])
 
         let make context ~value ~children () =
-          createElementVariadic (provider context) (makeProps value) children]
+          create_element_variadic (provider context) (makeProps value) children]
   end
 end
 
@@ -728,7 +728,7 @@ module Fragment : sig
             Js_of_ocaml.Js.Unsafe.(obj [||])
 
       let make ~children ?key () =
-        createElementVariadic
+        create_element_variadic
           (to_component fragment_internal)
           (makeProps ?key ()) children]
 end

--- a/lib/dom.mli
+++ b/lib/dom.mli
@@ -17,7 +17,8 @@ external dom_element_of_js : Ojs.t -> dom_element = "%identity"]
 
 val unmount_component_at_node : dom_element -> bool
   [@@js.custom
-    val unmount_component_at_node_internal : Imports.react_dom -> dom_element -> bool
+    val unmount_component_at_node_internal :
+      Imports.react_dom -> dom_element -> bool
       [@@js.call "unmountComponentAtNode"]
 
     let unmount_component_at_node dom_element =
@@ -25,7 +26,8 @@ val unmount_component_at_node : dom_element -> bool
 
 val render : Core.element -> dom_element -> unit
   [@@js.custom
-    val render_internal : Imports.react_dom -> Core.element -> dom_element -> unit
+    val render_internal :
+      Imports.react_dom -> Core.element -> dom_element -> unit
       [@@js.call "render"]
 
     let render element dom_element =
@@ -1429,7 +1431,8 @@ module Style : sig
 
   let color_interpolation = string_style_prop "colorInterpolation"
 
-  let color_interpolation_filters = string_style_prop "colorInterpolationFilters"
+  let color_interpolation_filters =
+    string_style_prop "colorInterpolationFilters"
 
   let color_profile = string_style_prop "colorProfile"
 

--- a/lib/dom.mli
+++ b/lib/dom.mli
@@ -1,59 +1,59 @@
 [@@@js.stop]
 
-type domElement = Js_of_ocaml.Dom_html.element Js_of_ocaml.Js.t
+type dom_element = Js_of_ocaml.Dom_html.element Js_of_ocaml.Js.t
 
-val domElement_to_js : domElement -> Ojs.t
+val dom_element_to_js : dom_element -> Ojs.t
 
-val domElement_of_js : Ojs.t -> domElement
+val dom_element_of_js : Ojs.t -> dom_element
 
 [@@@js.start]
 
 [@@@js.implem
-type domElement = Js_of_ocaml.Dom_html.element Js_of_ocaml.Js.t
+type dom_element = Js_of_ocaml.Dom_html.element Js_of_ocaml.Js.t
 
-external domElement_to_js : domElement -> Ojs.t = "%identity"
+external dom_element_to_js : dom_element -> Ojs.t = "%identity"
 
-external domElement_of_js : Ojs.t -> domElement = "%identity"]
+external dom_element_of_js : Ojs.t -> dom_element = "%identity"]
 
-val unmountComponentAtNode : domElement -> bool
+val unmount_component_at_node : dom_element -> bool
   [@@js.custom
-    val unmountComponentAtNode_internal : Imports.reactDom -> domElement -> bool
+    val unmount_component_at_node_internal : Imports.reactDom -> dom_element -> bool
       [@@js.call "unmountComponentAtNode"]
 
-    let unmountComponentAtNode domElement =
-      unmountComponentAtNode_internal Imports.reactDom domElement]
+    let unmount_component_at_node dom_element =
+      unmount_component_at_node_internal Imports.reactDom dom_element]
 
-val render : Core.element -> domElement -> unit
+val render : Core.element -> dom_element -> unit
   [@@js.custom
-    val render_internal : Imports.reactDom -> Core.element -> domElement -> unit
+    val render_internal : Imports.reactDom -> Core.element -> dom_element -> unit
       [@@js.call "render"]
 
-    let render element domElement =
-      render_internal Imports.reactDom element domElement]
+    let render element dom_element =
+      render_internal Imports.reactDom element dom_element]
 
-val renderToElementWithId : Core.element -> string -> unit
+val render_to_element_with_id : Core.element -> string -> unit
   [@@js.custom
-    val getElementById : string -> domElement option
+    val get_element_by_id : string -> dom_element option
       [@@js.global "document.getElementById"]
 
-    let renderToElementWithId reactElement id =
-      match getElementById id with
+    let render_to_element_with_id react_element id =
+      match get_element_by_id id with
       | None ->
           raise
             (Invalid_argument
-               ( "ReactDOM.renderToElementWithId : no element of id " ^ id
+               ( "ReactDOM.render_to_element_with_id : no element of id " ^ id
                ^ " found in the HTML." ) )
       | Some element ->
-          render reactElement element]
+          render react_element element]
 
 type dom_ref = private Ojs.t
 
 module Ref : sig
   type t = dom_ref
 
-  type current_dom_ref = domElement Core.js_nullable Core.Ref.t
+  type current_dom_ref = dom_element Core.js_nullable Core.Ref.t
 
-  type callback_dom_ref = domElement Core.js_nullable -> unit
+  type callback_dom_ref = dom_element Core.js_nullable -> unit
 
   [@@@js.stop]
 
@@ -71,7 +71,7 @@ end
 
 type domProps = private Ojs.t
 
-val createDOMElementVariadic :
+val create_dom_element_variadic :
      string
   -> props:
        domProps
@@ -79,7 +79,7 @@ val createDOMElementVariadic :
   -> Core.element list
   -> Core.element
   [@@js.custom
-    val createDOMElementVariadic_internal :
+    val create_dom_element_variadic_internal :
          Imports.react
       -> string
       -> props:domProps
@@ -87,8 +87,8 @@ val createDOMElementVariadic :
       -> Core.element
       [@@js.call "createElement"]
 
-    let createDOMElementVariadic typ ~props elts =
-      createDOMElementVariadic_internal Imports.react typ ~props elts]
+    let create_dom_element_variadic typ ~props elts =
+      create_dom_element_variadic_internal Imports.react typ ~props elts]
 
 val forward_ref : ('props -> dom_ref -> Core.element) -> 'props Core.component
   [@@js.custom

--- a/lib/dom.mli
+++ b/lib/dom.mli
@@ -115,63 +115,63 @@ module Style : sig
 
   val background : string -> decl
 
-  val backgroundAttachment : string -> decl
+  val background_attachment : string -> decl
 
-  val backgroundColor : string -> decl
+  val background_color : string -> decl
 
-  val backgroundImage : string -> decl
+  val background_image : string -> decl
 
-  val backgroundPosition : string -> decl
+  val background_position : string -> decl
 
-  val backgroundRepeat : string -> decl
+  val background_repeat : string -> decl
 
   val border : string -> decl
 
-  val borderCollapse : string -> decl
+  val border_collapse : string -> decl
 
-  val borderColor : string -> decl
+  val border_color : string -> decl
 
-  val borderSpacing : string -> decl
+  val border_spacing : string -> decl
 
-  val borderStyle : string -> decl
+  val border_style : string -> decl
 
-  val borderTop : string -> decl
+  val border_top : string -> decl
 
-  val borderRight : string -> decl
+  val border_right : string -> decl
 
-  val borderBottom : string -> decl
+  val border_bottom : string -> decl
 
-  val borderLeft : string -> decl
+  val border_left : string -> decl
 
-  val borderTopColor : string -> decl
+  val border_top_color : string -> decl
 
-  val borderRightColor : string -> decl
+  val border_right_color : string -> decl
 
-  val borderBottomColor : string -> decl
+  val border_bottom_color : string -> decl
 
-  val borderLeftColor : string -> decl
+  val border_left_color : string -> decl
 
-  val borderTopStyle : string -> decl
+  val border_top_style : string -> decl
 
-  val borderRightStyle : string -> decl
+  val border_right_style : string -> decl
 
-  val borderBottomStyle : string -> decl
+  val border_bottom_style : string -> decl
 
-  val borderLeftStyle : string -> decl
+  val border_left_style : string -> decl
 
-  val borderTopWidth : string -> decl
+  val border_top_width : string -> decl
 
-  val borderRightWidth : string -> decl
+  val border_right_width : string -> decl
 
-  val borderBottomWidth : string -> decl
+  val border_bottom_width : string -> decl
 
-  val borderLeftWidth : string -> decl
+  val border_left_width : string -> decl
 
-  val borderWidth : string -> decl
+  val border_width : string -> decl
 
   val bottom : string -> decl
 
-  val captionSide : string -> decl
+  val caption_side : string -> decl
 
   val clear : string -> decl
 
@@ -179,15 +179,15 @@ module Style : sig
 
   val content : string -> decl
 
-  val counterIncrement : string -> decl
+  val counter_increment : string -> decl
 
-  val counterReset : string -> decl
+  val counter_reset : string -> decl
 
   val cue : string -> decl
 
-  val cueAfter : string -> decl
+  val cue_after : string -> decl
 
-  val cueBefore : string -> decl
+  val cue_before : string -> decl
 
   val direction : string -> decl
 
@@ -195,109 +195,109 @@ module Style : sig
 
   val elevation : string -> decl
 
-  val emptyCells : string -> decl
+  val empty_cells : string -> decl
 
   val float : string -> decl
 
   val font : string -> decl
 
-  val fontFamily : string -> decl
+  val font_family : string -> decl
 
-  val fontSize : string -> decl
+  val font_size : string -> decl
 
-  val fontSizeAdjust : string -> decl
+  val font_size_adjust : string -> decl
 
-  val fontStretch : string -> decl
+  val font_stretch : string -> decl
 
-  val fontStyle : string -> decl
+  val font_style : string -> decl
 
-  val fontVariant : string -> decl
+  val font_variant : string -> decl
 
-  val fontWeight : string -> decl
+  val font_weight : string -> decl
 
   val height : string -> decl
 
   val left : string -> decl
 
-  val letterSpacing : string -> decl
+  val letter_spacing : string -> decl
 
-  val lineHeight : string -> decl
+  val line_height : string -> decl
 
-  val listStyle : string -> decl
+  val list_style : string -> decl
 
-  val listStyleImage : string -> decl
+  val list_style_image : string -> decl
 
-  val listStylePosition : string -> decl
+  val list_style_position : string -> decl
 
-  val listStyleType : string -> decl
+  val list_style_type : string -> decl
 
   val margin : string -> decl
 
-  val marginTop : string -> decl
+  val margin_top : string -> decl
 
-  val marginRight : string -> decl
+  val margin_right : string -> decl
 
-  val marginBottom : string -> decl
+  val margin_bottom : string -> decl
 
-  val marginLeft : string -> decl
+  val margin_left : string -> decl
 
-  val markerOffset : string -> decl
+  val marker_offset : string -> decl
 
   val marks : string -> decl
 
-  val maxHeight : string -> decl
+  val max_height : string -> decl
 
-  val maxWidth : string -> decl
+  val max_width : string -> decl
 
-  val minHeight : string -> decl
+  val min_height : string -> decl
 
-  val minWidth : string -> decl
+  val min_width : string -> decl
 
   val orphans : string -> decl
 
   val outline : string -> decl
 
-  val outlineColor : string -> decl
+  val outline_color : string -> decl
 
-  val outlineStyle : string -> decl
+  val outline_style : string -> decl
 
-  val outlineWidth : string -> decl
+  val outline_width : string -> decl
 
   val overflow : string -> decl
 
-  val overflowX : string -> decl
+  val overflow_x : string -> decl
 
-  val overflowY : string -> decl
+  val overflow_y : string -> decl
 
   val padding : string -> decl
 
-  val paddingTop : string -> decl
+  val padding_top : string -> decl
 
-  val paddingRight : string -> decl
+  val padding_right : string -> decl
 
-  val paddingBottom : string -> decl
+  val padding_bottom : string -> decl
 
-  val paddingLeft : string -> decl
+  val padding_left : string -> decl
 
   val page : string -> decl
 
-  val pageBreakAfter : string -> decl
+  val page_break_after : string -> decl
 
-  val pageBreakBefore : string -> decl
+  val page_break_before : string -> decl
 
-  val pageBreakInside : string -> decl
+  val page_break_inside : string -> decl
 
   val pause : string -> decl
 
-  val pauseAfter : string -> decl
+  val pause_after : string -> decl
 
-  val pauseBefore : string -> decl
+  val pause_before : string -> decl
 
   val pitch : string -> decl
 
-  val pitchRange : string -> decl
+  val pitch_range : string -> decl
 
-  val playDuring : string -> decl
+  val play_during : string -> decl
 
   val position : string -> decl
 
@@ -311,489 +311,489 @@ module Style : sig
 
   val speak : string -> decl
 
-  val speakHeader : string -> decl
+  val speak_header : string -> decl
 
-  val speakNumeral : string -> decl
+  val speak_numeral : string -> decl
 
-  val speakPunctuation : string -> decl
+  val speak_punctuation : string -> decl
 
-  val speechRate : string -> decl
+  val speech_rate : string -> decl
 
   val stress : string -> decl
 
-  val tableLayout : string -> decl
+  val table_layout : string -> decl
 
-  val textAlign : string -> decl
+  val text_align : string -> decl
 
-  val textDecoration : string -> decl
+  val text_decoration : string -> decl
 
-  val textIndent : string -> decl
+  val text_indent : string -> decl
 
-  val textShadow : string -> decl
+  val text_shadow : string -> decl
 
-  val textTransform : string -> decl
+  val text_transform : string -> decl
 
   val top : string -> decl
 
-  val unicodeBidi : string -> decl
+  val unicode_bidi : string -> decl
 
-  val verticalAlign : string -> decl
+  val vertical_align : string -> decl
 
   val visibility : string -> decl
 
-  val voiceFamily : string -> decl
+  val voice_family : string -> decl
 
   val volume : string -> decl
 
-  val whiteSpace : string -> decl
+  val white_space : string -> decl
 
   val widows : string -> decl
 
   val width : string -> decl
 
-  val wordSpacing : string -> decl
+  val word_spacing : string -> decl
 
-  val zIndex : string -> decl
+  val z_index : string -> decl
 
   val opacity : string -> decl
 
-  val backgroundOrigin : string -> decl
+  val background_origin : string -> decl
 
-  val backgroundSize : string -> decl
+  val background_size : string -> decl
 
-  val backgroundClip : string -> decl
+  val background_clip : string -> decl
 
-  val borderRadius : string -> decl
+  val border_radius : string -> decl
 
-  val borderTopLeftRadius : string -> decl
+  val border_top_left_radius : string -> decl
 
-  val borderTopRightRadius : string -> decl
+  val border_top_right_radius : string -> decl
 
-  val borderBottomLeftRadius : string -> decl
+  val border_bottom_left_radius : string -> decl
 
-  val borderBottomRightRadius : string -> decl
+  val border_bottom_right_radius : string -> decl
 
-  val borderImage : string -> decl
+  val border_image : string -> decl
 
-  val borderImageSource : string -> decl
+  val border_image_source : string -> decl
 
-  val borderImageSlice : string -> decl
+  val border_image_slice : string -> decl
 
-  val borderImageWidth : string -> decl
+  val border_image_width : string -> decl
 
-  val borderImageOutset : string -> decl
+  val border_image_outset : string -> decl
 
-  val borderImageRepeat : string -> decl
+  val border_image_repeat : string -> decl
 
-  val boxShadow : string -> decl
+  val box_shadow : string -> decl
 
   val columns : string -> decl
 
-  val columnCount : string -> decl
+  val column_count : string -> decl
 
-  val columnFill : string -> decl
+  val column_fill : string -> decl
 
-  val columnGap : string -> decl
+  val column_gap : string -> decl
 
-  val columnRule : string -> decl
+  val column_rule : string -> decl
 
-  val columnRuleColor : string -> decl
+  val column_rule_color : string -> decl
 
-  val columnRuleStyle : string -> decl
+  val column_rule_style : string -> decl
 
-  val columnRuleWidth : string -> decl
+  val column_rule_width : string -> decl
 
-  val columnSpan : string -> decl
+  val column_span : string -> decl
 
-  val columnWidth : string -> decl
+  val column_width : string -> decl
 
-  val breakAfter : string -> decl
+  val break_after : string -> decl
 
-  val breakBefore : string -> decl
+  val break_before : string -> decl
 
-  val breakInside : string -> decl
+  val break_inside : string -> decl
 
   val rest : string -> decl
 
-  val restAfter : string -> decl
+  val rest_after : string -> decl
 
-  val restBefore : string -> decl
+  val rest_before : string -> decl
 
-  val speakAs : string -> decl
+  val speak_as : string -> decl
 
-  val voiceBalance : string -> decl
+  val voice_balance : string -> decl
 
-  val voiceDuration : string -> decl
+  val voice_duration : string -> decl
 
-  val voicePitch : string -> decl
+  val voice_pitch : string -> decl
 
-  val voiceRange : string -> decl
+  val voice_range : string -> decl
 
-  val voiceRate : string -> decl
+  val voice_rate : string -> decl
 
-  val voiceStress : string -> decl
+  val voice_stress : string -> decl
 
-  val voiceVolume : string -> decl
+  val voice_volume : string -> decl
 
-  val objectFit : string -> decl
+  val object_fit : string -> decl
 
-  val objectPosition : string -> decl
+  val object_position : string -> decl
 
-  val imageResolution : string -> decl
+  val image_resolution : string -> decl
 
-  val imageOrientation : string -> decl
+  val image_orientation : string -> decl
 
-  val alignContent : string -> decl
+  val align_content : string -> decl
 
-  val alignItems : string -> decl
+  val align_items : string -> decl
 
-  val alignSelf : string -> decl
+  val align_self : string -> decl
 
   val flex : string -> decl
 
-  val flexBasis : string -> decl
+  val flex_basis : string -> decl
 
-  val flexDirection : string -> decl
+  val flex_direction : string -> decl
 
-  val flexFlow : string -> decl
+  val flex_flow : string -> decl
 
-  val flexGrow : string -> decl
+  val flex_grow : string -> decl
 
-  val flexShrink : string -> decl
+  val flex_shrink : string -> decl
 
-  val flexWrap : string -> decl
+  val flex_wrap : string -> decl
 
-  val justifyContent : string -> decl
+  val justify_content : string -> decl
 
   val order : string -> decl
 
-  val textDecorationColor : string -> decl
+  val text_decoration_color : string -> decl
 
-  val textDecorationLine : string -> decl
+  val text_decoration_line : string -> decl
 
-  val textDecorationSkip : string -> decl
+  val text_decoration_skip : string -> decl
 
-  val textDecorationStyle : string -> decl
+  val text_decoration_style : string -> decl
 
-  val textEmphasis : string -> decl
+  val text_emphasis : string -> decl
 
-  val textEmphasisColor : string -> decl
+  val text_emphasis_color : string -> decl
 
-  val textEmphasisPosition : string -> decl
+  val text_emphasis_position : string -> decl
 
-  val textEmphasisStyle : string -> decl
+  val text_emphasis_style : string -> decl
 
-  val textUnderlinePosition : string -> decl
+  val text_underline_position : string -> decl
 
-  val fontFeatureSettings : string -> decl
+  val font_feature_settings : string -> decl
 
-  val fontKerning : string -> decl
+  val font_kerning : string -> decl
 
-  val fontLanguageOverride : string -> decl
+  val font_language_override : string -> decl
 
-  val fontSynthesis : string -> decl
+  val font_synthesis : string -> decl
 
-  val forntVariantAlternates : string -> decl
+  val fornt_variant_alternates : string -> decl
 
-  val fontVariantCaps : string -> decl
+  val font_variant_caps : string -> decl
 
-  val fontVariantEastAsian : string -> decl
+  val font_variant_east_asian : string -> decl
 
-  val fontVariantLigatures : string -> decl
+  val font_variant_ligatures : string -> decl
 
-  val fontVariantNumeric : string -> decl
+  val font_variant_numeric : string -> decl
 
-  val fontVariantPosition : string -> decl
+  val font_variant_position : string -> decl
 
   val all : string -> decl
 
-  val textCombineUpright : string -> decl
+  val text_combine_upright : string -> decl
 
-  val textOrientation : string -> decl
+  val text_orientation : string -> decl
 
-  val writingMode : string -> decl
+  val writing_mode : string -> decl
 
-  val shapeImageThreshold : string -> decl
+  val shape_image_threshold : string -> decl
 
-  val shapeMargin : string -> decl
+  val shape_margin : string -> decl
 
-  val shapeOutside : string -> decl
+  val shape_outside : string -> decl
 
   val mask : string -> decl
 
-  val maskBorder : string -> decl
+  val mask_border : string -> decl
 
-  val maskBorderMode : string -> decl
+  val mask_border_mode : string -> decl
 
-  val maskBorderOutset : string -> decl
+  val mask_border_outset : string -> decl
 
-  val maskBorderRepeat : string -> decl
+  val mask_border_repeat : string -> decl
 
-  val maskBorderSlice : string -> decl
+  val mask_border_slice : string -> decl
 
-  val maskBorderSource : string -> decl
+  val mask_border_source : string -> decl
 
-  val maskBorderWidth : string -> decl
+  val mask_border_width : string -> decl
 
-  val maskClip : string -> decl
+  val mask_clip : string -> decl
 
-  val maskComposite : string -> decl
+  val mask_composite : string -> decl
 
-  val maskImage : string -> decl
+  val mask_image : string -> decl
 
-  val maskMode : string -> decl
+  val mask_mode : string -> decl
 
-  val maskOrigin : string -> decl
+  val mask_origin : string -> decl
 
-  val maskPosition : string -> decl
+  val mask_position : string -> decl
 
-  val maskRepeat : string -> decl
+  val mask_repeat : string -> decl
 
-  val maskSize : string -> decl
+  val mask_size : string -> decl
 
-  val maskType : string -> decl
+  val mask_type : string -> decl
 
-  val backgroundBlendMode : string -> decl
+  val background_blend_mode : string -> decl
 
   val isolation : string -> decl
 
-  val mixBlendMode : string -> decl
+  val mix_blend_mode : string -> decl
 
-  val boxDecorationBreak : string -> decl
+  val box_decoration_break : string -> decl
 
-  val boxSizing : string -> decl
+  val box_sizing : string -> decl
 
-  val caretColor : string -> decl
+  val caret_color : string -> decl
 
-  val navDown : string -> decl
+  val nav_down : string -> decl
 
-  val navLeft : string -> decl
+  val nav_left : string -> decl
 
-  val navRight : string -> decl
+  val nav_right : string -> decl
 
-  val navUp : string -> decl
+  val nav_up : string -> decl
 
-  val outlineOffset : string -> decl
+  val outline_offset : string -> decl
 
   val resize : string -> decl
 
-  val textOverflow : string -> decl
+  val text_overflow : string -> decl
 
   val grid : string -> decl
 
-  val gridArea : string -> decl
+  val grid_area : string -> decl
 
-  val gridAutoColumns : string -> decl
+  val grid_auto_columns : string -> decl
 
-  val gridAutoFlow : string -> decl
+  val grid_auto_flow : string -> decl
 
-  val gridAutoRows : string -> decl
+  val grid_auto_rows : string -> decl
 
-  val gridColumn : string -> decl
+  val grid_column : string -> decl
 
-  val gridColumnEnd : string -> decl
+  val grid_column_end : string -> decl
 
-  val gridColumnGap : string -> decl
+  val grid_column_gap : string -> decl
 
-  val gridColumnStart : string -> decl
+  val grid_column_start : string -> decl
 
-  val gridGap : string -> decl
+  val grid_gap : string -> decl
 
-  val gridRow : string -> decl
+  val grid_row : string -> decl
 
-  val gridRowEnd : string -> decl
+  val grid_row_end : string -> decl
 
-  val gridRowGap : string -> decl
+  val grid_row_gap : string -> decl
 
-  val gridRowStart : string -> decl
+  val grid_row_start : string -> decl
 
-  val gridTemplate : string -> decl
+  val grid_template : string -> decl
 
-  val gridTemplateAreas : string -> decl
+  val grid_template_areas : string -> decl
 
-  val gridTemplateColumns : string -> decl
+  val grid_template_columns : string -> decl
 
-  val gridTemplateRows : string -> decl
+  val grid_template_rows : string -> decl
 
-  val willChange : string -> decl
+  val will_change : string -> decl
 
-  val hangingPunctuation : string -> decl
+  val hanging_punctuation : string -> decl
 
   val hyphens : string -> decl
 
-  val lineBreak : string -> decl
+  val line_break : string -> decl
 
-  val overflowWrap : string -> decl
+  val overflow_wrap : string -> decl
 
-  val tabSize : string -> decl
+  val tab_size : string -> decl
 
-  val textAlignLast : string -> decl
+  val text_align_last : string -> decl
 
-  val textJustify : string -> decl
+  val text_justify : string -> decl
 
-  val wordBreak : string -> decl
+  val word_break : string -> decl
 
-  val wordWrap : string -> decl
+  val word_wrap : string -> decl
 
   val animation : string -> decl
 
-  val animationDelay : string -> decl
+  val animation_delay : string -> decl
 
-  val animationDirection : string -> decl
+  val animation_direction : string -> decl
 
-  val animationDuration : string -> decl
+  val animation_duration : string -> decl
 
-  val animationFillMode : string -> decl
+  val animation_fill_mode : string -> decl
 
-  val animationIterationCount : string -> decl
+  val animation_iteration_count : string -> decl
 
-  val animationName : string -> decl
+  val animation_name : string -> decl
 
-  val animationPlayState : string -> decl
+  val animation_play_state : string -> decl
 
-  val animationTimingFunction : string -> decl
+  val animation_timing_function : string -> decl
 
   val transition : string -> decl
 
-  val transitionDelay : string -> decl
+  val transition_delay : string -> decl
 
-  val transitionDuration : string -> decl
+  val transition_duration : string -> decl
 
-  val transitionProperty : string -> decl
+  val transition_property : string -> decl
 
-  val transitionTimingFunction : string -> decl
+  val transition_timing_function : string -> decl
 
-  val backfaceVisibility : string -> decl
+  val backface_visibility : string -> decl
 
   val perspective : string -> decl
 
-  val perspectiveOrigin : string -> decl
+  val perspective_origin : string -> decl
 
   val transform : string -> decl
 
-  val transformOrigin : string -> decl
+  val transform_origin : string -> decl
 
-  val transformStyle : string -> decl
+  val transform_style : string -> decl
 
-  val justifyItems : string -> decl
+  val justify_items : string -> decl
 
-  val justifySelf : string -> decl
+  val justify_self : string -> decl
 
-  val placeContent : string -> decl
+  val place_content : string -> decl
 
-  val placeItems : string -> decl
+  val place_items : string -> decl
 
-  val placeSelf : string -> decl
+  val place_self : string -> decl
 
   val appearance : string -> decl
 
   val caret : string -> decl
 
-  val caretAnimation : string -> decl
+  val caret_animation : string -> decl
 
-  val caretShape : string -> decl
+  val caret_shape : string -> decl
 
-  val userSelect : string -> decl
+  val user_select : string -> decl
 
-  val maxLines : string -> decl
+  val max_lines : string -> decl
 
-  val marqueeDirection : string -> decl
+  val marquee_direction : string -> decl
 
-  val marqueeLoop : string -> decl
+  val marquee_loop : string -> decl
 
-  val marqueeSpeed : string -> decl
+  val marquee_speed : string -> decl
 
-  val marqueeStyle : string -> decl
+  val marquee_style : string -> decl
 
-  val overflowStyle : string -> decl
+  val overflow_style : string -> decl
 
   val rotation : string -> decl
 
-  val rotationPoint : string -> decl
+  val rotation_point : string -> decl
 
-  val alignmentBaseline : string -> decl
+  val alignment_baseline : string -> decl
 
-  val baselineShift : string -> decl
+  val baseline_shift : string -> decl
 
   val clip : string -> decl
 
-  val clipPath : string -> decl
+  val clip_path : string -> decl
 
-  val clipRule : string -> decl
+  val clip_rule : string -> decl
 
-  val colorInterpolation : string -> decl
+  val color_interpolation : string -> decl
 
-  val colorInterpolationFilters : string -> decl
+  val color_interpolation_filters : string -> decl
 
-  val colorProfile : string -> decl
+  val color_profile : string -> decl
 
-  val colorRendering : string -> decl
+  val color_rendering : string -> decl
 
   val cursor : string -> decl
 
-  val dominantBaseline : string -> decl
+  val dominant_baseline : string -> decl
 
   val fill : string -> decl
 
-  val fillOpacity : string -> decl
+  val fill_opacity : string -> decl
 
-  val fillRule : string -> decl
+  val fill_rule : string -> decl
 
   val filter : string -> decl
 
-  val floodColor : string -> decl
+  val flood_color : string -> decl
 
-  val floodOpacity : string -> decl
+  val flood_opacity : string -> decl
 
-  val glyphOrientationHorizontal : string -> decl
+  val glyph_orientation_horizontal : string -> decl
 
-  val glyphOrientationVertical : string -> decl
+  val glyph_orientation_vertical : string -> decl
 
-  val imageRendering : string -> decl
+  val image_rendering : string -> decl
 
   val kerning : string -> decl
 
-  val lightingColor : string -> decl
+  val lighting_color : string -> decl
 
-  val markerEnd : string -> decl
+  val marker_end : string -> decl
 
-  val markerMid : string -> decl
+  val marker_mid : string -> decl
 
-  val markerStart : string -> decl
+  val marker_start : string -> decl
 
-  val pointerEvents : string -> decl
+  val pointer_events : string -> decl
 
-  val shapeRendering : string -> decl
+  val shape_rendering : string -> decl
 
-  val stopColor : string -> decl
+  val stop_color : string -> decl
 
-  val stopOpacity : string -> decl
+  val stop_opacity : string -> decl
 
   val stroke : string -> decl
 
-  val strokeDasharray : string -> decl
+  val stroke_dasharray : string -> decl
 
-  val strokeDashoffset : string -> decl
+  val stroke_dashoffset : string -> decl
 
-  val strokeLinecap : string -> decl
+  val stroke_linecap : string -> decl
 
-  val strokeLinejoin : string -> decl
+  val stroke_linejoin : string -> decl
 
-  val strokeMiterlimit : string -> decl
+  val stroke_miterlimit : string -> decl
 
-  val strokeOpacity : string -> decl
+  val stroke_opacity : string -> decl
 
-  val strokeWidth : string -> decl
+  val stroke_width : string -> decl
 
-  val textAnchor : string -> decl
+  val text_anchor : string -> decl
 
-  val textRendering : string -> decl
+  val text_rendering : string -> decl
 
-  val rubyAlign : string -> decl
+  val ruby_align : string -> decl
 
-  val rubyMerge : string -> decl
+  val ruby_merge : string -> decl
 
-  val rubyPosition : string -> decl
+  val ruby_position : string -> decl
 
   [@@@js.start]
 
@@ -811,63 +811,63 @@ module Style : sig
 
   let background = string_style_prop "background"
 
-  let backgroundAttachment = string_style_prop "backgroundAttachment"
+  let background_attachment = string_style_prop "backgroundAttachment"
 
-  let backgroundColor = string_style_prop "backgroundColor"
+  let background_color = string_style_prop "backgroundColor"
 
-  let backgroundImage = string_style_prop "backgroundImage"
+  let background_image = string_style_prop "backgroundImage"
 
-  let backgroundPosition = string_style_prop "backgroundPosition"
+  let background_position = string_style_prop "backgroundPosition"
 
-  let backgroundRepeat = string_style_prop "backgroundRepeat"
+  let background_repeat = string_style_prop "backgroundRepeat"
 
   let border = string_style_prop "border"
 
-  let borderCollapse = string_style_prop "borderCollapse"
+  let border_collapse = string_style_prop "borderCollapse"
 
-  let borderColor = string_style_prop "borderColor"
+  let border_color = string_style_prop "borderColor"
 
-  let borderSpacing = string_style_prop "borderSpacing"
+  let border_spacing = string_style_prop "borderSpacing"
 
-  let borderStyle = string_style_prop "borderStyle"
+  let border_style = string_style_prop "borderStyle"
 
-  let borderTop = string_style_prop "borderTop"
+  let border_top = string_style_prop "borderTop"
 
-  let borderRight = string_style_prop "borderRight"
+  let border_right = string_style_prop "borderRight"
 
-  let borderBottom = string_style_prop "borderBottom"
+  let border_bottom = string_style_prop "borderBottom"
 
-  let borderLeft = string_style_prop "borderLeft"
+  let border_left = string_style_prop "borderLeft"
 
-  let borderTopColor = string_style_prop "borderTopColor"
+  let border_top_color = string_style_prop "borderTopColor"
 
-  let borderRightColor = string_style_prop "borderRightColor"
+  let border_right_color = string_style_prop "borderRightColor"
 
-  let borderBottomColor = string_style_prop "borderBottomColor"
+  let border_bottom_color = string_style_prop "borderBottomColor"
 
-  let borderLeftColor = string_style_prop "borderLeftColor"
+  let border_left_color = string_style_prop "borderLeftColor"
 
-  let borderTopStyle = string_style_prop "borderTopStyle"
+  let border_top_style = string_style_prop "borderTopStyle"
 
-  let borderRightStyle = string_style_prop "borderRightStyle"
+  let border_right_style = string_style_prop "borderRightStyle"
 
-  let borderBottomStyle = string_style_prop "borderBottomStyle"
+  let border_bottom_style = string_style_prop "borderBottomStyle"
 
-  let borderLeftStyle = string_style_prop "borderLeftStyle"
+  let border_left_style = string_style_prop "borderLeftStyle"
 
-  let borderTopWidth = string_style_prop "borderTopWidth"
+  let border_top_width = string_style_prop "borderTopWidth"
 
-  let borderRightWidth = string_style_prop "borderRightWidth"
+  let border_right_width = string_style_prop "borderRightWidth"
 
-  let borderBottomWidth = string_style_prop "borderBottomWidth"
+  let border_bottom_width = string_style_prop "borderBottomWidth"
 
-  let borderLeftWidth = string_style_prop "borderLeftWidth"
+  let border_left_width = string_style_prop "borderLeftWidth"
 
-  let borderWidth = string_style_prop "borderWidth"
+  let border_width = string_style_prop "borderWidth"
 
   let bottom = string_style_prop "bottom"
 
-  let captionSide = string_style_prop "captionSide"
+  let caption_side = string_style_prop "captionSide"
 
   let clear = string_style_prop "clear"
 
@@ -877,15 +877,15 @@ module Style : sig
 
   let content = string_style_prop "content"
 
-  let counterIncrement = string_style_prop "counterIncrement"
+  let counter_increment = string_style_prop "counterIncrement"
 
-  let counterReset = string_style_prop "counterReset"
+  let counter_reset = string_style_prop "counterReset"
 
   let cue = string_style_prop "cue"
 
-  let cueAfter = string_style_prop "cueAfter"
+  let cue_after = string_style_prop "cueAfter"
 
-  let cueBefore = string_style_prop "cueBefore"
+  let cue_before = string_style_prop "cueBefore"
 
   let cursor = string_style_prop "cursor"
 
@@ -895,109 +895,109 @@ module Style : sig
 
   let elevation = string_style_prop "elevation"
 
-  let emptyCells = string_style_prop "emptyCells"
+  let empty_cells = string_style_prop "emptyCells"
 
   let float = string_style_prop "float"
 
   let font = string_style_prop "font"
 
-  let fontFamily = string_style_prop "fontFamily"
+  let font_family = string_style_prop "fontFamily"
 
-  let fontSize = string_style_prop "fontSize"
+  let font_size = string_style_prop "fontSize"
 
-  let fontSizeAdjust = string_style_prop "fontSizeAdjust"
+  let font_size_adjust = string_style_prop "fontSizeAdjust"
 
-  let fontStretch = string_style_prop "fontStretch"
+  let font_stretch = string_style_prop "fontStretch"
 
-  let fontStyle = string_style_prop "fontStyle"
+  let font_style = string_style_prop "fontStyle"
 
-  let fontVariant = string_style_prop "fontVariant"
+  let font_variant = string_style_prop "fontVariant"
 
-  let fontWeight = string_style_prop "fontWeight"
+  let font_weight = string_style_prop "fontWeight"
 
   let height = string_style_prop "height"
 
   let left = string_style_prop "left"
 
-  let letterSpacing = string_style_prop "letterSpacing"
+  let letter_spacing = string_style_prop "letterSpacing"
 
-  let lineHeight = string_style_prop "lineHeight"
+  let line_height = string_style_prop "lineHeight"
 
-  let listStyle = string_style_prop "listStyle"
+  let list_style = string_style_prop "listStyle"
 
-  let listStyleImage = string_style_prop "listStyleImage"
+  let list_style_image = string_style_prop "listStyleImage"
 
-  let listStylePosition = string_style_prop "listStylePosition"
+  let list_style_position = string_style_prop "listStylePosition"
 
-  let listStyleType = string_style_prop "listStyleType"
+  let list_style_type = string_style_prop "listStyleType"
 
   let margin = string_style_prop "margin"
 
-  let marginTop = string_style_prop "marginTop"
+  let margin_top = string_style_prop "marginTop"
 
-  let marginRight = string_style_prop "marginRight"
+  let margin_right = string_style_prop "marginRight"
 
-  let marginBottom = string_style_prop "marginBottom"
+  let margin_bottom = string_style_prop "marginBottom"
 
-  let marginLeft = string_style_prop "marginLeft"
+  let margin_left = string_style_prop "marginLeft"
 
-  let markerOffset = string_style_prop "markerOffset"
+  let marker_offset = string_style_prop "markerOffset"
 
   let marks = string_style_prop "marks"
 
-  let maxHeight = string_style_prop "maxHeight"
+  let max_height = string_style_prop "maxHeight"
 
-  let maxWidth = string_style_prop "maxWidth"
+  let max_width = string_style_prop "maxWidth"
 
-  let minHeight = string_style_prop "minHeight"
+  let min_height = string_style_prop "minHeight"
 
-  let minWidth = string_style_prop "minWidth"
+  let min_width = string_style_prop "minWidth"
 
   let orphans = string_style_prop "orphans"
 
   let outline = string_style_prop "outline"
 
-  let outlineColor = string_style_prop "outlineColor"
+  let outline_color = string_style_prop "outlineColor"
 
-  let outlineStyle = string_style_prop "outlineStyle"
+  let outline_style = string_style_prop "outlineStyle"
 
-  let outlineWidth = string_style_prop "outlineWidth"
+  let outline_width = string_style_prop "outlineWidth"
 
   let overflow = string_style_prop "overflow"
 
-  let overflowX = string_style_prop "overflowX"
+  let overflow_x = string_style_prop "overflowX"
 
-  let overflowY = string_style_prop "overflowY"
+  let overflow_y = string_style_prop "overflowY"
 
   let padding = string_style_prop "padding"
 
-  let paddingTop = string_style_prop "paddingTop"
+  let padding_top = string_style_prop "paddingTop"
 
-  let paddingRight = string_style_prop "paddingRight"
+  let padding_right = string_style_prop "paddingRight"
 
-  let paddingBottom = string_style_prop "paddingBottom"
+  let padding_bottom = string_style_prop "paddingBottom"
 
-  let paddingLeft = string_style_prop "paddingLeft"
+  let padding_left = string_style_prop "paddingLeft"
 
   let page = string_style_prop "page"
 
-  let pageBreakAfter = string_style_prop "pageBreakAfter"
+  let page_break_after = string_style_prop "pageBreakAfter"
 
-  let pageBreakBefore = string_style_prop "pageBreakBefore"
+  let page_break_before = string_style_prop "pageBreakBefore"
 
-  let pageBreakInside = string_style_prop "pageBreakInside"
+  let page_break_inside = string_style_prop "pageBreakInside"
 
   let pause = string_style_prop "pause"
 
-  let pauseAfter = string_style_prop "pauseAfter"
+  let pause_after = string_style_prop "pauseAfter"
 
-  let pauseBefore = string_style_prop "pauseBefore"
+  let pause_before = string_style_prop "pauseBefore"
 
   let pitch = string_style_prop "pitch"
 
-  let pitchRange = string_style_prop "pitchRange"
+  let pitch_range = string_style_prop "pitchRange"
 
-  let playDuring = string_style_prop "playDuring"
+  let play_during = string_style_prop "playDuring"
 
   let position = string_style_prop "position"
 
@@ -1011,496 +1011,496 @@ module Style : sig
 
   let speak = string_style_prop "speak"
 
-  let speakHeader = string_style_prop "speakHeader"
+  let speak_header = string_style_prop "speakHeader"
 
-  let speakNumeral = string_style_prop "speakNumeral"
+  let speak_numeral = string_style_prop "speakNumeral"
 
-  let speakPunctuation = string_style_prop "speakPunctuation"
+  let speak_punctuation = string_style_prop "speakPunctuation"
 
-  let speechRate = string_style_prop "speechRate"
+  let speech_rate = string_style_prop "speechRate"
 
   let stress = string_style_prop "stress"
 
-  let tableLayout = string_style_prop "tableLayout"
+  let table_layout = string_style_prop "tableLayout"
 
-  let textAlign = string_style_prop "textAlign"
+  let text_align = string_style_prop "textAlign"
 
-  let textDecoration = string_style_prop "textDecoration"
+  let text_decoration = string_style_prop "textDecoration"
 
-  let textIndent = string_style_prop "textIndent"
+  let text_indent = string_style_prop "textIndent"
 
-  let textShadow = string_style_prop "textShadow"
+  let text_shadow = string_style_prop "textShadow"
 
-  let textTransform = string_style_prop "textTransform"
+  let text_transform = string_style_prop "textTransform"
 
   let top = string_style_prop "top"
 
-  let unicodeBidi = string_style_prop "unicodeBidi"
+  let unicode_bidi = string_style_prop "unicodeBidi"
 
-  let verticalAlign = string_style_prop "verticalAlign"
+  let vertical_align = string_style_prop "verticalAlign"
 
   let visibility = string_style_prop "visibility"
 
-  let voiceFamily = string_style_prop "voiceFamily"
+  let voice_family = string_style_prop "voiceFamily"
 
   let volume = string_style_prop "volume"
 
-  let whiteSpace = string_style_prop "whiteSpace"
+  let white_space = string_style_prop "whiteSpace"
 
   let widows = string_style_prop "widows"
 
   let width = string_style_prop "width"
 
-  let wordSpacing = string_style_prop "wordSpacing"
+  let word_spacing = string_style_prop "wordSpacing"
 
-  let zIndex = string_style_prop "zIndex"
+  let z_index = string_style_prop "zIndex"
 
   let opacity = string_style_prop "opacity"
 
-  let backgroundOrigin = string_style_prop "backgroundOrigin"
+  let background_origin = string_style_prop "backgroundOrigin"
 
-  let backgroundSize = string_style_prop "backgroundSize"
+  let background_size = string_style_prop "backgroundSize"
 
-  let backgroundClip = string_style_prop "backgroundClip"
+  let background_clip = string_style_prop "backgroundClip"
 
-  let borderRadius = string_style_prop "borderRadius"
+  let border_radius = string_style_prop "borderRadius"
 
-  let borderTopLeftRadius = string_style_prop "borderTopLeftRadius"
+  let border_top_left_radius = string_style_prop "borderTopLeftRadius"
 
-  let borderTopRightRadius = string_style_prop "borderTopRightRadius"
+  let border_top_right_radius = string_style_prop "borderTopRightRadius"
 
-  let borderBottomLeftRadius = string_style_prop "borderBottomLeftRadius"
+  let border_bottom_left_radius = string_style_prop "borderBottomLeftRadius"
 
-  let borderBottomRightRadius = string_style_prop "borderBottomRightRadius"
+  let border_bottom_right_radius = string_style_prop "borderBottomRightRadius"
 
-  let borderImage = string_style_prop "borderImage"
+  let border_image = string_style_prop "borderImage"
 
-  let borderImageSource = string_style_prop "borderImageSource"
+  let border_image_source = string_style_prop "borderImageSource"
 
-  let borderImageSlice = string_style_prop "borderImageSlice"
+  let border_image_slice = string_style_prop "borderImageSlice"
 
-  let borderImageWidth = string_style_prop "borderImageWidth"
+  let border_image_width = string_style_prop "borderImageWidth"
 
-  let borderImageOutset = string_style_prop "borderImageOutset"
+  let border_image_outset = string_style_prop "borderImageOutset"
 
-  let borderImageRepeat = string_style_prop "borderImageRepeat"
+  let border_image_repeat = string_style_prop "borderImageRepeat"
 
-  let boxShadow = string_style_prop "boxShadow"
+  let box_shadow = string_style_prop "boxShadow"
 
   let columns = string_style_prop "columns"
 
-  let columnCount = string_style_prop "columnCount"
+  let column_count = string_style_prop "columnCount"
 
-  let columnFill = string_style_prop "columnFill"
+  let column_fill = string_style_prop "columnFill"
 
-  let columnGap = string_style_prop "columnGap"
+  let column_gap = string_style_prop "columnGap"
 
-  let columnRule = string_style_prop "columnRule"
+  let column_rule = string_style_prop "columnRule"
 
-  let columnRuleColor = string_style_prop "columnRuleColor"
+  let column_rule_color = string_style_prop "columnRuleColor"
 
-  let columnRuleStyle = string_style_prop "columnRuleStyle"
+  let column_rule_style = string_style_prop "columnRuleStyle"
 
-  let columnRuleWidth = string_style_prop "columnRuleWidth"
+  let column_rule_width = string_style_prop "columnRuleWidth"
 
-  let columnSpan = string_style_prop "columnSpan"
+  let column_span = string_style_prop "columnSpan"
 
-  let columnWidth = string_style_prop "columnWidth"
+  let column_width = string_style_prop "columnWidth"
 
-  let breakAfter = string_style_prop "breakAfter"
+  let break_after = string_style_prop "breakAfter"
 
-  let breakBefore = string_style_prop "breakBefore"
+  let break_before = string_style_prop "breakBefore"
 
-  let breakInside = string_style_prop "breakInside"
+  let break_inside = string_style_prop "breakInside"
 
   let rest = string_style_prop "rest"
 
-  let restAfter = string_style_prop "restAfter"
+  let rest_after = string_style_prop "restAfter"
 
-  let restBefore = string_style_prop "restBefore"
+  let rest_before = string_style_prop "restBefore"
 
-  let speakAs = string_style_prop "speakAs"
+  let speak_as = string_style_prop "speakAs"
 
-  let voiceBalance = string_style_prop "voiceBalance"
+  let voice_balance = string_style_prop "voiceBalance"
 
-  let voiceDuration = string_style_prop "voiceDuration"
+  let voice_duration = string_style_prop "voiceDuration"
 
-  let voicePitch = string_style_prop "voicePitch"
+  let voice_pitch = string_style_prop "voicePitch"
 
-  let voiceRange = string_style_prop "voiceRange"
+  let voice_range = string_style_prop "voiceRange"
 
-  let voiceRate = string_style_prop "voiceRate"
+  let voice_rate = string_style_prop "voiceRate"
 
-  let voiceStress = string_style_prop "voiceStress"
+  let voice_stress = string_style_prop "voiceStress"
 
-  let voiceVolume = string_style_prop "voiceVolume"
+  let voice_volume = string_style_prop "voiceVolume"
 
-  let objectFit = string_style_prop "objectFit"
+  let object_fit = string_style_prop "objectFit"
 
-  let objectPosition = string_style_prop "objectPosition"
+  let object_position = string_style_prop "objectPosition"
 
-  let imageResolution = string_style_prop "imageResolution"
+  let image_resolution = string_style_prop "imageResolution"
 
-  let imageOrientation = string_style_prop "imageOrientation"
+  let image_orientation = string_style_prop "imageOrientation"
 
-  let alignContent = string_style_prop "alignContent"
+  let align_content = string_style_prop "alignContent"
 
-  let alignItems = string_style_prop "alignItems"
+  let align_items = string_style_prop "alignItems"
 
-  let alignSelf = string_style_prop "alignSelf"
+  let align_self = string_style_prop "alignSelf"
 
   let flex = string_style_prop "flex"
 
-  let flexBasis = string_style_prop "flexBasis"
+  let flex_basis = string_style_prop "flexBasis"
 
-  let flexDirection = string_style_prop "flexDirection"
+  let flex_direction = string_style_prop "flexDirection"
 
-  let flexFlow = string_style_prop "flexFlow"
+  let flex_flow = string_style_prop "flexFlow"
 
-  let flexGrow = string_style_prop "flexGrow"
+  let flex_grow = string_style_prop "flexGrow"
 
-  let flexShrink = string_style_prop "flexShrink"
+  let flex_shrink = string_style_prop "flexShrink"
 
-  let flexWrap = string_style_prop "flexWrap"
+  let flex_wrap = string_style_prop "flexWrap"
 
-  let justifyContent = string_style_prop "justifyContent"
+  let justify_content = string_style_prop "justifyContent"
 
   let order = string_style_prop "order"
 
-  let textDecorationColor = string_style_prop "textDecorationColor"
+  let text_decoration_color = string_style_prop "textDecorationColor"
 
-  let textDecorationLine = string_style_prop "textDecorationLine"
+  let text_decoration_line = string_style_prop "textDecorationLine"
 
-  let textDecorationSkip = string_style_prop "textDecorationSkip"
+  let text_decoration_skip = string_style_prop "textDecorationSkip"
 
-  let textDecorationStyle = string_style_prop "textDecorationStyle"
+  let text_decoration_style = string_style_prop "textDecorationStyle"
 
-  let textEmphasis = string_style_prop "textEmphasis"
+  let text_emphasis = string_style_prop "textEmphasis"
 
-  let textEmphasisColor = string_style_prop "textEmphasisColor"
+  let text_emphasis_color = string_style_prop "textEmphasisColor"
 
-  let textEmphasisPosition = string_style_prop "textEmphasisPosition"
+  let text_emphasis_position = string_style_prop "textEmphasisPosition"
 
-  let textEmphasisStyle = string_style_prop "textEmphasisStyle"
+  let text_emphasis_style = string_style_prop "textEmphasisStyle"
 
-  let textUnderlinePosition = string_style_prop "textUnderlinePosition"
+  let text_underline_position = string_style_prop "textUnderlinePosition"
 
-  let fontFeatureSettings = string_style_prop "fontFeatureSettings"
+  let font_feature_settings = string_style_prop "fontFeatureSettings"
 
-  let fontKerning = string_style_prop "fontKerning"
+  let font_kerning = string_style_prop "fontKerning"
 
-  let fontLanguageOverride = string_style_prop "fontLanguageOverride"
+  let font_language_override = string_style_prop "fontLanguageOverride"
 
-  let fontSynthesis = string_style_prop "fontSynthesis"
+  let font_synthesis = string_style_prop "fontSynthesis"
 
-  let forntVariantAlternates = string_style_prop "forntVariantAlternates"
+  let fornt_variant_alternates = string_style_prop "forntVariantAlternates"
 
-  let fontVariantCaps = string_style_prop "fontVariantCaps"
+  let font_variant_caps = string_style_prop "fontVariantCaps"
 
-  let fontVariantEastAsian = string_style_prop "fontVariantEastAsian"
+  let font_variant_east_asian = string_style_prop "fontVariantEastAsian"
 
-  let fontVariantLigatures = string_style_prop "fontVariantLigatures"
+  let font_variant_ligatures = string_style_prop "fontVariantLigatures"
 
-  let fontVariantNumeric = string_style_prop "fontVariantNumeric"
+  let font_variant_numeric = string_style_prop "fontVariantNumeric"
 
-  let fontVariantPosition = string_style_prop "fontVariantPosition"
+  let font_variant_position = string_style_prop "fontVariantPosition"
 
   let all = string_style_prop "all"
 
-  let glyphOrientationVertical = string_style_prop "glyphOrientationVertical"
+  let glyph_orientation_vertical = string_style_prop "glyphOrientationVertical"
 
-  let textCombineUpright = string_style_prop "textCombineUpright"
+  let text_combine_upright = string_style_prop "textCombineUpright"
 
-  let textOrientation = string_style_prop "textOrientation"
+  let text_orientation = string_style_prop "textOrientation"
 
-  let writingMode = string_style_prop "writingMode"
+  let writing_mode = string_style_prop "writingMode"
 
-  let shapeImageThreshold = string_style_prop "shapeImageThreshold"
+  let shape_image_threshold = string_style_prop "shapeImageThreshold"
 
-  let shapeMargin = string_style_prop "shapeMargin"
+  let shape_margin = string_style_prop "shapeMargin"
 
-  let shapeOutside = string_style_prop "shapeOutside"
+  let shape_outside = string_style_prop "shapeOutside"
 
-  let clipPath = string_style_prop "clipPath"
+  let clip_path = string_style_prop "clipPath"
 
-  let clipRule = string_style_prop "clipRule"
+  let clip_rule = string_style_prop "clipRule"
 
   let mask = string_style_prop "mask"
 
-  let maskBorder = string_style_prop "maskBorder"
+  let mask_border = string_style_prop "maskBorder"
 
-  let maskBorderMode = string_style_prop "maskBorderMode"
+  let mask_border_mode = string_style_prop "maskBorderMode"
 
-  let maskBorderOutset = string_style_prop "maskBorderOutset"
+  let mask_border_outset = string_style_prop "maskBorderOutset"
 
-  let maskBorderRepeat = string_style_prop "maskBorderRepeat"
+  let mask_border_repeat = string_style_prop "maskBorderRepeat"
 
-  let maskBorderSlice = string_style_prop "maskBorderSlice"
+  let mask_border_slice = string_style_prop "maskBorderSlice"
 
-  let maskBorderSource = string_style_prop "maskBorderSource"
+  let mask_border_source = string_style_prop "maskBorderSource"
 
-  let maskBorderWidth = string_style_prop "maskBorderWidth"
+  let mask_border_width = string_style_prop "maskBorderWidth"
 
-  let maskClip = string_style_prop "maskClip"
+  let mask_clip = string_style_prop "maskClip"
 
-  let maskComposite = string_style_prop "maskComposite"
+  let mask_composite = string_style_prop "maskComposite"
 
-  let maskImage = string_style_prop "maskImage"
+  let mask_image = string_style_prop "maskImage"
 
-  let maskMode = string_style_prop "maskMode"
+  let mask_mode = string_style_prop "maskMode"
 
-  let maskOrigin = string_style_prop "maskOrigin"
+  let mask_origin = string_style_prop "maskOrigin"
 
-  let maskPosition = string_style_prop "maskPosition"
+  let mask_position = string_style_prop "maskPosition"
 
-  let maskRepeat = string_style_prop "maskRepeat"
+  let mask_repeat = string_style_prop "maskRepeat"
 
-  let maskSize = string_style_prop "maskSize"
+  let mask_size = string_style_prop "maskSize"
 
-  let maskType = string_style_prop "maskType"
+  let mask_type = string_style_prop "maskType"
 
-  let backgroundBlendMode = string_style_prop "backgroundBlendMode"
+  let background_blend_mode = string_style_prop "backgroundBlendMode"
 
   let isolation = string_style_prop "isolation"
 
-  let mixBlendMode = string_style_prop "mixBlendMode"
+  let mix_blend_mode = string_style_prop "mixBlendMode"
 
-  let boxDecorationBreak = string_style_prop "boxDecorationBreak"
+  let box_decoration_break = string_style_prop "boxDecorationBreak"
 
-  let boxSizing = string_style_prop "boxSizing"
+  let box_sizing = string_style_prop "boxSizing"
 
-  let caretColor = string_style_prop "caretColor"
+  let caret_color = string_style_prop "caretColor"
 
-  let navDown = string_style_prop "navDown"
+  let nav_down = string_style_prop "navDown"
 
-  let navLeft = string_style_prop "navLeft"
+  let nav_left = string_style_prop "navLeft"
 
-  let navRight = string_style_prop "navRight"
+  let nav_right = string_style_prop "navRight"
 
-  let navUp = string_style_prop "navUp"
+  let nav_up = string_style_prop "navUp"
 
-  let outlineOffset = string_style_prop "outlineOffset"
+  let outline_offset = string_style_prop "outlineOffset"
 
   let resize = string_style_prop "resize"
 
-  let textOverflow = string_style_prop "textOverflow"
+  let text_overflow = string_style_prop "textOverflow"
 
   let grid = string_style_prop "grid"
 
-  let gridArea = string_style_prop "gridArea"
+  let grid_area = string_style_prop "gridArea"
 
-  let gridAutoColumns = string_style_prop "gridAutoColumns"
+  let grid_auto_columns = string_style_prop "gridAutoColumns"
 
-  let gridAutoFlow = string_style_prop "gridAutoFlow"
+  let grid_auto_flow = string_style_prop "gridAutoFlow"
 
-  let gridAutoRows = string_style_prop "gridAutoRows"
+  let grid_auto_rows = string_style_prop "gridAutoRows"
 
-  let gridColumn = string_style_prop "gridColumn"
+  let grid_column = string_style_prop "gridColumn"
 
-  let gridColumnEnd = string_style_prop "gridColumnEnd"
+  let grid_column_end = string_style_prop "gridColumnEnd"
 
-  let gridColumnGap = string_style_prop "gridColumnGap"
+  let grid_column_gap = string_style_prop "gridColumnGap"
 
-  let gridColumnStart = string_style_prop "gridColumnStart"
+  let grid_column_start = string_style_prop "gridColumnStart"
 
-  let gridGap = string_style_prop "gridGap"
+  let grid_gap = string_style_prop "gridGap"
 
-  let gridRow = string_style_prop "gridRow"
+  let grid_row = string_style_prop "gridRow"
 
-  let gridRowEnd = string_style_prop "gridRowEnd"
+  let grid_row_end = string_style_prop "gridRowEnd"
 
-  let gridRowGap = string_style_prop "gridRowGap"
+  let grid_row_gap = string_style_prop "gridRowGap"
 
-  let gridRowStart = string_style_prop "gridRowStart"
+  let grid_row_start = string_style_prop "gridRowStart"
 
-  let gridTemplate = string_style_prop "gridTemplate"
+  let grid_template = string_style_prop "gridTemplate"
 
-  let gridTemplateAreas = string_style_prop "gridTemplateAreas"
+  let grid_template_areas = string_style_prop "gridTemplateAreas"
 
-  let gridTemplateColumns = string_style_prop "gridTemplateColumns"
+  let grid_template_columns = string_style_prop "gridTemplateColumns"
 
-  let gridTemplateRows = string_style_prop "gridTemplateRows"
+  let grid_template_rows = string_style_prop "gridTemplateRows"
 
-  let willChange = string_style_prop "willChange"
+  let will_change = string_style_prop "willChange"
 
-  let hangingPunctuation = string_style_prop "hangingPunctuation"
+  let hanging_punctuation = string_style_prop "hangingPunctuation"
 
   let hyphens = string_style_prop "hyphens"
 
-  let lineBreak = string_style_prop "lineBreak"
+  let line_break = string_style_prop "lineBreak"
 
-  let overflowWrap = string_style_prop "overflowWrap"
+  let overflow_wrap = string_style_prop "overflowWrap"
 
-  let tabSize = string_style_prop "tabSize"
+  let tab_size = string_style_prop "tabSize"
 
-  let textAlignLast = string_style_prop "textAlignLast"
+  let text_align_last = string_style_prop "textAlignLast"
 
-  let textJustify = string_style_prop "textJustify"
+  let text_justify = string_style_prop "textJustify"
 
-  let wordBreak = string_style_prop "wordBreak"
+  let word_break = string_style_prop "wordBreak"
 
-  let wordWrap = string_style_prop "wordWrap"
+  let word_wrap = string_style_prop "wordWrap"
 
   let animation = string_style_prop "animation"
 
-  let animationDelay = string_style_prop "animationDelay"
+  let animation_delay = string_style_prop "animationDelay"
 
-  let animationDirection = string_style_prop "animationDirection"
+  let animation_direction = string_style_prop "animationDirection"
 
-  let animationDuration = string_style_prop "animationDuration"
+  let animation_duration = string_style_prop "animationDuration"
 
-  let animationFillMode = string_style_prop "animationFillMode"
+  let animation_fill_mode = string_style_prop "animationFillMode"
 
-  let animationIterationCount = string_style_prop "animationIterationCount"
+  let animation_iteration_count = string_style_prop "animationIterationCount"
 
-  let animationName = string_style_prop "animationName"
+  let animation_name = string_style_prop "animationName"
 
-  let animationPlayState = string_style_prop "animationPlayState"
+  let animation_play_state = string_style_prop "animationPlayState"
 
-  let animationTimingFunction = string_style_prop "animationTimingFunction"
+  let animation_timing_function = string_style_prop "animationTimingFunction"
 
   let transition = string_style_prop "transition"
 
-  let transitionDelay = string_style_prop "transitionDelay"
+  let transition_delay = string_style_prop "transitionDelay"
 
-  let transitionDuration = string_style_prop "transitionDuration"
+  let transition_duration = string_style_prop "transitionDuration"
 
-  let transitionProperty = string_style_prop "transitionProperty"
+  let transition_property = string_style_prop "transitionProperty"
 
-  let transitionTimingFunction = string_style_prop "transitionTimingFunction"
+  let transition_timing_function = string_style_prop "transitionTimingFunction"
 
-  let backfaceVisibility = string_style_prop "backfaceVisibility"
+  let backface_visibility = string_style_prop "backfaceVisibility"
 
   let perspective = string_style_prop "perspective"
 
-  let perspectiveOrigin = string_style_prop "perspectiveOrigin"
+  let perspective_origin = string_style_prop "perspectiveOrigin"
 
   let transform = string_style_prop "transform"
 
-  let transformOrigin = string_style_prop "transformOrigin"
+  let transform_origin = string_style_prop "transformOrigin"
 
-  let transformStyle = string_style_prop "transformStyle"
+  let transform_style = string_style_prop "transformStyle"
 
-  let justifyItems = string_style_prop "justifyItems"
+  let justify_items = string_style_prop "justifyItems"
 
-  let justifySelf = string_style_prop "justifySelf"
+  let justify_self = string_style_prop "justifySelf"
 
-  let placeContent = string_style_prop "placeContent"
+  let place_content = string_style_prop "placeContent"
 
-  let placeItems = string_style_prop "placeItems"
+  let place_items = string_style_prop "placeItems"
 
-  let placeSelf = string_style_prop "placeSelf"
+  let place_self = string_style_prop "placeSelf"
 
   let appearance = string_style_prop "appearance"
 
   let caret = string_style_prop "caret"
 
-  let caretAnimation = string_style_prop "caretAnimation"
+  let caret_animation = string_style_prop "caretAnimation"
 
-  let caretShape = string_style_prop "caretShape"
+  let caret_shape = string_style_prop "caretShape"
 
-  let userSelect = string_style_prop "userSelect"
+  let user_select = string_style_prop "userSelect"
 
-  let maxLines = string_style_prop "maxLines"
+  let max_lines = string_style_prop "maxLines"
 
-  let marqueeDirection = string_style_prop "marqueeDirection"
+  let marquee_direction = string_style_prop "marqueeDirection"
 
-  let marqueeLoop = string_style_prop "marqueeLoop"
+  let marquee_loop = string_style_prop "marqueeLoop"
 
-  let marqueeSpeed = string_style_prop "marqueeSpeed"
+  let marquee_speed = string_style_prop "marqueeSpeed"
 
-  let marqueeStyle = string_style_prop "marqueeStyle"
+  let marquee_style = string_style_prop "marqueeStyle"
 
-  let overflowStyle = string_style_prop "overflowStyle"
+  let overflow_style = string_style_prop "overflowStyle"
 
   let rotation = string_style_prop "rotation"
 
-  let rotationPoint = string_style_prop "rotationPoint"
+  let rotation_point = string_style_prop "rotationPoint"
 
-  let alignmentBaseline = string_style_prop "alignmentBaseline"
+  let alignment_baseline = string_style_prop "alignmentBaseline"
 
-  let baselineShift = string_style_prop "baselineShift"
+  let baseline_shift = string_style_prop "baselineShift"
 
   let clip = string_style_prop "clip"
 
-  let clipPath = string_style_prop "clipPath"
+  let clip_path = string_style_prop "clipPath"
 
-  let clipRule = string_style_prop "clipRule"
+  let clip_rule = string_style_prop "clipRule"
 
-  let colorInterpolation = string_style_prop "colorInterpolation"
+  let color_interpolation = string_style_prop "colorInterpolation"
 
-  let colorInterpolationFilters = string_style_prop "colorInterpolationFilters"
+  let color_interpolation_filters = string_style_prop "colorInterpolationFilters"
 
-  let colorProfile = string_style_prop "colorProfile"
+  let color_profile = string_style_prop "colorProfile"
 
-  let colorRendering = string_style_prop "colorRendering"
+  let color_rendering = string_style_prop "colorRendering"
 
   let cursor = string_style_prop "cursor"
 
-  let dominantBaseline = string_style_prop "dominantBaseline"
+  let dominant_baseline = string_style_prop "dominantBaseline"
 
   let fill = string_style_prop "fill"
 
-  let fillOpacity = string_style_prop "fillOpacity"
+  let fill_opacity = string_style_prop "fillOpacity"
 
-  let fillRule = string_style_prop "fillRule"
+  let fill_rule = string_style_prop "fillRule"
 
   let filter = string_style_prop "filter"
 
-  let floodColor = string_style_prop "floodColor"
+  let flood_color = string_style_prop "floodColor"
 
-  let floodOpacity = string_style_prop "floodOpacity"
+  let flood_opacity = string_style_prop "floodOpacity"
 
-  let glyphOrientationHorizontal =
+  let glyph_orientation_horizontal =
     string_style_prop "glyphOrientationHorizontal"
 
-  let glyphOrientationVertical = string_style_prop "glyphOrientationVertical"
+  let glyph_orientation_vertical = string_style_prop "glyphOrientationVertical"
 
-  let imageRendering = string_style_prop "imageRendering"
+  let image_rendering = string_style_prop "imageRendering"
 
   let kerning = string_style_prop "kerning"
 
-  let lightingColor = string_style_prop "lightingColor"
+  let lighting_color = string_style_prop "lightingColor"
 
-  let markerEnd = string_style_prop "markerEnd"
+  let marker_end = string_style_prop "markerEnd"
 
-  let markerMid = string_style_prop "markerMid"
+  let marker_mid = string_style_prop "markerMid"
 
-  let markerStart = string_style_prop "markerStart"
+  let marker_start = string_style_prop "markerStart"
 
-  let pointerEvents = string_style_prop "pointerEvents"
+  let pointer_events = string_style_prop "pointerEvents"
 
-  let shapeRendering = string_style_prop "shapeRendering"
+  let shape_rendering = string_style_prop "shapeRendering"
 
-  let stopColor = string_style_prop "stopColor"
+  let stop_color = string_style_prop "stopColor"
 
-  let stopOpacity = string_style_prop "stopOpacity"
+  let stop_opacity = string_style_prop "stopOpacity"
 
   let stroke = string_style_prop "stroke"
 
-  let strokeDasharray = string_style_prop "strokeDasharray"
+  let stroke_dasharray = string_style_prop "strokeDasharray"
 
-  let strokeDashoffset = string_style_prop "strokeDashoffset"
+  let stroke_dashoffset = string_style_prop "strokeDashoffset"
 
-  let strokeLinecap = string_style_prop "strokeLinecap"
+  let stroke_linecap = string_style_prop "strokeLinecap"
 
-  let strokeLinejoin = string_style_prop "strokeLinejoin"
+  let stroke_linejoin = string_style_prop "strokeLinejoin"
 
-  let strokeMiterlimit = string_style_prop "strokeMiterlimit"
+  let stroke_miterlimit = string_style_prop "strokeMiterlimit"
 
-  let strokeOpacity = string_style_prop "strokeOpacity"
+  let stroke_opacity = string_style_prop "strokeOpacity"
 
-  let strokeWidth = string_style_prop "strokeWidth"
+  let stroke_width = string_style_prop "strokeWidth"
 
-  let textAnchor = string_style_prop "textAnchor"
+  let text_anchor = string_style_prop "textAnchor"
 
-  let textRendering = string_style_prop "textRendering"
+  let text_rendering = string_style_prop "textRendering"
 
-  let rubyAlign = string_style_prop "rubyAlign"
+  let ruby_align = string_style_prop "rubyAlign"
 
-  let rubyMerge = string_style_prop "rubyMerge"
+  let ruby_merge = string_style_prop "rubyMerge"
 
-  let rubyPosition = string_style_prop "rubyPosition"]
+  let ruby_position = string_style_prop "rubyPosition"]
 end
 
 module SafeString : sig

--- a/lib/dom.mli
+++ b/lib/dom.mli
@@ -17,19 +17,19 @@ external dom_element_of_js : Ojs.t -> dom_element = "%identity"]
 
 val unmount_component_at_node : dom_element -> bool
   [@@js.custom
-    val unmount_component_at_node_internal : Imports.reactDom -> dom_element -> bool
+    val unmount_component_at_node_internal : Imports.react_dom -> dom_element -> bool
       [@@js.call "unmountComponentAtNode"]
 
     let unmount_component_at_node dom_element =
-      unmount_component_at_node_internal Imports.reactDom dom_element]
+      unmount_component_at_node_internal Imports.react_dom dom_element]
 
 val render : Core.element -> dom_element -> unit
   [@@js.custom
-    val render_internal : Imports.reactDom -> Core.element -> dom_element -> unit
+    val render_internal : Imports.react_dom -> Core.element -> dom_element -> unit
       [@@js.call "render"]
 
     let render element dom_element =
-      render_internal Imports.reactDom element dom_element]
+      render_internal Imports.react_dom element dom_element]
 
 val render_to_element_with_id : Core.element -> string -> unit
   [@@js.custom

--- a/lib/dom.mli
+++ b/lib/dom.mli
@@ -46,27 +46,27 @@ val renderToElementWithId : Core.element -> string -> unit
       | Some element ->
           render reactElement element]
 
-type domRef = private Ojs.t
+type dom_ref = private Ojs.t
 
 module Ref : sig
-  type t = domRef
+  type t = dom_ref
 
-  type currentDomRef = domElement Core.js_nullable Core.Ref.t
+  type current_dom_ref = domElement Core.js_nullable Core.Ref.t
 
-  type callbackDomRef = domElement Core.js_nullable -> unit
+  type callback_dom_ref = domElement Core.js_nullable -> unit
 
   [@@@js.stop]
 
-  val domRef : currentDomRef -> domRef
+  val dom_ref : current_dom_ref -> dom_ref
 
-  val callbackDomRef : callbackDomRef -> domRef
+  val callback_dom_ref : callback_dom_ref -> dom_ref
 
   [@@@js.start]
 
   [@@@js.implem
-  external domRef : currentDomRef -> domRef = "%identity"
+  external dom_ref : current_dom_ref -> dom_ref = "%identity"
 
-  external callbackDomRef : callbackDomRef -> domRef = "%identity"]
+  external callback_dom_ref : callback_dom_ref -> dom_ref = "%identity"]
 end
 
 type domProps = private Ojs.t
@@ -90,15 +90,15 @@ val createDOMElementVariadic :
     let createDOMElementVariadic typ ~props elts =
       createDOMElementVariadic_internal Imports.react typ ~props elts]
 
-val forwardRef : ('props -> domRef -> Core.element) -> 'props Core.component
+val forward_ref : ('props -> dom_ref -> Core.element) -> 'props Core.component
   [@@js.custom
-    val forwardRef_internal :
+    val forward_ref_internal :
          Imports.react
-      -> ('props -> domRef -> Core.element)
+      -> ('props -> dom_ref -> Core.element)
       -> 'props Core.component
       [@@js.call "forwardRef"]
 
-    let forwardRef renderFunc = forwardRef_internal Imports.react renderFunc]
+    let forward_ref renderFunc = forward_ref_internal Imports.react renderFunc]
 
 type block
 

--- a/lib/dom_dsl_core.ml
+++ b/lib/dom_dsl_core.ml
@@ -18,7 +18,7 @@ module Prop = struct
 
   let key = string "key"
 
-  let ref_ = (any "ref" : Dom.domRef -> t)
+  let ref_ = (any "ref" : Dom.dom_ref -> t)
 end
 
 module Element = struct

--- a/lib/dom_dsl_core.ml
+++ b/lib/dom_dsl_core.ml
@@ -23,7 +23,7 @@ end
 
 module Element = struct
   let h name props children =
-    Dom.createDOMElementVariadic name
+    Dom.create_dom_element_variadic name
       ~props:(Js_of_ocaml.Js.Unsafe.obj props)
       children
 end

--- a/lib/dom_dsl_core.mli
+++ b/lib/dom_dsl_core.mli
@@ -17,7 +17,7 @@ module Prop : sig
 
   val key : string -> t
 
-  val ref_ : Dom.domRef -> t
+  val ref_ : Dom.dom_ref -> t
 end
 
 module Element : sig

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -17,7 +17,7 @@ module Prop : sig
 
   val key : string -> t
 
-  val ref_ : Dom.domRef -> t
+  val ref_ : Dom.dom_ref -> t
 
   (** Modifiers *)
 

--- a/lib/dom_svg.mli
+++ b/lib/dom_svg.mli
@@ -15,7 +15,7 @@ module Prop : sig
 
   val key : string -> t
 
-  val ref_ : Dom.domRef -> t
+  val ref_ : Dom.dom_ref -> t
 
   (** Modifiers *)
 

--- a/lib/event.ml
+++ b/lib/event.ml
@@ -12,47 +12,49 @@ module CommonApi = struct
 
     val t_to_js : t -> Ojs.t
 
-    val bubbles : Ojs.t -> bool [@@js.get]
+    val bubbles : Ojs.t -> bool [@@js.get "bubbles"]
 
-    val cancelable : t -> bool [@@js.get]
+    val cancelable : t -> bool [@@js.get "cancelable"]
 
-    val currentTarget : t -> Ojs.t [@@js.get]
+    val current_target : t -> Ojs.t [@@js.get "currentTarget"]
     (* Should return Dom.eventTarget *)
 
-    val defaultPrevented : t -> bool [@@js.get]
+    val default_prevented : t -> bool [@@js.get "defaultPrevented"]
 
-    val eventPhase : t -> int [@@js.get]
+    val event_phase : t -> int [@@js.get "eventPhase"]
 
-    val isTrusted : t -> bool [@@js.get]
+    val is_trusted : t -> bool [@@js.get "isTrusted"]
 
-    val nativeEvent : t -> Ojs.t [@@js.get] (* Should return Dom.event *)
+    val native_event : t -> Ojs.t [@@js.get "nativeEvent"]
+    (* Should return Dom.event *)
 
-    val preventDefault : t -> unit [@@js.call]
+    val prevent_default : t -> unit [@@js.call "preventDefault"]
 
-    val isDefaultPrevented : t -> bool [@@js.call]
+    val is_default_prevented : t -> bool [@@js.call "isDefaultPrevented"]
 
-    val stopPropagation : t -> unit [@@js.call]
+    val stop_propagation : t -> unit [@@js.call "stopPropagation"]
 
-    val isPropagationStopped : t -> bool [@@js.call]
+    val is_propagation_stopped : t -> bool [@@js.call "isPropagationStopped"]
 
-    val target : t -> Ojs.t [@@js.get] (* Should return Dom.eventTarget *)
+    val target : t -> Ojs.t [@@js.get "target"]
+    (* Should return Dom.eventTarget *)
 
-    val timeStamp : t -> float [@@js.get]
+    val time_stamp : t -> float [@@js.get "timeStamp"]
 
     val type_ : t -> string [@@js.get "type"]
 
-    val persist : t -> unit [@@js.call]]
+    val persist : t -> unit [@@js.call "persist"]]
 end
 
 module Synthetic = CommonApi
 
 (* Cast any event type to the general synthetic type. This is safe, since synthetic is more general *)
-external toSyntheticEvent : 'a synthetic -> Synthetic.t = "%identity"
+external to_synthetic_event : 'a synthetic -> Synthetic.t = "%identity"
 
 module Clipboard = struct
   include CommonApi
 
-  include [%js: val clipboardData : t -> Ojs.t [@@js.get]]
+  include [%js: val clipboard_data : t -> Ojs.t [@@js.get "clipboardData"]]
 
   (* Should return Dom.dataTransfer *)
 end
@@ -60,7 +62,7 @@ end
 module Composition = struct
   include CommonApi
 
-  include [%js: val data : t -> string [@@js.get]]
+  include [%js: val data : t -> string [@@js.get "data"]]
 end
 
 module Keyboard = struct
@@ -68,35 +70,37 @@ module Keyboard = struct
 
   include
     [%js:
-    val altKey : t -> bool [@@js.get]
+    val alt_key : t -> bool [@@js.get "altKey"]
 
-    val charCode : t -> int [@@js.get]
+    val char_code : t -> int [@@js.get "charCode"]
 
-    val ctrlKey : t -> bool [@@js.get]
+    val ctrl_key : t -> bool [@@js.get "ctrlKey"]
 
-    val getModifierState : t -> string -> bool [@@js.call]
+    val get_modifier_state : t -> string -> bool [@@js.call "getModifierState"]
 
-    val key : t -> string [@@js.get]
+    val key : t -> string [@@js.get "key"]
 
-    val keyCode : t -> int [@@js.get]
+    val key_code : t -> int [@@js.get "keyCode"]
 
-    val locale : t -> string [@@js.get]
+    val locale : t -> string [@@js.get "locale"]
 
-    val location : t -> int [@@js.get]
+    val location : t -> int [@@js.get "location"]
 
-    val metaKey : t -> bool [@@js.get]
+    val meta_key : t -> bool [@@js.get "metaKey"]
 
-    val repeat : t -> bool [@@js.get]
+    val repeat : t -> bool [@@js.get "repeat"]
 
-    val shiftKey : t -> bool [@@js.get]
+    val shift_key : t -> bool [@@js.get "shiftKey"]
 
-    val which : t -> int [@@js.get]]
+    val which : t -> int [@@js.get "which"]]
 end
 
 module Focus = struct
   include CommonApi
 
-  include [%js: val relatedTarget : t -> Ojs.t option [@@js.get]]
+  include
+    [%js:
+    val related_target : t -> Ojs.t option [@@js.get "relatedTarget"]]
 
   (* Should return Dom.eventTarget *)
 end
@@ -110,35 +114,35 @@ module Mouse = struct
 
   include
     [%js:
-    val altKey : t -> bool [@@js.get]
+    val alt_key : t -> bool [@@js.get "altKey"]
 
-    val button : t -> int [@@js.get]
+    val button : t -> int [@@js.get "button"]
 
-    val buttons : t -> int [@@js.get]
+    val buttons : t -> int [@@js.get "buttons"]
 
-    val clientX : t -> int [@@js.get]
+    val client_x : t -> int [@@js.get "clientX"]
 
-    val clientY : t -> int [@@js.get]
+    val client_y : t -> int [@@js.get "clientY"]
 
-    val ctrlKey : t -> bool [@@js.get]
+    val ctrl_key : t -> bool [@@js.get "ctrlKey"]
 
-    val getModifierState : t -> string -> bool [@@js.call]
+    val get_modifier_state : t -> string -> bool [@@js.call "getModifierState"]
 
-    val metaKey : t -> bool [@@js.get]
+    val meta_key : t -> bool [@@js.get "metaKey"]
 
-    val pageX : t -> int [@@js.get]
+    val page_x : t -> int [@@js.get "pageX"]
 
-    val pageY : t -> int [@@js.get]
+    val page_y : t -> int [@@js.get "pageY"]
 
-    val relatedTarget : t -> Ojs.t option [@@js.get]
+    val related_target : t -> Ojs.t option [@@js.get "relatedTarget"]
 
     (* Should return Dom.eventTarget *)
 
-    val screenX : t -> int [@@js.get]
+    val screen_x : t -> int [@@js.get "screenX"]
 
-    val screenY : t -> int [@@js.get]
+    val screen_y : t -> int [@@js.get "screenY"]
 
-    val shiftKey : t -> bool [@@js.get]]
+    val shift_key : t -> bool [@@js.get "shiftKey"]]
 end
 
 module Selection = struct
@@ -150,21 +154,23 @@ module Touch = struct
 
   include
     [%js:
-    val altKey : t -> bool [@@js.get]
+    val alt_key : t -> bool [@@js.get "altKey"]
 
-    val changedTouches : t -> Ojs.t [@@js.get] (* Should return Dom.touchList *)
+    val changed_touches : t -> Ojs.t [@@js.get "changedTouches"]
+    (* Should return Dom.touchList *)
 
-    val ctrlKey : t -> bool [@@js.get]
+    val ctrl_key : t -> bool [@@js.get "ctrlKey"]
 
-    val getModifierState : t -> string -> bool [@@js.call]
+    val get_modifier_state : t -> string -> bool [@@js.call "getModifierState"]
 
-    val metaKey : t -> bool [@@js.get]
+    val meta_key : t -> bool [@@js.get "metaKey"]
 
-    val shiftKey : t -> bool [@@js.get]
+    val shift_key : t -> bool [@@js.get "shiftKey"]
 
-    val targetTouches : t -> Ojs.t [@@js.get] (* Should return Dom.touchList *)
+    val target_touches : t -> Ojs.t [@@js.get "targetTouches"]
+    (* Should return Dom.touchList *)
 
-    val touches : t -> Ojs.t [@@js.get]]
+    val touches : t -> Ojs.t [@@js.get "touches"]]
 
   (* Should return Dom.touchList *)
 end
@@ -204,9 +210,9 @@ module UI = struct
 
   include
     [%js:
-    val detail : t -> int [@@js.get]
+    val detail : t -> int [@@js.get "detail"]
 
-    val view : t -> window [@@js.get]]
+    val view : t -> window [@@js.get "view"]]
 
   (* Should return DOMAbstractView/WindowProxy *)
 end
@@ -216,13 +222,13 @@ module Wheel = struct
 
   include
     [%js:
-    val deltaMode : t -> int [@@js.get]
+    val delta_mode : t -> int [@@js.get "deltaMode"]
 
-    val deltaX : t -> float [@@js.get]
+    val delta_x : t -> float [@@js.get "deltaX"]
 
-    val deltaY : t -> float [@@js.get]
+    val delta_y : t -> float [@@js.get "deltaY"]
 
-    val deltaZ : t -> float [@@js.get]]
+    val delta_z : t -> float [@@js.get "deltaZ"]]
 end
 
 module Media = struct
@@ -238,11 +244,11 @@ module Animation = struct
 
   include
     [%js:
-    val animationName : t -> string [@@js.get]
+    val animation_name : t -> string [@@js.get "animationName"]
 
-    val pseudoElement : t -> string [@@js.get]
+    val pseudo_element : t -> string [@@js.get "pseudoElement"]
 
-    val elapsedTime : t -> float [@@js.get]]
+    val elapsed_time : t -> float [@@js.get "elapsedTime"]]
 end
 
 module Transition = struct
@@ -250,9 +256,9 @@ module Transition = struct
 
   include
     [%js:
-    val propertyName : t -> string [@@js.get]
+    val property_name : t -> string [@@js.get "propertyName"]
 
-    val pseudoElement : t -> string [@@js.get]
+    val pseudo_element : t -> string [@@js.get "pseudoElement"]
 
-    val elapsedTime : t -> float [@@js.get]]
+    val elapsed_time : t -> float [@@js.get "elapsedTime"]]
 end

--- a/lib/event.mli
+++ b/lib/event.mli
@@ -517,9 +517,9 @@ module Pointer : sig
 
   val related_target : t -> Ojs.t option
 
-  val screen_x: t -> int
+  val screen_x : t -> int
 
-  val screen_y: t -> int
+  val screen_y : t -> int
 
   val shift_key : t -> bool
 end

--- a/lib/event.mli
+++ b/lib/event.mli
@@ -10,27 +10,27 @@ module Synthetic : sig
 
   val cancelable : 'a synthetic -> bool
 
-  val currentTarget : 'a synthetic -> Ojs.t
+  val current_target : 'a synthetic -> Ojs.t
 
-  val defaultPrevented : 'a synthetic -> bool
+  val default_prevented : 'a synthetic -> bool
 
-  val eventPhase : 'a synthetic -> int
+  val event_phase : 'a synthetic -> int
 
-  val isTrusted : 'a synthetic -> bool
+  val is_trusted : 'a synthetic -> bool
 
-  val nativeEvent : 'a synthetic -> Ojs.t
+  val native_event : 'a synthetic -> Ojs.t
 
-  val preventDefault : 'a synthetic -> unit
+  val prevent_default : 'a synthetic -> unit
 
-  val isDefaultPrevented : 'a synthetic -> bool
+  val is_default_prevented : 'a synthetic -> bool
 
-  val stopPropagation : 'a synthetic -> unit
+  val stop_propagation : 'a synthetic -> unit
 
-  val isPropagationStopped : 'a synthetic -> bool
+  val is_propagation_stopped : 'a synthetic -> bool
 
   val target : 'a synthetic -> Ojs.t
 
-  val timeStamp : 'a synthetic -> float
+  val time_stamp : 'a synthetic -> float
 
   val type_ : 'a synthetic -> string
 
@@ -38,7 +38,7 @@ module Synthetic : sig
 end
 
 (* Cast any event type to the general synthetic type. This is safe, since synthetic is more general *)
-val toSyntheticEvent : 'a synthetic -> Synthetic.t
+val to_synthetic_event : 'a synthetic -> Synthetic.t
 
 module Clipboard : sig
   type tag
@@ -53,33 +53,33 @@ module Clipboard : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
   val persist : t -> unit
 
-  val clipboardData : t -> Ojs.t
+  val clipboard_data : t -> Ojs.t
 end
 
 module Composition : sig
@@ -95,27 +95,27 @@ module Composition : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
@@ -137,53 +137,53 @@ module Keyboard : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
   val persist : t -> unit
 
-  val altKey : t -> bool
+  val alt_key : t -> bool
 
-  val charCode : t -> int
+  val char_code : t -> int
 
-  val ctrlKey : t -> bool
+  val ctrl_key : t -> bool
 
-  val getModifierState : t -> string -> bool
+  val get_modifier_state : t -> string -> bool
 
   val key : t -> string
 
-  val keyCode : t -> int
+  val key_code : t -> int
 
   val locale : t -> string
 
   val location : t -> int
 
-  val metaKey : t -> bool
+  val meta_key : t -> bool
 
   val repeat : t -> bool
 
-  val shiftKey : t -> bool
+  val shift_key : t -> bool
 
   val which : t -> int
 end
@@ -201,33 +201,33 @@ module Focus : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
   val persist : t -> unit
 
-  val relatedTarget : t -> Ojs.t option
+  val related_target : t -> Ojs.t option
 end
 
 module Form : sig
@@ -243,27 +243,27 @@ module Form : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
@@ -283,59 +283,59 @@ module Mouse : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
   val persist : t -> unit
 
-  val altKey : t -> bool
+  val alt_key : t -> bool
 
   val button : t -> int
 
   val buttons : t -> int
 
-  val clientX : t -> int
+  val client_x : t -> int
 
-  val clientY : t -> int
+  val client_y : t -> int
 
-  val ctrlKey : t -> bool
+  val ctrl_key : t -> bool
 
-  val getModifierState : t -> string -> bool
+  val get_modifier_state : t -> string -> bool
 
-  val metaKey : t -> bool
+  val meta_key : t -> bool
 
-  val pageX : t -> int
+  val page_x : t -> int
 
-  val pageY : t -> int
+  val page_y : t -> int
 
-  val relatedTarget : t -> Ojs.t option
+  val related_target : t -> Ojs.t option
 
-  val screenX : t -> int
+  val screen_x : t -> int
 
-  val screenY : t -> int
+  val screen_y : t -> int
 
-  val shiftKey : t -> bool
+  val shift_key : t -> bool
 end
 
 module Selection : sig
@@ -351,27 +351,27 @@ module Selection : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
@@ -391,45 +391,45 @@ module Touch : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
   val persist : t -> unit
 
-  val altKey : t -> bool
+  val alt_key : t -> bool
 
-  val changedTouches : t -> Ojs.t
+  val changed_touches : t -> Ojs.t
 
-  val ctrlKey : t -> bool
+  val ctrl_key : t -> bool
 
-  val getModifierState : t -> string -> bool
+  val get_modifier_state : t -> string -> bool
 
-  val metaKey : t -> bool
+  val meta_key : t -> bool
 
-  val shiftKey : t -> bool
+  val shift_key : t -> bool
 
-  val targetTouches : t -> Ojs.t
+  val target_touches : t -> Ojs.t
 
   val touches : t -> Ojs.t
 end
@@ -469,59 +469,59 @@ module Pointer : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
   val persist : t -> unit
 
-  val altKey : t -> bool
+  val alt_key : t -> bool
 
   val button : t -> int
 
   val buttons : t -> int
 
-  val clientX : t -> int
+  val client_x : t -> int
 
-  val clientY : t -> int
+  val client_y : t -> int
 
-  val ctrlKey : t -> bool
+  val ctrl_key : t -> bool
 
-  val getModifierState : t -> string -> bool
+  val get_modifier_state : t -> string -> bool
 
-  val metaKey : t -> bool
+  val meta_key : t -> bool
 
-  val pageX : t -> int
+  val page_x : t -> int
 
-  val pageY : t -> int
+  val page_y : t -> int
 
-  val relatedTarget : t -> Ojs.t option
+  val related_target : t -> Ojs.t option
 
-  val screenX : t -> int
+  val screen_x: t -> int
 
-  val screenY : t -> int
+  val screen_y: t -> int
 
-  val shiftKey : t -> bool
+  val shift_key : t -> bool
 end
 
 module UI : sig
@@ -537,27 +537,27 @@ module UI : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
@@ -581,39 +581,39 @@ module Wheel : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
   val persist : t -> unit
 
-  val deltaMode : t -> int
+  val delta_mode : t -> int
 
-  val deltaX : t -> float
+  val delta_x : t -> float
 
-  val deltaY : t -> float
+  val delta_y : t -> float
 
-  val deltaZ : t -> float
+  val delta_z : t -> float
 end
 
 module Media : sig
@@ -629,27 +629,27 @@ module Media : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
@@ -669,27 +669,27 @@ module Image : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
@@ -709,37 +709,37 @@ module Animation : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
   val persist : t -> unit
 
-  val animationName : t -> string
+  val animation_name : t -> string
 
-  val pseudoElement : t -> string
+  val pseudo_element : t -> string
 
-  val elapsedTime : t -> float
+  val elapsed_time : t -> float
 end
 
 module Transition : sig
@@ -755,35 +755,35 @@ module Transition : sig
 
   val cancelable : t -> bool
 
-  val currentTarget : t -> Ojs.t
+  val current_target : t -> Ojs.t
 
-  val defaultPrevented : t -> bool
+  val default_prevented : t -> bool
 
-  val eventPhase : t -> int
+  val event_phase : t -> int
 
-  val isTrusted : t -> bool
+  val is_trusted : t -> bool
 
-  val nativeEvent : t -> Ojs.t
+  val native_event : t -> Ojs.t
 
-  val preventDefault : t -> unit
+  val prevent_default : t -> unit
 
-  val isDefaultPrevented : t -> bool
+  val is_default_prevented : t -> bool
 
-  val stopPropagation : t -> unit
+  val stop_propagation : t -> unit
 
-  val isPropagationStopped : t -> bool
+  val is_propagation_stopped : t -> bool
 
   val target : t -> Ojs.t
 
-  val timeStamp : t -> float
+  val time_stamp : t -> float
 
   val type_ : t -> string
 
   val persist : t -> unit
 
-  val propertyName : t -> string
+  val property_name : t -> string
 
-  val pseudoElement : t -> string
+  val pseudo_element : t -> string
 
-  val elapsedTime : t -> float
+  val elapsed_time : t -> float
 end

--- a/lib/imports.ml
+++ b/lib/imports.ml
@@ -8,4 +8,5 @@ let react_dom_to_js v = v
 
 let react : react = Js_of_ocaml.Js.Unsafe.js_expr {|require("react")|}
 
-let react_dom : react_dom = Js_of_ocaml.Js.Unsafe.js_expr {|require("react-dom")|}
+let react_dom : react_dom =
+  Js_of_ocaml.Js.Unsafe.js_expr {|require("react-dom")|}

--- a/lib/imports.ml
+++ b/lib/imports.ml
@@ -1,11 +1,11 @@
 type react = Ojs.t
 
-type reactDom = Ojs.t
+type react_dom = Ojs.t
 
 let react_to_js v = v
 
-let reactDom_to_js v = v
+let react_dom_to_js v = v
 
 let react : react = Js_of_ocaml.Js.Unsafe.js_expr {|require("react")|}
 
-let reactDom : reactDom = Js_of_ocaml.Js.Unsafe.js_expr {|require("react-dom")|}
+let react_dom : react_dom = Js_of_ocaml.Js.Unsafe.js_expr {|require("react-dom")|}

--- a/lib/router.ml
+++ b/lib/router.ml
@@ -187,7 +187,7 @@ let useUrl ?serverUrl () =
         | None ->
             dangerouslyGetInitialUrl () )
   in
-  Core.useEffect0 (fun () ->
+  Core.use_effect0 (fun () ->
       let watcherId = watchUrl (fun url -> setUrl (fun _ -> url)) in
       (* check for updates that may have occured between the initial state and the subscribe above *)
       let newUrl = dangerouslyGetInitialUrl () in

--- a/lib/router.ml
+++ b/lib/router.ml
@@ -180,7 +180,7 @@ let unwatchUrl watcherID =
 
 let useUrl ?serverUrl () =
   let url, setUrl =
-    Core.useState (fun () ->
+    Core.use_state (fun () ->
         match serverUrl with
         | Some url ->
             url

--- a/lib/router.mli
+++ b/lib/router.mli
@@ -6,7 +6,7 @@ val push : string -> unit
 val replace : string -> unit
 (** update the url with the string path. modifies the current history entry instead of creating a new one. Example: `replace("/book/1")`, `replace("/books#title")` *)
 
-type watcherID
+type watcher_id
 
 type url =
   { (* path takes window.location.path, like "/book/title/edit" and turns it into `["book", "title", "edit"]` *)
@@ -16,13 +16,13 @@ type url =
   ; (* the url's query params, if any. The ? symbol is stripped out for you *)
     search: string }
 
-val watchUrl : (url -> unit) -> watcherID
+val watch_url : (url -> unit) -> watcher_id
 (** start watching for URL changes. Returns a subscription token. Upon url change, calls the callback and passes it the url record *)
 
-val unwatchUrl : watcherID -> unit
+val unwatch_url : watcher_id -> unit
 (** stop watching for URL changes *)
 
-val dangerouslyGetInitialUrl : unit -> url
+val dangerously_get_initial_url : unit -> url
 (** this is marked as "dangerous" because you technically shouldn't be accessing the URL outside of watchUrl's callback;
       you'd read a potentially stale url, instead of the fresh one inside watchUrl.
       But this helper is sometimes needed, if you'd like to initialize a page whose display/state depends on the URL,
@@ -33,7 +33,7 @@ val dangerouslyGetInitialUrl : unit -> url
       for an example.
       *)
 
-val useUrl : ?serverUrl:url -> unit -> url
+val use_url : ?server_url:url -> unit -> url
 (** hook for watching url changes.
  * serverUrl is used for ssr. it allows you to specify the url without relying on browser apis existing/working as expected
  *)

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -8,7 +8,7 @@
 (*
    The transform:
    transform `[@JSX] div(~props1=a, ~props2=b, ~children=[foo, bar], ())` into
-   `React.Dom.createDOMElementVariadic("div", React.Dom.domProps(~props1=1, ~props2=b), [foo, bar])`.
+   `React.Dom.create_dom_element_variadic("div", React.Dom.domProps(~props1=1, ~props2=b), [foo, bar])`.
    transform the upper-cased case
    `[@JSX] Foo.createElement(~key=a, ~ref=b, ~foo=bar, ~children=[], ())` into
    `React.create_element(Foo.make, Foo.makeProps(~key=a, ~ref=b, ~foo=bar, ()))`

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -674,7 +674,7 @@ let make_js_comp ~loc ~fn_name ~forward_ref ~has_unit ~named_arg_list
 
 (* Builds the intermediate function with labelled arguments that will call make_props.
    [body] is the the component implementation as originally written in source,
-   but without any wrappers like React.memo or forwar_ref *)
+   but without any wrappers like React.memo or forward_ref *)
 let make_ml_comp ~loc ~fn_name ~body rest =
   Exp.mk ~loc
     (Pexp_let (Nonrecursive, [Vb.mk (Pat.var {loc; txt= fn_name}) body], rest))

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -11,10 +11,10 @@
    `React.Dom.createDOMElementVariadic("div", React.Dom.domProps(~props1=1, ~props2=b), [foo, bar])`.
    transform the upper-cased case
    `[@JSX] Foo.createElement(~key=a, ~ref=b, ~foo=bar, ~children=[], ())` into
-   `React.createElement(Foo.make, Foo.makeProps(~key=a, ~ref=b, ~foo=bar, ()))`
+   `React.create_element(Foo.make, Foo.makeProps(~key=a, ~ref=b, ~foo=bar, ()))`
    transform the upper-cased case
    `[@JSX] Foo.createElement(~foo=bar, ~children=[foo, bar], ())` into
-   `React.createElementVariadic(Foo.make, Foo.makeProps(~foo=bar, ~children=React.null, ()), [foo, bar])`
+   `React.create_element_variadic(Foo.make, Foo.makeProps(~foo=bar, ~children=React.null, ()), [foo, bar])`
    transform `[@JSX] [foo]` into
    `React.createFragment([foo])`
  *)
@@ -605,7 +605,7 @@ let argToType types (name, default, _noLabelName, _alias, loc, type_) =
         ; ptyp_loc_stack= [] } )
       :: types
 
-(* Builds the function that will be passed as first param to React.createElement *)
+(* Builds the function that will be passed as first param to React.create_element *)
 let make_js_comp ~loc ~fn_name ~forward_ref ~has_unit ~named_arg_list
     ~named_type_list ~payload ~wrap rest =
   let props = get_props_attr payload in
@@ -887,7 +887,7 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
              (let loc = gloc in
               [%expr
                 fun () ->
-                  React.createElement [%e expression]
+                  React.create_element [%e expression]
                     [%e
                       Exp.apply ~loc
                         (Exp.ident ~loc
@@ -1075,7 +1075,7 @@ let jsxMapper () =
                      (let loc = gloc in
                       [%expr
                         fun () ->
-                          React.createElement [%e expression]
+                          React.create_element [%e expression]
                             [%e
                               Exp.apply ~loc
                                 (Exp.ident ~loc

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -77,7 +77,7 @@ let keyType loc =
   Typ.constr ~loc {loc; txt= optionIdent}
     [Typ.constr ~loc {loc; txt= Lident "string"} []]
 
-let refType loc = [%type: React.Dom.domRef]
+let refType loc = [%type: React.Dom.dom_ref]
 
 type componentConfig = {propsName: string}
 
@@ -288,9 +288,9 @@ let makeAttributeValue ~loc ~isOptional (type_ : Html.attributeType) value =
   | Style, true ->
       [%expr ([%e value] : React.Dom.Style.t option)]
   | Ref, false ->
-      [%expr ([%e value] : React.Dom.domRef)]
+      [%expr ([%e value] : React.Dom.dom_ref)]
   | Ref, true ->
-      [%expr ([%e value] : React.Dom.domRef option)]
+      [%expr ([%e value] : React.Dom.dom_ref option)]
   | InnerHtml, false ->
       [%expr ([%e value] : React.Dom.DangerouslySetInnerHTML.t)]
   | InnerHtml, true ->
@@ -482,7 +482,7 @@ let rec recursivelyTransformNamedArgsForMake mapper expr list =
   | Pexp_fun (Labelled "ref", _, _, _) | Pexp_fun (Optional "ref", _, _, _) ->
       Location.raise_errorf ~loc
         "jsoo-react: ref cannot be passed as a normal prop. Please use \
-         `forwardRef` API instead."
+         `forward_ref` API instead."
   | Pexp_fun
       (((Labelled label | Optional label) as arg), default, pattern, expression)
     ->
@@ -674,7 +674,7 @@ let make_js_comp ~loc ~fn_name ~forward_ref ~has_unit ~named_arg_list
 
 (* Builds the intermediate function with labelled arguments that will call make_props.
    [body] is the the component implementation as originally written in source,
-   but without any wrappers like React.memo or forwardRef *)
+   but without any wrappers like React.memo or forwar_ref *)
 let make_ml_comp ~loc ~fn_name ~body rest =
   Exp.mk ~loc
     (Pexp_let (Nonrecursive, [Vb.mk (Pat.var {loc; txt= fn_name}) body], rest))
@@ -699,7 +699,7 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
         | {pexp_desc= Pexp_let (_recursive, _vbs, return_expr)} ->
             (* here's where we spelunk! *)
             spelunk_for_fun_expr return_expr
-        (* let make = React.forwardRef((~prop) => ...) or
+        (* let make = React.forward_ref((~prop) => ...) or
            let make = React.memoCustomCompareProps((~prop) => ..., compareProps()) *)
         | { pexp_desc=
               Pexp_apply
@@ -714,7 +714,7 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
             raise
               (Invalid_argument
                  "react.component calls can only be on function definitions or \
-                  component wrappers (forwardRef, memo)." )
+                  component wrappers (forward_ref, memo)." )
       in
       spelunk_for_fun_expr expression
     in
@@ -813,7 +813,7 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
               Location.raise_errorf ~loc:pattern.ppat_loc
                 "jsoo-react: props need to be labelled arguments.\n\
                 \  If you are working with refs be sure to wrap with \
-                 React.forwardRef.\n\
+                 React.forward_ref.\n\
                 \  If your component doesn't have any props use () or _ \
                  instead of a name."
         (* let make = {let foo = bar in (~prop) => ...} *)
@@ -823,7 +823,7 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
             ( wrap
             , has_unit
             , {expression with pexp_desc= Pexp_let (recursive, vbs, exp)} )
-        (* let make = React.forwardRef((~prop) => ...) *)
+        (* let make = React.forward_ref((~prop) => ...) *)
         | {pexp_desc= Pexp_apply (wrapper_expr, [(Nolabel, internalExpression)])}
           ->
             let () = has_application := true in

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -16,7 +16,7 @@
    `[@JSX] Foo.createElement(~foo=bar, ~children=[foo, bar], ())` into
    `React.create_element_variadic(Foo.make, Foo.makeProps(~foo=bar, ~children=React.null, ()), [foo, bar])`
    transform `[@JSX] [foo]` into
-   `React.createFragment([foo])`
+   `React.create_fragment([foo])`
  *)
 
 open Ppxlib

--- a/ppx/test/input_reason.re
+++ b/ppx/test/input_reason.re
@@ -47,7 +47,7 @@ module Func = (M: X_int) => {
 module ForwardRef = {
   [@react.component]
   let make =
-    React.forwardRef(theRef =>
+    React.forward_ref(theRef =>
       <div ref={theRef |> Js_of_ocaml.Js.Opt.to_option}>
         {React.string("ForwardRef")}
       </div>
@@ -159,7 +159,7 @@ let t = <button ref className="FancyButton"> ...children </button>;
 
 [@react.component]
 let make =
-  React.Dom.forwardRef((~children, ref) => {
+  React.Dom.forward_ref((~children, ref) => {
     <button ref className="FancyButton"> ...children </button>
   });
 

--- a/ppx/test/pp_ocaml.expected
+++ b/ppx/test/pp_ocaml.expected
@@ -39,7 +39,7 @@ let make =
                  (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
     fun ?name ->
       fun ?key ->
-        fun () -> React.createElement make (make_props ?key ?name ()))
+        fun () -> React.create_element make (make_props ?key ?name ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -82,7 +82,7 @@ let make =
                      (fun x -> x#children)) in
     fun ~children ->
       fun ?key ->
-        fun () -> React.createElement make (make_props ?key ~children ()))
+        fun () -> React.create_element make (make_props ?key ~children ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -123,7 +123,7 @@ let make =
                      (fun x -> x#children)) in
     fun ~children ->
       fun ?key ->
-        fun () -> React.createElement make (make_props ?key ~children ()))
+        fun () -> React.create_element make (make_props ?key ~children ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -166,7 +166,7 @@ let make =
                      (fun x -> x#children)) () in
     fun ~children ->
       fun ?key ->
-        fun () -> React.createElement make (make_props ?key ~children ()))
+        fun () -> React.create_element make (make_props ?key ~children ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -205,7 +205,7 @@ let make =
                  (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
     fun ?name ->
       fun ?key ->
-        fun () -> React.createElement make (make_props ?key ?name ()))
+        fun () -> React.create_element make (make_props ?key ?name ()))
     [@merlin.hide ])
 let make =
   let make_props : ?key:string -> unit -> <  >  Js_of_ocaml.Js.t =
@@ -220,7 +220,7 @@ let make =
                                                                    ] in
   let make () = (div [||] [] : React.element) in
   ((let make (Props : <  >  Js_of_ocaml.Js.t) = make () in
-    fun ?key -> fun () -> React.createElement make (make_props ?key ()))
+    fun ?key -> fun () -> React.create_element make (make_props ?key ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -261,7 +261,7 @@ let make =
                 (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#bar)) in
     fun ~bar ->
       fun ?key ->
-        fun () -> React.createElement make (make_props ?key ~bar ()))
+        fun () -> React.create_element make (make_props ?key ~bar ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -287,7 +287,7 @@ let make =
   fun ~name ->
     fun ?key ->
       fun () ->
-        React.createElement
+        React.create_element
           (Js_of_ocaml.Js.Unsafe.js_expr
              "require(\"my-react-library\").MyReactComponent")
           (make_props ?key ~name ())
@@ -316,7 +316,7 @@ let make =
   fun ?name ->
     fun ?key ->
       fun () ->
-        React.createElement
+        React.create_element
           (Js_of_ocaml.Js.Unsafe.js_expr
              "require(\"my-react-library\").MyReactComponent")
           (make_props ?key ?name ())
@@ -349,7 +349,7 @@ let make =
   fun ~names ->
     fun ?key ->
       fun () ->
-        React.createElement
+        React.create_element
           (Js_of_ocaml.Js.Unsafe.js_expr
              "require(\"my-react-library\").MyReactComponent")
           (make_props ?key ~names ())

--- a/ppx/test/pp_reason.expected
+++ b/ppx/test/pp_reason.expected
@@ -49,7 +49,7 @@ let make =
                  (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
     fun ?name ->
       fun ?key ->
-        fun () -> React.createElement make (make_props ?key ?name ()))
+        fun () -> React.create_element make (make_props ?key ?name ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -108,7 +108,7 @@ let make =
     fun ~a ->
       fun ~b ->
         fun ?key ->
-          fun () -> React.createElement make (make_props ?key ~b ~a ()))
+          fun () -> React.create_element make (make_props ?key ~b ~a ()))
     [@merlin.hide ])
 module External =
   struct
@@ -141,7 +141,7 @@ module External =
         fun ~b ->
           fun ?key ->
             fun () ->
-              React.createElement
+              React.create_element
                 (Js_of_ocaml.Js.Unsafe.js_expr
                    "require(\"my-react-library\").MyReactComponent")
                 (component_props ?key ~b ~a ())[@@otherAttribute
@@ -210,7 +210,7 @@ module Bar =
         fun ~a ->
           fun ~b ->
             fun ?key ->
-              fun () -> React.createElement make (make_props ?key ~b ~a ()))
+              fun () -> React.create_element make (make_props ?key ~b ~a ()))
         [@merlin.hide ])
     let component =
       let component_props
@@ -272,7 +272,8 @@ module Bar =
           fun ~b ->
             fun ?key ->
               fun () ->
-                React.createElement component (component_props ?key ~b ~a ()))
+                React.create_element component
+                  (component_props ?key ~b ~a ()))
         [@merlin.hide ])
   end
 module type X_int  = sig val x : int end
@@ -338,7 +339,7 @@ module Func(M:X_int) =
         fun ~a ->
           fun ~b ->
             fun ?key ->
-              fun () -> React.createElement make (make_props ?key ~b ~a ()))
+              fun () -> React.create_element make (make_props ?key ~b ~a ()))
         [@merlin.hide ])
   end
 module ForwardRef =
@@ -374,7 +375,7 @@ module ForwardRef =
                fun theRef -> make theRef) in
         fun ?key ->
           fun ?ref ->
-            fun () -> React.createElement make (make_props ?ref ?key ()))
+            fun () -> React.create_element make (make_props ?ref ?key ()))
         [@merlin.hide ])
   end
 module Memo =
@@ -422,7 +423,7 @@ module Memo =
                        (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#a))) in
         fun ~a ->
           fun ?key ->
-            fun () -> React.createElement make (make_props ?key ~a ()))
+            fun () -> React.create_element make (make_props ?key ~a ()))
         [@merlin.hide ])
   end
 module MemoCustomCompareProps =
@@ -471,7 +472,7 @@ module MemoCustomCompareProps =
             (fun prevPros -> fun nextProps -> false) in
         fun ~a ->
           fun ?key ->
-            fun () -> React.createElement make (make_props ?key ~a ()))
+            fun () -> React.create_element make (make_props ?key ~a ()))
         [@merlin.hide ])
   end
 let fragment foo = ((React.Fragment.make ~children:[foo] ())[@bla ])
@@ -622,7 +623,7 @@ let make =
       fun ~children ->
         fun ?key ->
           fun () ->
-            React.createElement make (make_props ?key ~children ~title ()))
+            React.create_element make (make_props ?key ~children ~title ()))
     [@merlin.hide ])
 let t = FancyButton.make ~ref:buttonRef ~children:[div [||] []] ()
 let t =
@@ -686,7 +687,7 @@ let make =
       fun ?key ->
         fun ?ref ->
           fun () ->
-            React.createElement make (make_props ?ref ?key ~children ()))
+            React.create_element make (make_props ?ref ?key ~children ()))
     [@merlin.hide ])
 let testAttributes =
   div [|(Prop.translate (("yes")[@reason.raw_literal "yes"]))|]
@@ -797,7 +798,7 @@ let make =
         fun ?onClick ->
           fun ?key ->
             fun () ->
-              React.createElement make
+              React.create_element make
                 (make_props ?key ?onClick ?isDisabled ~name ()))
     [@merlin.hide ])
 let make =
@@ -844,5 +845,5 @@ let make =
                  (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
     fun ?name ->
       fun ?key ->
-        fun () -> React.createElement make (make_props ?key ?name ()))
+        fun () -> React.create_element make (make_props ?key ?name ()))
     [@merlin.hide ])

--- a/ppx/test/pp_reason.expected
+++ b/ppx/test/pp_reason.expected
@@ -347,7 +347,7 @@ module ForwardRef =
     let make =
       let make_props
         : ?key:string ->
-            ?ref:React.Dom.domRef -> unit -> <  >  Js_of_ocaml.Js.t
+            ?ref:React.Dom.dom_ref -> unit -> <  >  Js_of_ocaml.Js.t
         =
         fun ?key ->
           fun ?ref ->
@@ -370,7 +370,7 @@ module ForwardRef =
               [@reason.preserve_braces ])])
         [@warning "-16"]) in
       ((let make =
-          React.forwardRef
+          React.forward_ref
             (fun (Props : <  >  Js_of_ocaml.Js.t) ->
                fun theRef -> make theRef) in
         fun ?key ->
@@ -634,7 +634,7 @@ let make =
   let make_props
     : children:'children ->
         ?key:string ->
-          ?ref:React.Dom.domRef ->
+          ?ref:React.Dom.dom_ref ->
             unit ->
               < children: 'children Js_of_ocaml.Js.readonly_prop   > 
                 Js_of_ocaml.Js.t
@@ -664,7 +664,7 @@ let make =
         [@warning "-16"]))
     [@warning "-16"]) in
   ((let make =
-      React.Dom.forwardRef
+      React.Dom.forward_ref
         (fun
            (Props :
              < children: 'children Js_of_ocaml.Js.readonly_prop   > 

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -798,7 +798,8 @@ let use_effect =
 
 let use_callback =
   "use_callback"
-  >::: ["use_callback1" >:: testUseCallback1; "use_callback4" >:: testUseCallback4]
+  >::: [ "use_callback1" >:: testUseCallback1
+       ; "use_callback4" >:: testUseCallback4 ]
 
 let use_state =
   "use_state"

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -115,7 +115,7 @@ let testContext () =
 let testUseEffect () =
   let module UseEffect = struct
     let%component make () =
-      let count, setCount = React.useState (fun () -> 0) in
+      let count, setCount = React.use_state (fun () -> 0) in
       React.use_effect0 (fun () ->
           setCount (fun count -> count + 1) ;
           None ) ;
@@ -128,7 +128,7 @@ let testUseEffect () =
 let testUseEffect2 () =
   let module Add2 = struct
     let%component make ~a ~b =
-      let count, setCount = React.useState (fun () -> 0) in
+      let count, setCount = React.use_state (fun () -> 0) in
       React.use_effect2
         (fun () ->
           setCount (fun _ -> a + b) ;
@@ -150,7 +150,7 @@ let testUseEffect2 () =
 let testUseEffect3 () =
   let module Use3 = struct
     let%component make ~a ~b ~c =
-      let count, setCount = React.useState (fun () -> 0) in
+      let count, setCount = React.use_state (fun () -> 0) in
       React.use_effect3
         (fun () ->
           setCount (fun count -> count + 1) ;
@@ -192,7 +192,7 @@ let testUseCallback1 () =
   let module UseCallback = struct
     let%component make ~a =
       let (count, str), setCountStr =
-        React.useState (fun () -> (0, "init and"))
+        React.use_state (fun () -> (0, "init and"))
       in
       let f =
         React.use_callback1 (fun input -> input ^ " " ^ a ^ " and") [|a|]
@@ -223,7 +223,7 @@ let testUseCallback1 () =
 let testUseCallback4 () =
   let module UseCallback = struct
     let%component make ~a ~b ~d ~e =
-      let (count, str), setCountStr = React.useState (fun () -> (0, "init")) in
+      let (count, str), setCountStr = React.use_state (fun () -> (0, "init")) in
       let f =
         React.use_callback4
           (fun _input ->
@@ -282,7 +282,7 @@ let testUseCallback4 () =
 let testUseState () =
   let module DummyStateComponent = struct
     let%component make ?(initialValue = 0) () =
-      let counter, setCounter = React.useState (fun () -> initialValue) in
+      let counter, setCounter = React.use_state (fun () -> initialValue) in
       fragment
         [ div [|className "value"|] [React.int counter]
         ; button
@@ -324,7 +324,7 @@ let testUseStateUpdaterReference () =
     let prevSetCount = ref None
 
     let%component make () =
-      let _count, setCount = React.useState (fun () -> 0) in
+      let _count, setCount = React.use_state (fun () -> 0) in
       let equal =
         match (setCount, !prevSetCount) with
         | r1, Some r2 when r1 == r2 ->
@@ -455,7 +455,7 @@ let testUseReducerDispatchReference () =
 let testUseMemo1 () =
   let module UseMemo = struct
     let%component make ~a =
-      let count, setCount = React.useState (fun () -> 0) in
+      let count, setCount = React.use_state (fun () -> 0) in
       let result = React.use_memo1 (fun () -> a ^ "2") [|a|] in
       React.use_effect1
         (fun () ->
@@ -800,9 +800,9 @@ let use_callback =
   "use_callback"
   >::: ["use_callback1" >:: testUseCallback1; "use_callback4" >:: testUseCallback4]
 
-let useState =
-  "useState"
-  >::: [ "useState" >:: testUseState
+let use_state =
+  "use_state"
+  >::: [ "use_state" >:: testUseState
        ; "useStateUpdaterReference" >:: testUseStateUpdaterReference ]
 
 let useReducer =
@@ -859,10 +859,10 @@ let suite =
   "ocaml"
   >::: [ basic
        ; context
-       ; useState
        ; useReducer
        ; use_effect
        ; use_callback
+       ; use_state
        ; memoization
        ; refs
        ; children

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -578,7 +578,7 @@ let testChildrenMapWithIndex () =
   let module DummyComponentThatMapsChildren = struct
     let%component make ~children () =
       div [||]
-        [ React.Children.mapWithIndex children (fun element index ->
+        [ React.Children.map_with_index children (fun element index ->
               React.clone_element element
                 (let open Js_of_ocaml.Js.Unsafe in
                 obj [|("key", inject index); ("data-index", inject index)|]) )

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -347,7 +347,7 @@ let testUseReducer () =
 
     let%component make ?(initialValue = 0) () =
       let state, send =
-        React.useReducer
+        React.use_reducer
           (fun state action ->
             match action with Increment -> state + 1 | Decrement -> state - 1 )
           initialValue
@@ -390,7 +390,7 @@ let testUseReducerWithMapState () =
 
     let%component make ?(initialValue = 0) () =
       let state, send =
-        React.useReducerWithMapState
+        React.use_reducer_with_map_state
           (fun state action ->
             match action with Increment -> state + 1 | Decrement -> state - 1 )
           initialValue
@@ -435,7 +435,7 @@ let testUseReducerDispatchReference () =
     let prevDispatch = ref None
 
     let%component make () =
-      let _, dispatch = React.useReducer (fun _ _ -> 2) 2 in
+      let _, dispatch = React.use_reducer (fun _ _ -> 2) 2 in
       let equal =
         match (dispatch, !prevDispatch) with
         | r1, Some r2 when r1 == r2 ->
@@ -805,11 +805,11 @@ let use_state =
   >::: [ "use_state" >:: testUseState
        ; "useStateUpdaterReference" >:: testUseStateUpdaterReference ]
 
-let useReducer =
-  "useReducer"
-  >::: [ "useReducer" >:: testUseReducer
-       ; "useReducerWithMapState" >:: testUseReducerWithMapState
-       ; "useReducerDispatchReference" >:: testUseReducerDispatchReference ]
+let use_reducer =
+  "use_reducer"
+  >::: [ "use_reducer" >:: testUseReducer
+       ; "use_reducer_with_map_state" >:: testUseReducerWithMapState
+       ; "use_reducerDispatchReference" >:: testUseReducerDispatchReference ]
 
 let memoization =
   "memo"
@@ -859,10 +859,10 @@ let suite =
   "ocaml"
   >::: [ basic
        ; context
-       ; useReducer
        ; use_effect
        ; use_callback
        ; use_state
+       ; use_reducer
        ; memoization
        ; refs
        ; children

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -195,7 +195,7 @@ let testUseCallback1 () =
         React.useState (fun () -> (0, "init and"))
       in
       let f =
-        React.useCallback1 (fun input -> input ^ " " ^ a ^ " and") [|a|]
+        React.use_callback1 (fun input -> input ^ " " ^ a ^ " and") [|a|]
       in
       React.use_effect1
         (fun () ->
@@ -225,7 +225,7 @@ let testUseCallback4 () =
     let%component make ~a ~b ~d ~e =
       let (count, str), setCountStr = React.useState (fun () -> (0, "init")) in
       let f =
-        React.useCallback4
+        React.use_callback4
           (fun _input ->
             Printf.sprintf "a: %s, b: %d, d: [%d], e: [|%d|]" a b (List.nth d 0)
               e.(0) )
@@ -796,9 +796,9 @@ let use_effect =
        ; "use_effect2" >:: testUseEffect2
        ; "use_effect3" >:: testUseEffect3 ]
 
-let useCallback =
-  "useCallback"
-  >::: ["useCallback1" >:: testUseCallback1; "useCallback4" >:: testUseCallback4]
+let use_callback =
+  "use_callback"
+  >::: ["use_callback1" >:: testUseCallback1; "use_callback4" >:: testUseCallback4]
 
 let useState =
   "useState"
@@ -859,10 +859,10 @@ let suite =
   "ocaml"
   >::: [ basic
        ; context
-       ; useCallback
        ; useState
        ; useReducer
        ; use_effect
+       ; use_callback
        ; memoization
        ; refs
        ; children

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -579,7 +579,7 @@ let testChildrenMapWithIndex () =
     let%component make ~children () =
       div [||]
         [ React.Children.mapWithIndex children (fun element index ->
-              React.cloneElement element
+              React.clone_element element
                 (let open Js_of_ocaml.Js.Unsafe in
                 obj [|("key", inject index); ("data-index", inject index)|]) )
         ]
@@ -686,7 +686,7 @@ let testWithId () =
   let module WithTestId = struct
     let%component make ~id ~children () =
       React.Children.map children (fun child ->
-          React.cloneElement child
+          React.clone_element child
             (Js.Unsafe.obj
                [|("data-testid", Js.Unsafe.inject (Js.string id))|] ) )
   end in

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -456,7 +456,7 @@ let testUseMemo1 () =
   let module UseMemo = struct
     let%component make ~a =
       let count, setCount = React.useState (fun () -> 0) in
-      let result = React.useMemo1 (fun () -> a ^ "2") [|a|] in
+      let result = React.use_memo1 (fun () -> a ^ "2") [|a|] in
       React.use_effect1
         (fun () ->
           setCount (fun count -> count + 1) ;
@@ -813,7 +813,7 @@ let useReducer =
 
 let memoization =
   "memo"
-  >::: [ "useMemo1" >:: testUseMemo1
+  >::: [ "use_memo1" >:: testUseMemo1
        ; "memo" >:: testMemo
        ; "memoCustomCompareProps" >:: testMemoCustomCompareProps ]
 

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -505,7 +505,7 @@ let testMemoCustomCompareProps () =
   let numRenders = ref 0 in
   let module Memoized = struct
     let%component make =
-      React.memoCustomCompareProps
+      React.memo_custom_compare_props
         (fun ~a ->
           numRenders := !numRenders + 1 ;
           div [||]

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -529,9 +529,9 @@ let testMemoCustomCompareProps () =
         (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1")) )
 
 let testCreateRef () =
-  let reactRef = React.createRef () in
+  let reactRef = React.create_ref () in
   assert_equal (React.Ref.current reactRef) Js_of_ocaml.Js.null ;
-  React.Ref.setCurrent reactRef (Js_of_ocaml.Js.Opt.return 1) ;
+  React.Ref.set_current reactRef (Js_of_ocaml.Js.Opt.return 1) ;
   assert_equal (React.Ref.current reactRef) (Js_of_ocaml.Js.Opt.return 1)
 
 let testForwardRef () =
@@ -544,7 +544,7 @@ let testForwardRef () =
   withContainer (fun c ->
       let count = ref 0 in
       let buttonRef =
-        React.Dom.Ref.callbackDomRef (fun _ref -> count := !count + 1)
+        React.Dom.Ref.callback_dom_ref (fun _ref -> count := !count + 1)
       in
       act (fun () ->
           React.Dom.render
@@ -555,10 +555,10 @@ let testForwardRef () =
 let testUseRef () =
   let module DummyComponentWithRefAndEffect = struct
     let%component make ~cb () =
-      let myRef = React.useRef 1 in
+      let myRef = React.use_ref 1 in
       React.use_effect0 (fun () ->
           let open React.Ref in
-          setCurrent myRef (current myRef + 1) ;
+          set_current myRef (current myRef + 1) ;
           cb myRef ;
           None ) ;
       div [||] []
@@ -819,9 +819,9 @@ let memoization =
 
 let refs =
   "refs"
-  >::: [ "createRef" >:: testCreateRef
-       ; "forwardRef" >:: testForwardRef
-       ; "useRef" >:: testUseRef ]
+  >::: [ "create_ref" >:: testCreateRef
+       ; "forward_ref" >:: testForwardRef
+       ; "use_ref" >:: testUseRef ]
 
 let children =
   "children"

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -92,7 +92,7 @@ let testOptionalPropsLowercase () =
 
 let testContext () =
   let module DummyContext = struct
-    let context = React.createContext "foo"
+    let context = React.create_context "foo"
 
     module Provider = struct
       let make = Context.Provider.make context
@@ -100,7 +100,7 @@ let testContext () =
 
     module Consumer = struct
       let%component make () =
-        let value = React.useContext context in
+        let value = React.use_context context in
         div [||] [value |> string]
     end
   end in

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -27,7 +27,7 @@ let withContainer f =
   let container = Html.createDiv doc in
   Dom.appendChild doc##.body container ;
   let result = f container in
-  ignore (React.Dom.unmountComponentAtNode container) ;
+  ignore (React.Dom.unmount_component_at_node container) ;
   Dom.removeChild doc##.body container ;
   result
 

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -116,7 +116,7 @@ let testUseEffect () =
   let module UseEffect = struct
     let%component make () =
       let count, setCount = React.useState (fun () -> 0) in
-      React.useEffect0 (fun () ->
+      React.use_effect0 (fun () ->
           setCount (fun count -> count + 1) ;
           None ) ;
       div [||] [Printf.sprintf "`count` is %d" count |> string]
@@ -129,7 +129,7 @@ let testUseEffect2 () =
   let module Add2 = struct
     let%component make ~a ~b =
       let count, setCount = React.useState (fun () -> 0) in
-      React.useEffect2
+      React.use_effect2
         (fun () ->
           setCount (fun _ -> a + b) ;
           None )
@@ -151,7 +151,7 @@ let testUseEffect3 () =
   let module Use3 = struct
     let%component make ~a ~b ~c =
       let count, setCount = React.useState (fun () -> 0) in
-      React.useEffect3
+      React.use_effect3
         (fun () ->
           setCount (fun count -> count + 1) ;
           None )
@@ -197,7 +197,7 @@ let testUseCallback1 () =
       let f =
         React.useCallback1 (fun input -> input ^ " " ^ a ^ " and") [|a|]
       in
-      React.useEffect1
+      React.use_effect1
         (fun () ->
           setCountStr (fun (count, str) -> (count + 1, f str)) ;
           None )
@@ -231,7 +231,7 @@ let testUseCallback4 () =
               e.(0) )
           (a, b, d, e)
       in
-      React.useEffect1
+      React.use_effect1
         (fun () ->
           setCountStr (fun (count, str) -> (count + 1, f str)) ;
           None )
@@ -457,7 +457,7 @@ let testUseMemo1 () =
     let%component make ~a =
       let count, setCount = React.useState (fun () -> 0) in
       let result = React.useMemo1 (fun () -> a ^ "2") [|a|] in
-      React.useEffect1
+      React.use_effect1
         (fun () ->
           setCount (fun count -> count + 1) ;
           None )
@@ -556,7 +556,7 @@ let testUseRef () =
   let module DummyComponentWithRefAndEffect = struct
     let%component make ~cb () =
       let myRef = React.useRef 1 in
-      React.useEffect0 (fun () ->
+      React.use_effect0 (fun () ->
           let open React.Ref in
           setCurrent myRef (current myRef + 1) ;
           cb myRef ;
@@ -790,11 +790,11 @@ let basic =
 
 let context = "context" >::: ["testContext" >:: testContext]
 
-let useEffect =
-  "useEffect"
-  >::: [ "useEffect" >:: testUseEffect
-       ; "useEffect2" >:: testUseEffect2
-       ; "useEffect3" >:: testUseEffect3 ]
+let use_effect =
+  "use_effect"
+  >::: [ "use_effect" >:: testUseEffect
+       ; "use_effect2" >:: testUseEffect2
+       ; "use_effect3" >:: testUseEffect3 ]
 
 let useCallback =
   "useCallback"
@@ -859,10 +859,10 @@ let suite =
   "ocaml"
   >::: [ basic
        ; context
-       ; useEffect
        ; useCallback
        ; useState
        ; useReducer
+       ; use_effect
        ; memoization
        ; refs
        ; children

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -250,7 +250,7 @@ let testUseCallback1 = () => {
       let ((count, str), setCountStr) =
         React.useState(() => (0, "init and"));
       let f =
-        React.useCallback1(input => {input ++ " " ++ a ++ " and"}, [|a|]);
+        React.use_callback1(input => {input ++ " " ++ a ++ " and"}, [|a|]);
       React.use_effect1(
         () => {
           setCountStr(((count, str)) => (count + 1, f(str)));
@@ -298,7 +298,7 @@ let testUseCallback4 = () => {
     let make = (~a, ~b, ~d, ~e) => {
       let ((count, str), setCountStr) = React.useState(() => (0, "init"));
       let f =
-        React.useCallback4(
+        React.use_callback4(
           _input => {
             Printf.sprintf(
               "a: %s, b: %d, d: [%d], e: [|%d|]",
@@ -1294,11 +1294,11 @@ let use_effect =
     "use_effect3" >:: testUseEffect3,
   ];
 
-let useCallback =
-  "useCallback"
+let use_callback =
+  "use_callback"
   >::: [
-    "useCallback1" >:: testUseCallback1,
-    "useCallback4" >:: testUseCallback4,
+    "use_callback1" >:: testUseCallback1,
+    "use_callback4" >:: testUseCallback4,
   ];
 
 let useState =
@@ -1389,7 +1389,7 @@ let suite =
     basic,
     context,
     use_effect,
-    useCallback,
+    use_callback,
     useState,
     useReducer,
     memoization,

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -740,9 +740,9 @@ let testMemoCustomCompareProps = () => {
 };
 
 let testCreateRef = () => {
-  let reactRef = React.createRef();
+  let reactRef = React.create_ref();
   assert_equal(React.Ref.current(reactRef), Js_of_ocaml.Js.null);
-  React.Ref.setCurrent(reactRef, Js_of_ocaml.Js.Opt.return(1));
+  React.Ref.set_current(reactRef, Js_of_ocaml.Js.Opt.return(1));
   assert_equal(React.Ref.current(reactRef), Js_of_ocaml.Js.Opt.return(1));
 };
 
@@ -750,7 +750,7 @@ let testForwardRef = () => {
   module FancyButton = {
     [@react.component]
     let make =
-      React.Dom.forwardRef((~children, ref_) => {
+      React.Dom.forward_ref((~children, ref_) => {
         <button ref_ className="FancyButton"> ...children </button>
       });
   };
@@ -758,7 +758,7 @@ let testForwardRef = () => {
   withContainer(c => {
     let count = ref(0);
     let buttonRef =
-      React.Dom.Ref.callbackDomRef(_ref => {count := count^ + 1});
+      React.Dom.Ref.callback_dom_ref(_ref => {count := count^ + 1});
     act(() => {
       React.Dom.render(
         <FancyButton ref=buttonRef> <div /> </FancyButton>,
@@ -773,9 +773,9 @@ let testUseRef = () => {
   module DummyComponentWithRefAndEffect = {
     [@react.component]
     let make = (~cb, ()) => {
-      let myRef = React.useRef(1);
+      let myRef = React.use_ref(1);
       React.use_effect0(() => {
-        React.Ref.(setCurrent(myRef, current(myRef) + 1));
+        React.Ref.(set_current(myRef, current(myRef) + 1));
         cb(myRef);
         None;
       });
@@ -1327,9 +1327,9 @@ let memoization =
 let refs =
   "refs"
   >::: [
-    "createRef" >:: testCreateRef,
-    "forwardRef" >:: testForwardRef,
-    "useRef" >:: testUseRef,
+    "create_ref" >:: testCreateRef,
+    "forward_ref" >:: testForwardRef,
+    "use_ref" >:: testUseRef,
   ];
 
 let children =

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -151,7 +151,7 @@ let testUseEffect = () => {
     [@react.component]
     let make = () => {
       let (count, setCount) = React.useState(() => 0);
-      React.useEffect0(() => {
+      React.use_effect0(() => {
         setCount(count => count + 1);
         None;
       });
@@ -169,7 +169,7 @@ let testUseEffect2 = () => {
     [@react.component]
     let make = (~a, ~b) => {
       let (count, setCount) = React.useState(() => 0);
-      React.useEffect2(
+      React.use_effect2(
         () => {
           setCount(_ => a + b);
           None;
@@ -194,7 +194,7 @@ let testUseEffect3 = () => {
     [@react.component]
     let make = (~a, ~b, ~c) => {
       let (count, setCount) = React.useState(() => 0);
-      React.useEffect3(
+      React.use_effect3(
         () => {
           setCount(count => count + 1);
           None;
@@ -251,7 +251,7 @@ let testUseCallback1 = () => {
         React.useState(() => (0, "init and"));
       let f =
         React.useCallback1(input => {input ++ " " ++ a ++ " and"}, [|a|]);
-      React.useEffect1(
+      React.use_effect1(
         () => {
           setCountStr(((count, str)) => (count + 1, f(str)));
           None;
@@ -310,7 +310,7 @@ let testUseCallback4 = () => {
           },
           (a, b, d, e),
         );
-      React.useEffect1(
+      React.use_effect1(
         () => {
           setCountStr(((count, str)) => (count + 1, f(str)));
           None;
@@ -637,7 +637,7 @@ let testUseMemo1 = () => {
     let make = (~a) => {
       let (count, setCount) = React.useState(() => 0);
       let result = React.useMemo1(() => {a ++ "2"}, [|a|]);
-      React.useEffect1(
+      React.use_effect1(
         () => {
           setCount(count => count + 1);
           None;
@@ -774,7 +774,7 @@ let testUseRef = () => {
     [@react.component]
     let make = (~cb, ()) => {
       let myRef = React.useRef(1);
-      React.useEffect0(() => {
+      React.use_effect0(() => {
         React.Ref.(setCurrent(myRef, current(myRef) + 1));
         cb(myRef);
         None;
@@ -1286,12 +1286,12 @@ let basic =
 
 let context = "context" >::: ["testContext" >:: testContext];
 
-let useEffect =
-  "useEffect"
+let use_effect =
+  "use_effect"
   >::: [
-    "useEffect" >:: testUseEffect,
-    "useEffect2" >:: testUseEffect2,
-    "useEffect3" >:: testUseEffect3,
+    "use_effect" >:: testUseEffect,
+    "use_effect2" >:: testUseEffect2,
+    "use_effect3" >:: testUseEffect3,
   ];
 
 let useCallback =
@@ -1388,7 +1388,7 @@ let suite =
   >::: [
     basic,
     context,
-    useEffect,
+    use_effect,
     useCallback,
     useState,
     useReducer,

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -636,7 +636,7 @@ let testUseMemo1 = () => {
     [@react.component]
     let make = (~a) => {
       let (count, setCount) = React.useState(() => 0);
-      let result = React.useMemo1(() => {a ++ "2"}, [|a|]);
+      let result = React.use_memo1(() => {a ++ "2"}, [|a|]);
       React.use_effect1(
         () => {
           setCount(count => count + 1);
@@ -1319,7 +1319,7 @@ let useReducer =
 let memoization =
   "memo"
   >::: [
-    "useMemo1" >:: testUseMemo1,
+    "use_memo1" >:: testUseMemo1,
     "memo" >:: testMemo,
     "memoCustomCompareProps" >:: testMemoCustomCompareProps,
   ];

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -150,7 +150,7 @@ let testUseEffect = () => {
   module UseEffect = {
     [@react.component]
     let make = () => {
-      let (count, setCount) = React.useState(() => 0);
+      let (count, setCount) = React.use_state(() => 0);
       React.use_effect0(() => {
         setCount(count => count + 1);
         None;
@@ -168,7 +168,7 @@ let testUseEffect2 = () => {
   module Add2 = {
     [@react.component]
     let make = (~a, ~b) => {
-      let (count, setCount) = React.useState(() => 0);
+      let (count, setCount) = React.use_state(() => 0);
       React.use_effect2(
         () => {
           setCount(_ => a + b);
@@ -193,7 +193,7 @@ let testUseEffect3 = () => {
   module Use3 = {
     [@react.component]
     let make = (~a, ~b, ~c) => {
-      let (count, setCount) = React.useState(() => 0);
+      let (count, setCount) = React.use_state(() => 0);
       React.use_effect3(
         () => {
           setCount(count => count + 1);
@@ -248,7 +248,7 @@ let testUseCallback1 = () => {
     [@react.component]
     let make = (~a) => {
       let ((count, str), setCountStr) =
-        React.useState(() => (0, "init and"));
+        React.use_state(() => (0, "init and"));
       let f =
         React.use_callback1(input => {input ++ " " ++ a ++ " and"}, [|a|]);
       React.use_effect1(
@@ -296,7 +296,7 @@ let testUseCallback4 = () => {
   module UseCallback = {
     [@react.component]
     let make = (~a, ~b, ~d, ~e) => {
-      let ((count, str), setCountStr) = React.useState(() => (0, "init"));
+      let ((count, str), setCountStr) = React.use_state(() => (0, "init"));
       let f =
         React.use_callback4(
           _input => {
@@ -393,7 +393,7 @@ let testUseState = () => {
   module DummyStateComponent = {
     [@react.component]
     let make = (~initialValue=0, ()) => {
-      let (counter, setCounter) = React.useState(() => initialValue);
+      let (counter, setCounter) = React.use_state(() => initialValue);
       <>
         <div className="value"> {React.int(counter)} </div>
         <button onClick={_ => setCounter(counter => counter + 1)}>
@@ -450,7 +450,7 @@ let testUseStateUpdaterReference = () => {
     let prevSetCount = ref(None);
     [@react.component]
     let make = () => {
-      let (_count, setCount) = React.useState(() => 0);
+      let (_count, setCount) = React.use_state(() => 0);
       let equal =
         switch (setCount, prevSetCount^) {
         | (r1, Some(r2)) when r1 === r2 => "true"
@@ -635,7 +635,7 @@ let testUseMemo1 = () => {
   module UseMemo = {
     [@react.component]
     let make = (~a) => {
-      let (count, setCount) = React.useState(() => 0);
+      let (count, setCount) = React.use_state(() => 0);
       let result = React.use_memo1(() => {a ++ "2"}, [|a|]);
       React.use_effect1(
         () => {
@@ -1301,10 +1301,10 @@ let use_callback =
     "use_callback4" >:: testUseCallback4,
   ];
 
-let useState =
+let use_state =
   "useState"
   >::: [
-    "useState" >:: testUseState,
+    "use_state" >:: testUseState,
     "useStateUpdaterReference" >:: testUseStateUpdaterReference,
   ];
 
@@ -1390,7 +1390,7 @@ let suite =
     context,
     use_effect,
     use_callback,
-    useState,
+    use_state,
     useReducer,
     memoization,
     refs,

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -476,7 +476,7 @@ let testUseReducer = () => {
     [@react.component]
     let make = (~initialValue=0, ()) => {
       let (state, send) =
-        React.useReducer(
+        React.use_reducer(
           (state, action) =>
             switch (action) {
             | Increment => state + 1
@@ -544,7 +544,7 @@ let testUseReducerWithMapState = () => {
     [@react.component]
     let make = (~initialValue=0, ()) => {
       let (state, send) =
-        React.useReducerWithMapState(
+        React.use_reducer_with_map_state(
           (state, action) =>
             switch (action) {
             | Increment => state + 1
@@ -613,7 +613,7 @@ let testUseReducerDispatchReference = () => {
     let prevDispatch = ref(None);
     [@react.component]
     let make = () => {
-      let (_, dispatch) = React.useReducer((_, _) => 2, 2);
+      let (_, dispatch) = React.use_reducer((_, _) => 2, 2);
       let equal =
         switch (dispatch, prevDispatch^) {
         | (r1, Some(r2)) when r1 === r2 => "true"
@@ -1308,12 +1308,12 @@ let use_state =
     "useStateUpdaterReference" >:: testUseStateUpdaterReference,
   ];
 
-let useReducer =
-  "useReducer"
+let use_reducer =
+  "use_reducer"
   >::: [
-    "useReducer" >:: testUseReducer,
-    "useReducerWithMapState" >:: testUseReducerWithMapState,
-    "useReducerDispatchReference" >:: testUseReducerDispatchReference,
+    "use_reducer" >:: testUseReducer,
+    "use_reducer_with_map_state" >:: testUseReducerWithMapState,
+    "use_reducer_dispatch_reference" >:: testUseReducerDispatchReference,
   ];
 
 let memoization =
@@ -1391,7 +1391,7 @@ let suite =
     use_effect,
     use_callback,
     use_state,
-    useReducer,
+    use_reducer,
     memoization,
     refs,
     children,

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -28,7 +28,7 @@ let withContainer = f => {
   let container = Dom_html.createDiv(doc);
   Dom.appendChild(doc##.body, container);
   let result = f(container);
-  ignore(React.Dom.unmountComponentAtNode(container));
+  ignore(React.Dom.unmount_component_at_node(container));
   Dom.removeChild(doc##.body, container);
   result;
 };

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -807,7 +807,7 @@ let testChildrenMapWithIndex = () => {
     let make = (~children, ()) => {
       <div>
         {React.Children.mapWithIndex(children, (element, index) => {
-           React.cloneElement(
+           React.clone_element(
              element,
              Js_of_ocaml.Js.Unsafe.(
                obj([|
@@ -1132,7 +1132,7 @@ let testWithId = () => {
     [@react.component]
     let make = (~id, ~children, ()) =>
       React.Children.map(children, child =>
-        React.cloneElement(
+        React.clone_element(
           child,
           Js.Unsafe.obj([|
             ("data-testid", Js.Unsafe.inject(Js.string(id))),

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -806,7 +806,7 @@ let testChildrenMapWithIndex = () => {
     [@react.component]
     let make = (~children, ()) => {
       <div>
-        {React.Children.mapWithIndex(children, (element, index) => {
+        {React.Children.map_with_index(children, (element, index) => {
            React.clone_element(
              element,
              Js_of_ocaml.Js.Unsafe.(

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -704,7 +704,7 @@ let testMemoCustomCompareProps = () => {
   module Memoized = {
     [@react.component]
     let make =
-      React.memoCustomCompareProps(
+      React.memo_custom_compare_props(
         (~a) => {
           numRenders := numRenders^ + 1;
           <div>

--- a/test/test_reason.re
+++ b/test/test_reason.re
@@ -121,14 +121,14 @@ let testOptionalPropsLowercase = () => {
 
 let testContext = () => {
   module DummyContext = {
-    let context = React.createContext("foo");
+    let context = React.create_context("foo");
     module Provider = {
       let make = React.Context.Provider.make(context);
     };
     module Consumer = {
       [@react.component]
       let make = () => {
-        let value = React.useContext(context);
+        let value = React.use_context(context);
         <div> {value |> React.string} </div>;
       };
     };


### PR DESCRIPTION
While we're at it making breaking changes, I'd like to follow up with some reorganization and renaming to make the API more ergonomic, such as giving `useEffect0` etc. more meaningful names, dropping unnecessary repetition and verbosity, such as in `React.Dom.create_dom_element_variadic`, using more idiomatic OCaml constructs such as labeled arguments instead of putting `_with_X` in function names, and generally try to clean things up a bit. But I'll do that in a later PR once this has been approved and merged.