### PR TITLE
allow locally abstract type and type constraint on component definitions

### DIFF
--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -681,6 +681,8 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
             spelunk_for_fun_expr inner_fun_expr
         | { pexp_desc = Pexp_sequence (_wrapper_expr, inner_fun_expr) } ->
             spelunk_for_fun_expr inner_fun_expr
+        | {pexp_desc= Pexp_newtype (_label, inner_fun_expr)} ->
+            spelunk_for_fun_expr inner_fun_expr
         | exp ->
             Location.raise_errorf ~loc:exp.pexp_loc
               "react.component calls can only be on function definitions or \

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -80,11 +80,10 @@ let extractChildren ?(removeLastPositionUnit = false) ~loc propsAndChildren =
     | [ (Nolabel, { pexp_desc = Pexp_construct ({ txt = Lident "()" }, None) })
       ] ->
         acc
-    | (Nolabel, {pexp_loc}) :: _rest ->
+    | (Nolabel, { pexp_loc }) :: _rest ->
         Location.raise_errorf ~loc:pexp_loc
           "JSX: found non-labelled argument before the last position"
-    | arg :: rest ->
-        allButLast_ rest (arg :: acc)
+    | arg :: rest -> allButLast_ rest (arg :: acc)
   in
   let allButLast lst = allButLast_ lst [] |> List.rev in
   match
@@ -98,7 +97,7 @@ let extractChildren ?(removeLastPositionUnit = false) ~loc propsAndChildren =
       , if removeLastPositionUnit then allButLast props else props )
   | [ (_, childrenExpr) ], props ->
       (childrenExpr, if removeLastPositionUnit then allButLast props else props)
-  | _first :: (_, {pexp_loc}) :: _rest, _props ->
+  | _first :: (_, { pexp_loc }) :: _rest, _props ->
       Location.raise_errorf ~loc:pexp_loc
         "JSX: somehow there's more than one `children` label"
 
@@ -140,20 +139,18 @@ let filter_attr_name key attr =
 
 (* Finds the name of the variable the binding is assigned to, otherwise raises Invalid_argument *)
 let rec getFnName = function
-  | {ppat_desc= Ppat_var {txt}} ->
-      txt
-  | {ppat_desc= Ppat_constraint (pat, _)} ->
-      getFnName pat
-  | {ppat_loc} ->
+  | { ppat_desc = Ppat_var { txt } } -> txt
+  | { ppat_desc = Ppat_constraint (pat, _) } -> getFnName pat
+  | { ppat_loc } ->
       Location.raise_errorf ~loc:ppat_loc
         "react.component calls cannot be destructured."
 
 (* Lookup the value of `props` otherwise raise Invalid_argument error *)
 let getPropsNameValue _acc (loc, exp) =
   match (loc, exp) with
-  | {txt= Lident "props"}, {pexp_desc= Pexp_ident {txt= Lident str}} ->
-      {propsName= str}
-  | {txt; loc}, _ ->
+  | { txt = Lident "props" }, { pexp_desc = Pexp_ident { txt = Lident str } } ->
+      { propsName = str }
+  | { txt; loc }, _ ->
       Location.raise_errorf ~loc
         "react.component only accepts props as an option, given: %s"
         (Longident.last_exn txt)
@@ -171,15 +168,15 @@ let get_props_attr payload =
       List.fold_left getPropsNameValue default_props recordFields
   | Some
       (PStr
-        ({ pstr_desc=
-             Pstr_eval ({pexp_desc= Pexp_ident {txt= Lident "props"}}, _) }
-        :: _rest ) ) ->
-      {propsName= "props"}
-  | Some (PStr ({pstr_desc= Pstr_eval (_, _); pstr_loc} :: _rest)) ->
+        ({ pstr_desc =
+             Pstr_eval ({ pexp_desc = Pexp_ident { txt = Lident "props" } }, _)
+         }
+        :: _rest)) ->
+      { propsName = "props" }
+  | Some (PStr ({ pstr_desc = Pstr_eval (_, _); pstr_loc } :: _rest)) ->
       Location.raise_errorf ~loc:pstr_loc
         "react.component accepts a record config with props as an options."
-  | _ ->
-      default_props
+  | _ -> default_props
 
 (* Plucks the label, loc, and type_ from an AST node *)
 let pluckLabelDefaultLocType (label, default, _, _, loc, type_) =
@@ -682,9 +679,9 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
             spelunk_for_fun_expr inner_fun_expr
         | { pexp_desc = Pexp_sequence (_wrapper_expr, inner_fun_expr) } ->
             spelunk_for_fun_expr inner_fun_expr
-        | {pexp_desc= Pexp_newtype (_label, inner_fun_expr)} ->
+        | { pexp_desc = Pexp_newtype (_label, inner_fun_expr) } ->
             spelunk_for_fun_expr inner_fun_expr
-        | {pexp_desc= Pexp_constraint (inner_fun_expr, _typ)} ->
+        | { pexp_desc = Pexp_constraint (inner_fun_expr, _typ) } ->
             spelunk_for_fun_expr inner_fun_expr
         | exp ->
             Location.raise_errorf ~loc:exp.pexp_loc

--- a/ppx/test/input_ocaml.ml
+++ b/ppx/test/input_ocaml.ml
@@ -15,6 +15,8 @@ let%component make () = div [||] []
 
 let%component make (type a) ~(foo : a) : _ = div [||] []
 
+let%component make : type a. foo:a -> _ = fun ~foo:_ -> div [||] []
+
 let%component make ~(bar : int option) =
   div [||] [ React.string (string_of_int (Option.value ~default:0 bar)) ] ()
 

--- a/ppx/test/input_ocaml.ml
+++ b/ppx/test/input_ocaml.ml
@@ -13,6 +13,8 @@ let%component make ~children:(first, second) () = div [||] [ first; second ]
 let%component make ?(name = "") = div [||] [ name ]
 let%component make () = div [||] []
 
+let%component make (type a) ~(foo : a) : _ = div [||] []
+
 let%component make ~(bar : int option) =
   div [||] [ React.string (string_of_int (Option.value ~default:0 bar)) ] ()
 

--- a/ppx/test/input_ocaml.ml
+++ b/ppx/test/input_ocaml.ml
@@ -12,9 +12,7 @@ let%component make ~children:kids = div [||] kids
 let%component make ~children:(first, second) () = div [||] [ first; second ]
 let%component make ?(name = "") = div [||] [ name ]
 let%component make () = div [||] []
-
 let%component make (type a) ~(foo : a) : _ = div [||] []
-
 let%component make : type a. foo:a -> _ = fun ~foo:_ -> div [||] []
 
 let%component make ~(bar : int option) =

--- a/ppx/test/pp_ocaml.expected
+++ b/ppx/test/pp_ocaml.expected
@@ -256,6 +256,41 @@ let make =
     [@merlin.hide ])
 let make =
   let make_props
+    : foo:'foo ->
+        ?key:string ->
+          unit ->
+            < foo: 'foo Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t
+    =
+    fun ~foo ->
+      fun ?key ->
+        fun () ->
+          let open Js_of_ocaml.Js.Unsafe in
+            obj
+              [|("key",
+                  (inject
+                     (Js_of_ocaml.Js.Optdef.option
+                        (Option.map Js_of_ocaml.Js.string key))));("foo",
+                                                                    (
+                                                                    inject
+                                                                    foo))|]
+    [@@merlin.hide ] in
+  let make (type a) = (fun ~foo:_ -> div [||] [] : foo:a -> _) in
+  ((let make
+      (Props :
+        < foo: 'foo Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t)
+      =
+      make
+        ~foo:(fun (type res) -> fun (type a0) ->
+                fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                  fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                    -> (Js_of_ocaml.Js.Unsafe.get a0 "foo" : res)
+                (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#foo)) in
+    fun ~foo ->
+      fun ?key ->
+        fun () -> React.create_element make (make_props ?key ~foo ()))
+    [@merlin.hide ])
+let make =
+  let make_props
     : bar:int option ->
         ?key:string ->
           unit ->

--- a/ppx/test/pp_ocaml.expected
+++ b/ppx/test/pp_ocaml.expected
@@ -224,6 +224,38 @@ let make =
     [@merlin.hide ])
 let make =
   let make_props
+    : foo:a ->
+        ?key:string ->
+          unit -> < foo: a Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t
+    =
+    fun ~foo ->
+      fun ?key ->
+        fun () ->
+          let open Js_of_ocaml.Js.Unsafe in
+            obj
+              [|("key",
+                  (inject
+                     (Js_of_ocaml.Js.Optdef.option
+                        (Option.map Js_of_ocaml.Js.string key))));("foo",
+                                                                    (
+                                                                    inject
+                                                                    foo))|]
+    [@@merlin.hide ] in
+  let make (type a) ~foo:(foo : a)  = (div [||] [] : _) in
+  ((let make
+      (Props : < foo: a Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t) =
+      make
+        ~foo:(fun (type res) -> fun (type a0) ->
+                fun (a0 : a0 Js_of_ocaml.Js.t) ->
+                  fun (_ : a0 -> < get: res   ;.. >  Js_of_ocaml.Js.gen_prop)
+                    -> (Js_of_ocaml.Js.Unsafe.get a0 "foo" : res)
+                (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#foo)) in
+    fun ~foo ->
+      fun ?key ->
+        fun () -> React.create_element make (make_props ?key ~foo ()))
+    [@merlin.hide ])
+let make =
+  let make_props
     : bar:int option ->
         ?key:string ->
           unit ->


### PR DESCRIPTION
This makes the ppx not reject locally abstract type definitions (e.g. `(type a)`) and type constraints on component definitions.

For example, these used to be rejected:

```ml
let%component make (type a) ~(foo : a) : _ = div [||] []
let%component make : type a. foo:a -> _ = fun ~foo:_ -> div [||] []
```

with the error

```
react.component calls can only be on function definitions or component wrappers (forward_ref, memo).
```

The latter also produced the error:

```
Fatal error: exception (Invalid_argument "react.component calls cannot be destructured.")
```

Which has been improved, along with a few other errors, by using `Location.raise_errorf` instead of `invalid_arg`.