### PR TITLE
Hooks using OCaml idioms and equality semantics

### DIFF
--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -10,26 +10,31 @@ let use_state initial = Core.use_state (fun () -> initial)
 let use_state_lazy init = Core.use_state init
 let use_reducer = Core.use_reducer
 
-let use_resource ~on:deps ?(equal = ( = )) ~release acquire =
+let use_resource ~on:deps ?(equal = ( = )) ?before_render ~release acquire =
   let last_deps = use_ref deps in
   let resource = use_ref None in
 
   let release () = Option.iter release !resource in
   let acquire () = resource := Some (acquire ()) in
 
-  Core.use_effect_once (fun () ->
-      acquire ();
-      Some release);
+  let init () =
+    acquire ();
+    Some release
+  in
+  let update () =
+    if not (equal deps !last_deps) then begin
+      last_deps := deps;
+      release ();
+      acquire ()
+    end;
+    None
+  in
 
-  Core.use_effect_always (fun () ->
-      if not (equal deps !last_deps) then (
-        last_deps := deps;
-        release ();
-        acquire ());
-      None)
+  Core.use_effect_once ?before_render init;
+  Core.use_effect_always ?before_render update
 
-let use_effect ~on ?equal ?(cleanup = fun () -> ()) f =
-  use_resource ~on ?equal ~release:cleanup f
+let use_effect ~on ?equal ?before_render ?(cleanup = fun () -> ()) f =
+  use_resource ?before_render ~on ?equal ~release:cleanup f
 
 let use_effect_once ?before_render ?cleanup f =
   Core.use_effect_once ?before_render (fun () ->

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -7,10 +7,12 @@ let use_effect ~on ?(release = Fun.const ()) acquire =
   let state = use_ref None in
   let release () = Option.iter release !state in
   let acquire () = state := Some (acquire ()) in
-  Core.use_effect_once (fun () -> acquire () ; Some release) ;
+  Core.use_effect_once (fun () ->
+      acquire ();
+      Some release);
   Core.use_effect_always (fun () ->
       if on <> !last_value then (
-        last_value := on ;
-        release () ;
-        acquire () ) ;
-      None )
+        last_value := on;
+        release ();
+        acquire ());
+      None)

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -2,16 +2,19 @@ let use_ref initial =
   let state, _ = Core.use_state (fun () -> ref initial) in
   state
 
-let use_effect ~on ?(release = Fun.const ()) acquire =
+let use_effect ~on ?(equal = ( = )) ?(release = Fun.const ()) acquire =
   let last_value = use_ref on in
   let state = use_ref None in
+
   let release () = Option.iter release !state in
   let acquire () = state := Some (acquire ()) in
+
   Core.use_effect_once (fun () ->
       acquire ();
       Some release);
+
   Core.use_effect_always (fun () ->
-      if on <> !last_value then (
+      if not (equal on !last_value) then (
         last_value := on;
         release ();
         acquire ());

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -2,11 +2,15 @@ let use_ref initial =
   let state, _ = Core.use_state (fun () -> ref initial) in
   state
 
-let use_effect ~on f =
+let use_effect ~on ?(release = Fun.const ()) acquire =
   let last_value = use_ref on in
-  Core.use_effect_once (fun () -> f () ; None) ;
+  let state = use_ref None in
+  let release () = Option.iter release !state in
+  let acquire () = state := Some (acquire ()) in
+  Core.use_effect_once (fun () -> acquire () ; Some release) ;
   Core.use_effect_always (fun () ->
       if on <> !last_value then (
         last_value := on ;
-        f () ) ;
+        release () ;
+        acquire () ) ;
       None )

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -6,6 +6,10 @@ let use_ref_lazy init =
   let state, _ = Core.use_state (fun () -> ref (init ())) in
   state
 
+let use_state initial = Core.use_state (fun () -> initial)
+let use_state_lazy init = Core.use_state init
+let use_reducer = Core.use_reducer
+
 let use_resource ~on:deps ?(equal = ( = )) ~release acquire =
   let last_deps = use_ref deps in
   let resource = use_ref None in
@@ -27,6 +31,16 @@ let use_resource ~on:deps ?(equal = ( = )) ~release acquire =
 let use_effect ~on ?equal ?(cleanup = fun () -> ()) f =
   use_resource ~on ?equal ~release:cleanup f
 
+let use_effect_once ?before_render ?cleanup f =
+  Core.use_effect_once ?before_render (fun () ->
+      f ();
+      cleanup)
+
+let use_effect_always ?before_render ?cleanup f =
+  Core.use_effect_always ?before_render (fun () ->
+      f ();
+      cleanup)
+
 let use_memo ~on:deps ?(equal = ( = )) f =
   let last_deps = use_ref deps in
   let value = use_ref_lazy (fun () -> f ()) in
@@ -37,3 +51,5 @@ let use_memo ~on:deps ?(equal = ( = )) f =
   end;
 
   !value
+
+let use_context = Core.use_context

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -27,13 +27,13 @@ let use_resource ~on:deps ?(equal = ( = )) ~release acquire =
 let use_effect ~on ?equal ?(cleanup = fun () -> ()) f =
   use_resource ~on ?equal ~release:cleanup f
 
-let use_memo ~on:input ?(equal = ( = )) f =
-  let last_input = use_ref input in
-  let output = use_ref_lazy (fun () -> f input) in
+let use_memo ~on:deps ?(equal = ( = )) f =
+  let last_deps = use_ref deps in
+  let value = use_ref_lazy (fun () -> f ()) in
 
-  if not (equal input !last_input) then begin
-    last_input := input;
-    output := f input
+  if not (equal deps !last_deps) then begin
+    last_deps := deps;
+    value := f ()
   end;
 
-  !output
+  !value

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -23,3 +23,14 @@ let use_effect ~on ?(equal = ( = )) ?(release = Fun.const ()) acquire =
         release ();
         acquire ());
       None)
+
+let use_memo ~on:input ?(equal = ( = )) f =
+  let last_input = use_ref input in
+  let output = use_ref_lazy (fun () -> f input) in
+
+  if not (equal input !last_input) then begin
+    last_input := input;
+    output := f input
+  end;
+
+  !output

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -2,6 +2,10 @@ let use_ref initial =
   let state, _ = Core.use_state (fun () -> ref initial) in
   state
 
+let use_ref_lazy init =
+  let state, _ = Core.use_state (fun () -> ref (init ())) in
+  state
+
 let use_effect ~on ?(equal = ( = )) ?(release = Fun.const ()) acquire =
   let last_value = use_ref on in
   let state = use_ref None in

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -6,23 +6,26 @@ let use_ref_lazy init =
   let state, _ = Core.use_state (fun () -> ref (init ())) in
   state
 
-let use_effect ~on ?(equal = ( = )) ?(release = Fun.const ()) acquire =
-  let last_value = use_ref on in
-  let state = use_ref None in
+let use_resource ~on:deps ?(equal = ( = )) ~release acquire =
+  let last_deps = use_ref deps in
+  let resource = use_ref None in
 
-  let release () = Option.iter release !state in
-  let acquire () = state := Some (acquire ()) in
+  let release () = Option.iter release !resource in
+  let acquire () = resource := Some (acquire ()) in
 
   Core.use_effect_once (fun () ->
       acquire ();
       Some release);
 
   Core.use_effect_always (fun () ->
-      if not (equal on !last_value) then (
-        last_value := on;
+      if not (equal deps !last_deps) then (
+        last_deps := deps;
         release ();
         acquire ());
       None)
+
+let use_effect ~on ?equal ?(cleanup = fun () -> ()) f =
+  use_resource ~on ?equal ~release:cleanup f
 
 let use_memo ~on:input ?(equal = ( = )) f =
   let last_input = use_ref input in

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -1,8 +1,12 @@
+let use_ref initial =
+  let state, _ = Core.use_state (fun () -> ref initial) in
+  state
+
 let use_effect ~on f =
-  let last_value = Core.use_ref on in
+  let last_value = use_ref on in
   Core.use_effect_once (fun () -> f () ; None) ;
   Core.use_effect_always (fun () ->
-      if on <> Core.Ref.current last_value then (
-        Core.Ref.set_current last_value on ;
+      if on <> !last_value then (
+        last_value := on ;
         f () ) ;
       None )

--- a/lib/hooks.ml
+++ b/lib/hooks.ml
@@ -1,0 +1,8 @@
+let use_effect ~on f =
+  let last_value = Core.use_ref on in
+  Core.use_effect_once (fun () -> f () ; None) ;
+  Core.use_effect_always (fun () ->
+      if on <> Core.Ref.current last_value then (
+        Core.Ref.set_current last_value on ;
+        f () ) ;
+      None )

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -11,6 +11,7 @@ val use_reducer :
 val use_effect :
      on:'deps
   -> ?equal:('deps -> 'deps -> bool)
+  -> ?before_render:bool
   -> ?cleanup:(unit -> unit)
   -> (unit -> unit)
   -> unit
@@ -24,6 +25,7 @@ val use_effect_always :
 val use_resource :
      on:'deps
   -> ?equal:('deps -> 'deps -> bool)
+  -> ?before_render:bool
   -> release:('resource -> unit)
   -> (unit -> 'resource)
   -> unit

--- a/lib/hooks.mli
+++ b/lib/hooks.mli
@@ -1,0 +1,34 @@
+val use_ref : 'value -> 'value ref
+val use_ref_lazy : (unit -> 'value) -> 'value ref
+val use_state : 'state -> 'state * (('state -> 'state) -> unit)
+val use_state_lazy : (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
+
+val use_reducer :
+     init:(unit -> 'state)
+  -> ('state -> 'action -> 'state)
+  -> 'state * ('action -> unit)
+
+val use_effect :
+     on:'deps
+  -> ?equal:('deps -> 'deps -> bool)
+  -> ?cleanup:(unit -> unit)
+  -> (unit -> unit)
+  -> unit
+
+val use_effect_once :
+  ?before_render:bool -> ?cleanup:(unit -> unit) -> (unit -> unit) -> unit
+
+val use_effect_always :
+  ?before_render:bool -> ?cleanup:(unit -> unit) -> (unit -> unit) -> unit
+
+val use_resource :
+     on:'deps
+  -> ?equal:('deps -> 'deps -> bool)
+  -> release:('resource -> unit)
+  -> (unit -> 'resource)
+  -> unit
+
+val use_memo :
+  on:'deps -> ?equal:('deps -> 'deps -> bool) -> (unit -> 'value) -> 'value
+
+val use_context : 'value Core.Context.t -> 'value

--- a/lib/react.ml
+++ b/lib/react.ml
@@ -1,4 +1,5 @@
 include Core
+module Hooks = Hooks
 
 module Dom = struct
   include Dom

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -166,11 +166,11 @@ let test_hooks_use_effect () =
       act (fun () -> React.Dom.render (C.make ~a:2 ~b:3 ()) (Html.element c));
       assert_equal !count 2)
 
-let test_hooks_use_effect_release () =
+let test_hooks_use_resource_release () =
   let acquired = ref [] in
   let module C = struct
     let%component make ~a ~b =
-      React.Hooks.use_effect ~on:(a, b)
+      React.Hooks.use_resource ~on:(a, b)
         ~release:(fun resource ->
           if resource = List.hd !acquired then acquired := List.tl !acquired)
         (fun () ->
@@ -922,9 +922,9 @@ let hooks =
   "hooks"
   >::: [ "use_ref" >::: [ "basic" >:: test_hooks_use_ref ]
        ; "use_effect" >::: [ "basic" >:: test_hooks_use_effect ]
-       ; "use_effect" >::: [ "release" >:: test_hooks_use_effect_release ]
        ; "use_effect"
          >::: [ "custom equal" >:: test_hooks_use_effect_custom_equal ]
+       ; "use_resource" >::: [ "release" >:: test_hooks_use_resource_release ]
        ; "use_memo" >::: [ "basic" >:: test_hooks_use_memo ]
        ; "use_memo" >::: [ "custom equal" >:: test_hooks_use_memo_custom_equal ]
        ]

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -204,7 +204,7 @@ let test_hooks_use_memo () =
   let module UseMemo = struct
     let%component make ~a =
       let result =
-        React.Hooks.use_memo ~on:a (fun a ->
+        React.Hooks.use_memo ~on:a (fun () ->
             incr count;
             a ^ Int.to_string !count)
       in
@@ -233,7 +233,7 @@ let test_hooks_use_memo_custom_equal () =
     let%component make ~a ~b =
       let equal a b = fst a = fst b in
       let result =
-        React.Hooks.use_memo ~on:(a, b) ~equal (fun (a, b) ->
+        React.Hooks.use_memo ~on:(a, b) ~equal (fun () ->
             incr count;
             a ^ b ^ Int.to_string !count)
       in

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -137,6 +137,19 @@ let testContext () =
             (Html.element c));
       assert_equal c##.textContent (Js.Opt.return (Js.string "bar")))
 
+let test_hooks_use_effect () =
+  let count = ref 0 in
+  let module C = struct
+    let%component make ~a ~b =
+      React.Hooks.use_effect ~on:(a, b) (fun () -> incr count) ;
+      div [||] []
+  end in
+  withContainer (fun c ->
+      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c)) ;
+      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c)) ;
+      act (fun () -> React.Dom.render (C.make ~a:2 ~b:3 ()) (Html.element c)) ;
+      assert_equal !count 2 )
+
 let test_use_effect_always () =
   let count = ref 0 in
   let module C = struct
@@ -803,6 +816,8 @@ let basic =
 
 let context = "context" >::: [ "testContext" >:: testContext ]
 
+let hooks = "hooks" >::: ["use_effect" >::: ["basic" >:: test_hooks_use_effect]]
+
 let use_effect =
   "use_effect"
   >::: [ "use_effect_always" >:: test_use_effect_always
@@ -881,6 +896,7 @@ let suite =
   "ocaml"
   >::: [ basic
        ; context
+       ; hooks
        ; use_effect
        ; use_callback
        ; use_state

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -142,29 +142,29 @@ let test_hooks_use_ref () =
     let%component make ~cb () =
       let myRef = React.Hooks.use_ref 1 in
       React.use_effect_once (fun () ->
-          myRef := !myRef + 1 ;
-          cb myRef ;
-          None ) ;
+          myRef := !myRef + 1;
+          cb myRef;
+          None);
       div [||] []
   end in
   withContainer (fun c ->
       let myRef = ref None in
       let cb reactRef = myRef := Some reactRef in
-      act (fun () -> React.Dom.render (C.make ~cb ()) (Html.element c)) ;
-      assert_equal (myRef.contents |> Option.map (fun item -> !item)) (Some 2) )
+      act (fun () -> React.Dom.render (C.make ~cb ()) (Html.element c));
+      assert_equal (myRef.contents |> Option.map (fun item -> !item)) (Some 2))
 
 let test_hooks_use_effect () =
   let count = ref 0 in
   let module C = struct
     let%component make ~a ~b =
-      React.Hooks.use_effect ~on:(a, b) (fun () -> incr count) ;
+      React.Hooks.use_effect ~on:(a, b) (fun () -> incr count);
       div [||] []
   end in
   withContainer (fun c ->
-      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c)) ;
-      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c)) ;
-      act (fun () -> React.Dom.render (C.make ~a:2 ~b:3 ()) (Html.element c)) ;
-      assert_equal !count 2 )
+      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c));
+      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c));
+      act (fun () -> React.Dom.render (C.make ~a:2 ~b:3 ()) (Html.element c));
+      assert_equal !count 2)
 
 let test_hooks_use_effect_release () =
   let acquired = ref [] in
@@ -172,18 +172,18 @@ let test_hooks_use_effect_release () =
     let%component make ~a ~b =
       React.Hooks.use_effect ~on:(a, b)
         ~release:(fun resource ->
-          if resource = List.hd !acquired then acquired := List.tl !acquired )
+          if resource = List.hd !acquired then acquired := List.tl !acquired)
         (fun () ->
-          acquired := (a, b) :: !acquired ;
-          (a, b) ) ;
+          acquired := (a, b) :: !acquired;
+          (a, b));
       div [||] []
   end in
   withContainer (fun c ->
-      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c)) ;
-      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c)) ;
-      act (fun () -> React.Dom.render (C.make ~a:2 ~b:3 ()) (Html.element c)) ;
-      act (fun () -> React.Dom.render (div [||] []) (Html.element c)) ;
-      assert_equal !acquired [] )
+      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c));
+      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c));
+      act (fun () -> React.Dom.render (C.make ~a:2 ~b:3 ()) (Html.element c));
+      act (fun () -> React.Dom.render (div [||] []) (Html.element c));
+      assert_equal !acquired [])
 
 let test_use_effect_always () =
   let count = ref 0 in
@@ -853,9 +853,10 @@ let context = "context" >::: [ "testContext" >:: testContext ]
 
 let hooks =
   "hooks"
-  >::: [ "use_ref" >::: ["basic" >:: test_hooks_use_ref]
-       ; "use_effect" >::: ["basic" >:: test_hooks_use_effect]
-       ; "use_effect" >::: ["release" >:: test_hooks_use_effect_release] ]
+  >::: [ "use_ref" >::: [ "basic" >:: test_hooks_use_ref ]
+       ; "use_effect" >::: [ "basic" >:: test_hooks_use_effect ]
+       ; "use_effect" >::: [ "release" >:: test_hooks_use_effect_release ]
+       ]
 
 let use_effect =
   "use_effect"

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -185,6 +185,20 @@ let test_hooks_use_effect_release () =
       act (fun () -> React.Dom.render (div [||] []) (Html.element c));
       assert_equal !acquired [])
 
+let test_hooks_use_effect_custom_equal () =
+  let count = ref 0 in
+  let module C = struct
+    let%component make ~a ~b =
+      let equal a b = fst a = fst b in
+      React.Hooks.use_effect ~equal ~on:(a, b) (fun () -> incr count);
+      div [||] []
+  end in
+  withContainer (fun c ->
+      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c));
+      act (fun () -> React.Dom.render (C.make ~a:1 ~b:3 ()) (Html.element c));
+      act (fun () -> React.Dom.render (C.make ~a:2 ~b:3 ()) (Html.element c));
+      assert_equal !count 2)
+
 let test_use_effect_always () =
   let count = ref 0 in
   let module C = struct
@@ -856,6 +870,8 @@ let hooks =
   >::: [ "use_ref" >::: [ "basic" >:: test_hooks_use_ref ]
        ; "use_effect" >::: [ "basic" >:: test_hooks_use_effect ]
        ; "use_effect" >::: [ "release" >:: test_hooks_use_effect_release ]
+       ; "use_effect"
+         >::: [ "custom equal" >:: test_hooks_use_effect_custom_equal ]
        ]
 
 let use_effect =


### PR DESCRIPTION
Builds on #141, Addresses #153 

This adds a `use_effect` hook that uses OCaml equality semantics, and partly because of that also provides a much nicer API, in my opinion.

I also added a `use_ref` hook using an actual `ref`, because I needed that for `use_effect` and got tired of having to dealing with `React.Ref` when OCaml already has a first class ref cell.

If this API style agrees with y'all too I can go on to add equivalent hooks for `use_memo` and `use_callback`. I also suppose this is a good opportunity to move the old bindings to the reason-react compatibility layer.