### PR TITLE
consistent project-wide formatting

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,1 @@
+profile = default

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,7 @@
 profile = default
+break-separators = before
+dock-collection-brackets = false
+exp-grouping = preserve
+type-decl = sparse
+break-fun-decl = fit-or-vertical
+break-fun-sig = fit-or-vertical

--- a/docs/snippets/.ocamlformat
+++ b/docs/snippets/.ocamlformat
@@ -1,1 +1,0 @@
-profile = ocamlformat

--- a/docs/snippets/basic.ml
+++ b/docs/snippets/basic.ml
@@ -3,7 +3,7 @@ open React.Dom.Dsl
 open Html
 
 module Hello_message = struct
-  let%component make ~name = div [||] [React.string ("Hello " ^ name)]
+  let%component make ~name = div [||] [ React.string ("Hello " ^ name) ]
 end
 
 let () =

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
   (conf-npm :with-test)
 
   ;; Dev dependencies, using with-test so that consumers don't install them (until package is released in opam)
-  (ocamlformat :with-test)
+  (ocamlformat (and (= 0.20.1) :with-test))
   (reason :with-test)
 
   ;; Example dependencies, using with-test so that consumers don't install them (until package is released in opam)

--- a/example/.ocamlformat
+++ b/example/.ocamlformat
@@ -1,4 +1,0 @@
-profile = ocamlformat
-break-separators=after
-dock-collection-brackets=true
-space-around-lists=true

--- a/example/src/HelloWorldOCaml.ml
+++ b/example/src/HelloWorldOCaml.ml
@@ -3,25 +3,20 @@ open Html
 
 let%component make () =
   fragment
-    [
-      a
-        [|
-          href "https://github.com/jchavarri/jsoo-react-realworld-example-app";
-          target "_blank";
+    [ a
+        [| href "https://github.com/jchavarri/jsoo-react-realworld-example-app"
+         ; target "_blank"
         |]
-        [ i [|className "ion-social-github"|] []; string "Fork on GitHub" ];
-      footer [||]
-        [
-          div
-            [|className "container"|]
-            [
-              span
-                [|className "attribution"|]
-                [
-                  string "An interactive learning project from ";
-                  a [|href "https://thinkster.io"|] [ string "Thinkster" ];
-                  string ". Code &amp; design licensed under MIT.";
-                ];
-            ];
-        ];
+        [ i [| className "ion-social-github" |] []; string "Fork on GitHub" ]
+    ; footer [||]
+        [ div
+            [| className "container" |]
+            [ span
+                [| className "attribution" |]
+                [ string "An interactive learning project from "
+                ; a [| href "https://thinkster.io" |] [ string "Thinkster" ]
+                ; string ". Code &amp; design licensed under MIT."
+                ]
+            ]
+        ]
     ]

--- a/example/src/WebComponent.ml
+++ b/example/src/WebComponent.ml
@@ -146,26 +146,22 @@ let oslo_polygon =
 
 let%component make () =
   h "leafy-map" [||]
-    [
-      h "leafy-feature-group"
-        Prop.[|bool "zoom-to-fit" true|]
-        [
-          h "leafy-geojson"
+    [ h "leafy-feature-group"
+        Prop.[| bool "zoom-to-fit" true |]
+        [ h "leafy-geojson"
             Prop.
-              [|
-                string "data" oslo_polygon;
-                string "fill" "forestgreen";
-                string "stroke" "#006400";
-                int "stroke-wdith" 1;
+              [| string "data" oslo_polygon
+               ; string "fill" "forestgreen"
+               ; string "stroke" "#006400"
+               ; int "stroke-wdith" 1
               |]
-            [];
-          h "leafy-marker"
+            []
+        ; h "leafy-marker"
             Prop.
-              [|
-                string "lat" "59.9147857";
-                string "lng" "10.7470423";
-                string "tooltip" "Hello Oslo!";
+              [| string "lat" "59.9147857"
+               ; string "lng" "10.7470423"
+               ; string "tooltip" "Hello Oslo!"
               |]
-            [];
-        ];
+            []
+        ]
     ]

--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -16,7 +16,7 @@ depends: [
   "webtest-js" {with-test}
   "js_of_ocaml-ppx" {with-test}
   "conf-npm" {with-test}
-  "ocamlformat" {with-test}
+  "ocamlformat" {= "0.20.1" & with-test}
   "reason" {with-test}
   "ppx_blob" {with-test}
   "js_of_ocaml-lwt" {with-test}

--- a/lib/.ocamlformat
+++ b/lib/.ocamlformat
@@ -1,1 +1,0 @@
-profile = ocamlformat

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -1,5 +1,5 @@
-(** A React element *)
 type element = private Ojs.t
+(** A React element *)
 
 val element_of_js : Ojs.t -> element
 (** Conversion function for gen_js_api *)
@@ -12,27 +12,21 @@ val null : element
 (** A React element that will render the [null] value *)
 
 val string : string -> element [@@js.cast]
-
 val int : int -> element [@@js.cast]
-
 val float : float -> element [@@js.cast]
 
 [@@@js.stop]
 
 type 'a option_undefined = 'a option
-
 type 'a js_nullable = 'a Js_of_ocaml.Js.Opt.t
 
 val js_nullable_of_js : (Ojs.t -> 'value) -> Ojs.t -> 'value js_nullable
-
 val js_nullable_to_js : ('value -> Ojs.t) -> 'value js_nullable -> Ojs.t
 
 type ('props, 'return) componentLike = 'props -> 'return
-
 type 'props component = ('props, element) componentLike
 
 val component_of_js : 'a -> 'a
-
 val component_to_js : 'a -> 'a
 
 type ('input, 'output) callback = 'input -> 'output
@@ -41,37 +35,29 @@ type ('input, 'output) callback = 'input -> 'output
 
 [@@@js.implem
 type 'a option_undefined = 'a option
-
 type 'a js_nullable = 'a Js_of_ocaml.Js.Opt.t
 
 external equals : Ojs.t -> Ojs.t -> bool = "caml_js_equals"
 
 let undefined = Ojs.variable "undefined"
-
 let option_undefined_of_js f x = if equals x undefined then None else Some (f x)
-
 let option_undefined_to_js f = function Some x -> f x | None -> undefined
 
 external js_nullable_of_ojs : Ojs.t -> 'value js_nullable = "%identity"
-
 external js_nullable_to_js : 'value js_nullable -> Ojs.t = "%identity"
 
 let js_nullable_of_js _f x = js_nullable_of_ojs x
-
 let js_nullable_to_js _f x = js_nullable_to_js x
 
 type ('props, 'return) componentLike = 'props -> 'return
-
 type 'props component = ('props, element) componentLike
 
 let component_to_js cb = cb
-
 let component_of_js js = js
 
 type ('input, 'output) callback = 'input -> 'output
 
 let callback_to_js _ cb = cb
-
 let callback_of_js _ js = js]
 
 val create_element : 'props component -> 'props -> element
@@ -159,7 +145,7 @@ val use_effect1 :
 
     let use_effect1 ?(before_render = false) f value =
       (if before_render then _use_layout_effect else _use_effect)
-        Imports.react f [|value|]]
+        Imports.react f [| value |]]
 
 val use_effect2 :
      ?before_render:bool
@@ -318,7 +304,7 @@ val use_callback1 :
       [@@js.call "useCallback"]
 
     let use_callback1 callback watchlist =
-      use_callback1_internal Imports.react callback [|watchlist|]]
+      use_callback1_internal Imports.react callback [| watchlist |]]
 
 val use_callback2 :
   ('input, 'output) callback -> 'a * 'b -> ('input, 'output) callback
@@ -411,7 +397,7 @@ val use_memo1 : (unit -> 'value) -> 'a -> 'value
       [@@js.call "useMemo"]
 
     let use_memo1 callback watchlist =
-      use_memo1_internal Imports.react callback [|watchlist|]]
+      use_memo1_internal Imports.react callback [| watchlist |]]
 
 val use_memo2 : (unit -> 'value) -> 'a * 'b -> 'value
   [@@js.custom
@@ -475,13 +461,13 @@ val use_state : (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
     let (use_state_internal :
              Imports.react
           -> (unit -> 'state)
-          -> 'state * (('state -> 'state) -> unit) ) =
+          -> 'state * (('state -> 'state) -> unit)) =
      fun (react : Imports.react) (init : unit -> 'state) ->
       let result =
         Ojs.call
           (Imports.react_to_js react)
           "useState"
-          [|Ojs.fun_to_js 1 (fun _ -> Obj.magic (init ()))|]
+          [| Ojs.fun_to_js 1 (fun _ -> Obj.magic (init ())) |]
       in
       (Obj.magic (Ojs.array_get result 0), Obj.magic (Ojs.array_get result 1))
 
@@ -509,9 +495,10 @@ val use_reducer :
                  any_to_js
                    (reducer
                       (js_to_any state : state)
-                      (js_to_any action : action) ) )
+                      (js_to_any action : action)))
            ; Ojs.null
-           ; Ojs.fun_to_js 1 (fun _ -> any_to_js (init ())) |]
+           ; Ojs.fun_to_js 1 (fun _ -> any_to_js (init ()))
+          |]
       in
       Js_of_ocaml.(Js.Unsafe.get result 0, Js.Unsafe.get result 1)
 
@@ -531,13 +518,11 @@ module Ref : sig
   [@@@js.stop]
 
   val t_of_js : (Ojs.t -> 'value) -> Ojs.t -> 'value t
-
   val t_to_js : ('value -> Ojs.t) -> 'value t -> Ojs.t
 
   [@@@js.start]
 
   val current : 'value t -> 'value [@@js.get "current"]
-
   val set_current : 'value t -> 'value -> unit [@@js.set "current"]
 end
 
@@ -565,7 +550,7 @@ module Context : sig
       'props t -> value:'props -> children:element list -> unit -> element
       [@@js.custom
         let make_props value =
-          Js_of_ocaml.Js.Unsafe.(obj [|("value", inject value)|])
+          Js_of_ocaml.Js.Unsafe.(obj [| ("value", inject value) |])
 
         let make context ~value ~children () =
           create_element_variadic (provider context) (make_props value) children]
@@ -643,8 +628,9 @@ module Fragment : sig
     [@@js.custom
       external to_component :
            Ojs.t
-        -> < children: element Js_of_ocaml.Js.readonly_prop > Js_of_ocaml.Js.t
-           component = "%identity"
+        -> < children : element Js_of_ocaml.Js.readonly_prop > Js_of_ocaml.Js.t
+           component
+        = "%identity"
 
       val fragment_internal' : Imports.react -> Ojs.t [@@js.get "Fragment"]
 
@@ -652,10 +638,8 @@ module Fragment : sig
 
       let make_props ?key () =
         match key with
-        | Some k ->
-            Js_of_ocaml.Js.Unsafe.(obj [|("key", inject k)|])
-        | None ->
-            Js_of_ocaml.Js.Unsafe.(obj [||])
+        | Some k -> Js_of_ocaml.Js.Unsafe.(obj [| ("key", inject k) |])
+        | None -> Js_of_ocaml.Js.Unsafe.(obj [||])
 
       let make ~children ?key () =
         create_element_variadic

--- a/lib/dom.mli
+++ b/lib/dom.mli
@@ -3,7 +3,6 @@
 type dom_element = Js_of_ocaml.Dom_html.element Js_of_ocaml.Js.t
 
 val dom_element_to_js : dom_element -> Ojs.t
-
 val dom_element_of_js : Ojs.t -> dom_element
 
 [@@@js.start]
@@ -12,7 +11,6 @@ val dom_element_of_js : Ojs.t -> dom_element
 type dom_element = Js_of_ocaml.Dom_html.element Js_of_ocaml.Js.t
 
 external dom_element_to_js : dom_element -> Ojs.t = "%identity"
-
 external dom_element_of_js : Ojs.t -> dom_element = "%identity"]
 
 val unmount_component_at_node : dom_element -> bool
@@ -43,31 +41,26 @@ val render_to_element : id:string -> Core.element -> unit
       | None ->
           raise
             (Invalid_argument
-               ( "ReactDOM.render_to_element : no element of id " ^ id
-               ^ " found in the HTML." ) )
-      | Some element ->
-          render react_element element]
+               ("ReactDOM.render_to_element : no element of id " ^ id
+              ^ " found in the HTML."))
+      | Some element -> render react_element element]
 
 type dom_ref = private Ojs.t
 
 module Ref : sig
   type t = dom_ref
-
   type current_dom_ref = dom_element Core.js_nullable Core.Ref.t
-
   type callback_dom_ref = dom_element Core.js_nullable -> unit
 
   [@@@js.stop]
 
   val dom_ref : current_dom_ref -> dom_ref
-
   val callback_dom_ref : callback_dom_ref -> dom_ref
 
   [@@@js.start]
 
   [@@@js.implem
   external dom_ref : current_dom_ref -> dom_ref = "%identity"
-
   external callback_dom_ref : callback_dom_ref -> dom_ref = "%identity"]
 end
 
@@ -108,1401 +101,714 @@ module Style : sig
   [@@@js.stop]
 
   type decl
-
   type t = block
 
   val make : decl array -> block
-
   val azimuth : string -> decl
-
   val background : string -> decl
-
   val background_attachment : string -> decl
-
   val background_color : string -> decl
-
   val background_image : string -> decl
-
   val background_position : string -> decl
-
   val background_repeat : string -> decl
-
   val border : string -> decl
-
   val border_collapse : string -> decl
-
   val border_color : string -> decl
-
   val border_spacing : string -> decl
-
   val border_style : string -> decl
-
   val border_top : string -> decl
-
   val border_right : string -> decl
-
   val border_bottom : string -> decl
-
   val border_left : string -> decl
-
   val border_top_color : string -> decl
-
   val border_right_color : string -> decl
-
   val border_bottom_color : string -> decl
-
   val border_left_color : string -> decl
-
   val border_top_style : string -> decl
-
   val border_right_style : string -> decl
-
   val border_bottom_style : string -> decl
-
   val border_left_style : string -> decl
-
   val border_top_width : string -> decl
-
   val border_right_width : string -> decl
-
   val border_bottom_width : string -> decl
-
   val border_left_width : string -> decl
-
   val border_width : string -> decl
-
   val bottom : string -> decl
-
   val caption_side : string -> decl
-
   val clear : string -> decl
-
   val color : string -> decl
-
   val content : string -> decl
-
   val counter_increment : string -> decl
-
   val counter_reset : string -> decl
-
   val cue : string -> decl
-
   val cue_after : string -> decl
-
   val cue_before : string -> decl
-
   val direction : string -> decl
-
   val display : string -> decl
-
   val elevation : string -> decl
-
   val empty_cells : string -> decl
-
   val float : string -> decl
-
   val font : string -> decl
-
   val font_family : string -> decl
-
   val font_size : string -> decl
-
   val font_size_adjust : string -> decl
-
   val font_stretch : string -> decl
-
   val font_style : string -> decl
-
   val font_variant : string -> decl
-
   val font_weight : string -> decl
-
   val height : string -> decl
-
   val left : string -> decl
-
   val letter_spacing : string -> decl
-
   val line_height : string -> decl
-
   val list_style : string -> decl
-
   val list_style_image : string -> decl
-
   val list_style_position : string -> decl
-
   val list_style_type : string -> decl
-
   val margin : string -> decl
-
   val margin_top : string -> decl
-
   val margin_right : string -> decl
-
   val margin_bottom : string -> decl
-
   val margin_left : string -> decl
-
   val marker_offset : string -> decl
-
   val marks : string -> decl
-
   val max_height : string -> decl
-
   val max_width : string -> decl
-
   val min_height : string -> decl
-
   val min_width : string -> decl
-
   val orphans : string -> decl
-
   val outline : string -> decl
-
   val outline_color : string -> decl
-
   val outline_style : string -> decl
-
   val outline_width : string -> decl
-
   val overflow : string -> decl
-
   val overflow_x : string -> decl
-
   val overflow_y : string -> decl
-
   val padding : string -> decl
-
   val padding_top : string -> decl
-
   val padding_right : string -> decl
-
   val padding_bottom : string -> decl
-
   val padding_left : string -> decl
-
   val page : string -> decl
-
   val page_break_after : string -> decl
-
   val page_break_before : string -> decl
-
   val page_break_inside : string -> decl
-
   val pause : string -> decl
-
   val pause_after : string -> decl
-
   val pause_before : string -> decl
-
   val pitch : string -> decl
-
   val pitch_range : string -> decl
-
   val play_during : string -> decl
-
   val position : string -> decl
-
   val quotes : string -> decl
-
   val richness : string -> decl
-
   val right : string -> decl
-
   val size : string -> decl
-
   val speak : string -> decl
-
   val speak_header : string -> decl
-
   val speak_numeral : string -> decl
-
   val speak_punctuation : string -> decl
-
   val speech_rate : string -> decl
-
   val stress : string -> decl
-
   val table_layout : string -> decl
-
   val text_align : string -> decl
-
   val text_decoration : string -> decl
-
   val text_indent : string -> decl
-
   val text_shadow : string -> decl
-
   val text_transform : string -> decl
-
   val top : string -> decl
-
   val unicode_bidi : string -> decl
-
   val vertical_align : string -> decl
-
   val visibility : string -> decl
-
   val voice_family : string -> decl
-
   val volume : string -> decl
-
   val white_space : string -> decl
-
   val widows : string -> decl
-
   val width : string -> decl
-
   val word_spacing : string -> decl
-
   val z_index : string -> decl
-
   val opacity : string -> decl
-
   val background_origin : string -> decl
-
   val background_size : string -> decl
-
   val background_clip : string -> decl
-
   val border_radius : string -> decl
-
   val border_top_left_radius : string -> decl
-
   val border_top_right_radius : string -> decl
-
   val border_bottom_left_radius : string -> decl
-
   val border_bottom_right_radius : string -> decl
-
   val border_image : string -> decl
-
   val border_image_source : string -> decl
-
   val border_image_slice : string -> decl
-
   val border_image_width : string -> decl
-
   val border_image_outset : string -> decl
-
   val border_image_repeat : string -> decl
-
   val box_shadow : string -> decl
-
   val columns : string -> decl
-
   val column_count : string -> decl
-
   val column_fill : string -> decl
-
   val column_gap : string -> decl
-
   val column_rule : string -> decl
-
   val column_rule_color : string -> decl
-
   val column_rule_style : string -> decl
-
   val column_rule_width : string -> decl
-
   val column_span : string -> decl
-
   val column_width : string -> decl
-
   val break_after : string -> decl
-
   val break_before : string -> decl
-
   val break_inside : string -> decl
-
   val rest : string -> decl
-
   val rest_after : string -> decl
-
   val rest_before : string -> decl
-
   val speak_as : string -> decl
-
   val voice_balance : string -> decl
-
   val voice_duration : string -> decl
-
   val voice_pitch : string -> decl
-
   val voice_range : string -> decl
-
   val voice_rate : string -> decl
-
   val voice_stress : string -> decl
-
   val voice_volume : string -> decl
-
   val object_fit : string -> decl
-
   val object_position : string -> decl
-
   val image_resolution : string -> decl
-
   val image_orientation : string -> decl
-
   val align_content : string -> decl
-
   val align_items : string -> decl
-
   val align_self : string -> decl
-
   val flex : string -> decl
-
   val flex_basis : string -> decl
-
   val flex_direction : string -> decl
-
   val flex_flow : string -> decl
-
   val flex_grow : string -> decl
-
   val flex_shrink : string -> decl
-
   val flex_wrap : string -> decl
-
   val justify_content : string -> decl
-
   val order : string -> decl
-
   val text_decoration_color : string -> decl
-
   val text_decoration_line : string -> decl
-
   val text_decoration_skip : string -> decl
-
   val text_decoration_style : string -> decl
-
   val text_emphasis : string -> decl
-
   val text_emphasis_color : string -> decl
-
   val text_emphasis_position : string -> decl
-
   val text_emphasis_style : string -> decl
-
   val text_underline_position : string -> decl
-
   val font_feature_settings : string -> decl
-
   val font_kerning : string -> decl
-
   val font_language_override : string -> decl
-
   val font_synthesis : string -> decl
-
   val fornt_variant_alternates : string -> decl
-
   val font_variant_caps : string -> decl
-
   val font_variant_east_asian : string -> decl
-
   val font_variant_ligatures : string -> decl
-
   val font_variant_numeric : string -> decl
-
   val font_variant_position : string -> decl
-
   val all : string -> decl
-
   val text_combine_upright : string -> decl
-
   val text_orientation : string -> decl
-
   val writing_mode : string -> decl
-
   val shape_image_threshold : string -> decl
-
   val shape_margin : string -> decl
-
   val shape_outside : string -> decl
-
   val mask : string -> decl
-
   val mask_border : string -> decl
-
   val mask_border_mode : string -> decl
-
   val mask_border_outset : string -> decl
-
   val mask_border_repeat : string -> decl
-
   val mask_border_slice : string -> decl
-
   val mask_border_source : string -> decl
-
   val mask_border_width : string -> decl
-
   val mask_clip : string -> decl
-
   val mask_composite : string -> decl
-
   val mask_image : string -> decl
-
   val mask_mode : string -> decl
-
   val mask_origin : string -> decl
-
   val mask_position : string -> decl
-
   val mask_repeat : string -> decl
-
   val mask_size : string -> decl
-
   val mask_type : string -> decl
-
   val background_blend_mode : string -> decl
-
   val isolation : string -> decl
-
   val mix_blend_mode : string -> decl
-
   val box_decoration_break : string -> decl
-
   val box_sizing : string -> decl
-
   val caret_color : string -> decl
-
   val nav_down : string -> decl
-
   val nav_left : string -> decl
-
   val nav_right : string -> decl
-
   val nav_up : string -> decl
-
   val outline_offset : string -> decl
-
   val resize : string -> decl
-
   val text_overflow : string -> decl
-
   val grid : string -> decl
-
   val grid_area : string -> decl
-
   val grid_auto_columns : string -> decl
-
   val grid_auto_flow : string -> decl
-
   val grid_auto_rows : string -> decl
-
   val grid_column : string -> decl
-
   val grid_column_end : string -> decl
-
   val grid_column_gap : string -> decl
-
   val grid_column_start : string -> decl
-
   val grid_gap : string -> decl
-
   val grid_row : string -> decl
-
   val grid_row_end : string -> decl
-
   val grid_row_gap : string -> decl
-
   val grid_row_start : string -> decl
-
   val grid_template : string -> decl
-
   val grid_template_areas : string -> decl
-
   val grid_template_columns : string -> decl
-
   val grid_template_rows : string -> decl
-
   val will_change : string -> decl
-
   val hanging_punctuation : string -> decl
-
   val hyphens : string -> decl
-
   val line_break : string -> decl
-
   val overflow_wrap : string -> decl
-
   val tab_size : string -> decl
-
   val text_align_last : string -> decl
-
   val text_justify : string -> decl
-
   val word_break : string -> decl
-
   val word_wrap : string -> decl
-
   val animation : string -> decl
-
   val animation_delay : string -> decl
-
   val animation_direction : string -> decl
-
   val animation_duration : string -> decl
-
   val animation_fill_mode : string -> decl
-
   val animation_iteration_count : string -> decl
-
   val animation_name : string -> decl
-
   val animation_play_state : string -> decl
-
   val animation_timing_function : string -> decl
-
   val transition : string -> decl
-
   val transition_delay : string -> decl
-
   val transition_duration : string -> decl
-
   val transition_property : string -> decl
-
   val transition_timing_function : string -> decl
-
   val backface_visibility : string -> decl
-
   val perspective : string -> decl
-
   val perspective_origin : string -> decl
-
   val transform : string -> decl
-
   val transform_origin : string -> decl
-
   val transform_style : string -> decl
-
   val justify_items : string -> decl
-
   val justify_self : string -> decl
-
   val place_content : string -> decl
-
   val place_items : string -> decl
-
   val place_self : string -> decl
-
   val appearance : string -> decl
-
   val caret : string -> decl
-
   val caret_animation : string -> decl
-
   val caret_shape : string -> decl
-
   val user_select : string -> decl
-
   val max_lines : string -> decl
-
   val marquee_direction : string -> decl
-
   val marquee_loop : string -> decl
-
   val marquee_speed : string -> decl
-
   val marquee_style : string -> decl
-
   val overflow_style : string -> decl
-
   val rotation : string -> decl
-
   val rotation_point : string -> decl
-
   val alignment_baseline : string -> decl
-
   val baseline_shift : string -> decl
-
   val clip : string -> decl
-
   val clip_path : string -> decl
-
   val clip_rule : string -> decl
-
   val color_interpolation : string -> decl
-
   val color_interpolation_filters : string -> decl
-
   val color_profile : string -> decl
-
   val color_rendering : string -> decl
-
   val cursor : string -> decl
-
   val dominant_baseline : string -> decl
-
   val fill : string -> decl
-
   val fill_opacity : string -> decl
-
   val fill_rule : string -> decl
-
   val filter : string -> decl
-
   val flood_color : string -> decl
-
   val flood_opacity : string -> decl
-
   val glyph_orientation_horizontal : string -> decl
-
   val glyph_orientation_vertical : string -> decl
-
   val image_rendering : string -> decl
-
   val kerning : string -> decl
-
   val lighting_color : string -> decl
-
   val marker_end : string -> decl
-
   val marker_mid : string -> decl
-
   val marker_start : string -> decl
-
   val pointer_events : string -> decl
-
   val shape_rendering : string -> decl
-
   val stop_color : string -> decl
-
   val stop_opacity : string -> decl
-
   val stroke : string -> decl
-
   val stroke_dasharray : string -> decl
-
   val stroke_dashoffset : string -> decl
-
   val stroke_linecap : string -> decl
-
   val stroke_linejoin : string -> decl
-
   val stroke_miterlimit : string -> decl
-
   val stroke_opacity : string -> decl
-
   val stroke_width : string -> decl
-
   val text_anchor : string -> decl
-
   val text_rendering : string -> decl
-
   val ruby_align : string -> decl
-
   val ruby_merge : string -> decl
-
   val ruby_position : string -> decl
 
   [@@@js.start]
 
   [@@@js.implem
   type decl = string * Js_of_ocaml.Js.Unsafe.any
-
   type t = block
 
   let string_style_prop property value =
     (property, Js_of_ocaml.Js.Unsafe.inject (Js_of_ocaml.Js.string value))
 
   let make = Js_of_ocaml.Js.Unsafe.obj
-
   let azimuth = string_style_prop "azimuth"
-
   let background = string_style_prop "background"
-
   let background_attachment = string_style_prop "backgroundAttachment"
-
   let background_color = string_style_prop "backgroundColor"
-
   let background_image = string_style_prop "backgroundImage"
-
   let background_position = string_style_prop "backgroundPosition"
-
   let background_repeat = string_style_prop "backgroundRepeat"
-
   let border = string_style_prop "border"
-
   let border_collapse = string_style_prop "borderCollapse"
-
   let border_color = string_style_prop "borderColor"
-
   let border_spacing = string_style_prop "borderSpacing"
-
   let border_style = string_style_prop "borderStyle"
-
   let border_top = string_style_prop "borderTop"
-
   let border_right = string_style_prop "borderRight"
-
   let border_bottom = string_style_prop "borderBottom"
-
   let border_left = string_style_prop "borderLeft"
-
   let border_top_color = string_style_prop "borderTopColor"
-
   let border_right_color = string_style_prop "borderRightColor"
-
   let border_bottom_color = string_style_prop "borderBottomColor"
-
   let border_left_color = string_style_prop "borderLeftColor"
-
   let border_top_style = string_style_prop "borderTopStyle"
-
   let border_right_style = string_style_prop "borderRightStyle"
-
   let border_bottom_style = string_style_prop "borderBottomStyle"
-
   let border_left_style = string_style_prop "borderLeftStyle"
-
   let border_top_width = string_style_prop "borderTopWidth"
-
   let border_right_width = string_style_prop "borderRightWidth"
-
   let border_bottom_width = string_style_prop "borderBottomWidth"
-
   let border_left_width = string_style_prop "borderLeftWidth"
-
   let border_width = string_style_prop "borderWidth"
-
   let bottom = string_style_prop "bottom"
-
   let caption_side = string_style_prop "captionSide"
-
   let clear = string_style_prop "clear"
-
   let clip = string_style_prop "clip"
-
   let color = string_style_prop "color"
-
   let content = string_style_prop "content"
-
   let counter_increment = string_style_prop "counterIncrement"
-
   let counter_reset = string_style_prop "counterReset"
-
   let cue = string_style_prop "cue"
-
   let cue_after = string_style_prop "cueAfter"
-
   let cue_before = string_style_prop "cueBefore"
-
   let cursor = string_style_prop "cursor"
-
   let direction = string_style_prop "direction"
-
   let display = string_style_prop "display"
-
   let elevation = string_style_prop "elevation"
-
   let empty_cells = string_style_prop "emptyCells"
-
   let float = string_style_prop "float"
-
   let font = string_style_prop "font"
-
   let font_family = string_style_prop "fontFamily"
-
   let font_size = string_style_prop "fontSize"
-
   let font_size_adjust = string_style_prop "fontSizeAdjust"
-
   let font_stretch = string_style_prop "fontStretch"
-
   let font_style = string_style_prop "fontStyle"
-
   let font_variant = string_style_prop "fontVariant"
-
   let font_weight = string_style_prop "fontWeight"
-
   let height = string_style_prop "height"
-
   let left = string_style_prop "left"
-
   let letter_spacing = string_style_prop "letterSpacing"
-
   let line_height = string_style_prop "lineHeight"
-
   let list_style = string_style_prop "listStyle"
-
   let list_style_image = string_style_prop "listStyleImage"
-
   let list_style_position = string_style_prop "listStylePosition"
-
   let list_style_type = string_style_prop "listStyleType"
-
   let margin = string_style_prop "margin"
-
   let margin_top = string_style_prop "marginTop"
-
   let margin_right = string_style_prop "marginRight"
-
   let margin_bottom = string_style_prop "marginBottom"
-
   let margin_left = string_style_prop "marginLeft"
-
   let marker_offset = string_style_prop "markerOffset"
-
   let marks = string_style_prop "marks"
-
   let max_height = string_style_prop "maxHeight"
-
   let max_width = string_style_prop "maxWidth"
-
   let min_height = string_style_prop "minHeight"
-
   let min_width = string_style_prop "minWidth"
-
   let orphans = string_style_prop "orphans"
-
   let outline = string_style_prop "outline"
-
   let outline_color = string_style_prop "outlineColor"
-
   let outline_style = string_style_prop "outlineStyle"
-
   let outline_width = string_style_prop "outlineWidth"
-
   let overflow = string_style_prop "overflow"
-
   let overflow_x = string_style_prop "overflowX"
-
   let overflow_y = string_style_prop "overflowY"
-
   let padding = string_style_prop "padding"
-
   let padding_top = string_style_prop "paddingTop"
-
   let padding_right = string_style_prop "paddingRight"
-
   let padding_bottom = string_style_prop "paddingBottom"
-
   let padding_left = string_style_prop "paddingLeft"
-
   let page = string_style_prop "page"
-
   let page_break_after = string_style_prop "pageBreakAfter"
-
   let page_break_before = string_style_prop "pageBreakBefore"
-
   let page_break_inside = string_style_prop "pageBreakInside"
-
   let pause = string_style_prop "pause"
-
   let pause_after = string_style_prop "pauseAfter"
-
   let pause_before = string_style_prop "pauseBefore"
-
   let pitch = string_style_prop "pitch"
-
   let pitch_range = string_style_prop "pitchRange"
-
   let play_during = string_style_prop "playDuring"
-
   let position = string_style_prop "position"
-
   let quotes = string_style_prop "quotes"
-
   let richness = string_style_prop "richness"
-
   let right = string_style_prop "right"
-
   let size = string_style_prop "size"
-
   let speak = string_style_prop "speak"
-
   let speak_header = string_style_prop "speakHeader"
-
   let speak_numeral = string_style_prop "speakNumeral"
-
   let speak_punctuation = string_style_prop "speakPunctuation"
-
   let speech_rate = string_style_prop "speechRate"
-
   let stress = string_style_prop "stress"
-
   let table_layout = string_style_prop "tableLayout"
-
   let text_align = string_style_prop "textAlign"
-
   let text_decoration = string_style_prop "textDecoration"
-
   let text_indent = string_style_prop "textIndent"
-
   let text_shadow = string_style_prop "textShadow"
-
   let text_transform = string_style_prop "textTransform"
-
   let top = string_style_prop "top"
-
   let unicode_bidi = string_style_prop "unicodeBidi"
-
   let vertical_align = string_style_prop "verticalAlign"
-
   let visibility = string_style_prop "visibility"
-
   let voice_family = string_style_prop "voiceFamily"
-
   let volume = string_style_prop "volume"
-
   let white_space = string_style_prop "whiteSpace"
-
   let widows = string_style_prop "widows"
-
   let width = string_style_prop "width"
-
   let word_spacing = string_style_prop "wordSpacing"
-
   let z_index = string_style_prop "zIndex"
-
   let opacity = string_style_prop "opacity"
-
   let background_origin = string_style_prop "backgroundOrigin"
-
   let background_size = string_style_prop "backgroundSize"
-
   let background_clip = string_style_prop "backgroundClip"
-
   let border_radius = string_style_prop "borderRadius"
-
   let border_top_left_radius = string_style_prop "borderTopLeftRadius"
-
   let border_top_right_radius = string_style_prop "borderTopRightRadius"
-
   let border_bottom_left_radius = string_style_prop "borderBottomLeftRadius"
-
   let border_bottom_right_radius = string_style_prop "borderBottomRightRadius"
-
   let border_image = string_style_prop "borderImage"
-
   let border_image_source = string_style_prop "borderImageSource"
-
   let border_image_slice = string_style_prop "borderImageSlice"
-
   let border_image_width = string_style_prop "borderImageWidth"
-
   let border_image_outset = string_style_prop "borderImageOutset"
-
   let border_image_repeat = string_style_prop "borderImageRepeat"
-
   let box_shadow = string_style_prop "boxShadow"
-
   let columns = string_style_prop "columns"
-
   let column_count = string_style_prop "columnCount"
-
   let column_fill = string_style_prop "columnFill"
-
   let column_gap = string_style_prop "columnGap"
-
   let column_rule = string_style_prop "columnRule"
-
   let column_rule_color = string_style_prop "columnRuleColor"
-
   let column_rule_style = string_style_prop "columnRuleStyle"
-
   let column_rule_width = string_style_prop "columnRuleWidth"
-
   let column_span = string_style_prop "columnSpan"
-
   let column_width = string_style_prop "columnWidth"
-
   let break_after = string_style_prop "breakAfter"
-
   let break_before = string_style_prop "breakBefore"
-
   let break_inside = string_style_prop "breakInside"
-
   let rest = string_style_prop "rest"
-
   let rest_after = string_style_prop "restAfter"
-
   let rest_before = string_style_prop "restBefore"
-
   let speak_as = string_style_prop "speakAs"
-
   let voice_balance = string_style_prop "voiceBalance"
-
   let voice_duration = string_style_prop "voiceDuration"
-
   let voice_pitch = string_style_prop "voicePitch"
-
   let voice_range = string_style_prop "voiceRange"
-
   let voice_rate = string_style_prop "voiceRate"
-
   let voice_stress = string_style_prop "voiceStress"
-
   let voice_volume = string_style_prop "voiceVolume"
-
   let object_fit = string_style_prop "objectFit"
-
   let object_position = string_style_prop "objectPosition"
-
   let image_resolution = string_style_prop "imageResolution"
-
   let image_orientation = string_style_prop "imageOrientation"
-
   let align_content = string_style_prop "alignContent"
-
   let align_items = string_style_prop "alignItems"
-
   let align_self = string_style_prop "alignSelf"
-
   let flex = string_style_prop "flex"
-
   let flex_basis = string_style_prop "flexBasis"
-
   let flex_direction = string_style_prop "flexDirection"
-
   let flex_flow = string_style_prop "flexFlow"
-
   let flex_grow = string_style_prop "flexGrow"
-
   let flex_shrink = string_style_prop "flexShrink"
-
   let flex_wrap = string_style_prop "flexWrap"
-
   let justify_content = string_style_prop "justifyContent"
-
   let order = string_style_prop "order"
-
   let text_decoration_color = string_style_prop "textDecorationColor"
-
   let text_decoration_line = string_style_prop "textDecorationLine"
-
   let text_decoration_skip = string_style_prop "textDecorationSkip"
-
   let text_decoration_style = string_style_prop "textDecorationStyle"
-
   let text_emphasis = string_style_prop "textEmphasis"
-
   let text_emphasis_color = string_style_prop "textEmphasisColor"
-
   let text_emphasis_position = string_style_prop "textEmphasisPosition"
-
   let text_emphasis_style = string_style_prop "textEmphasisStyle"
-
   let text_underline_position = string_style_prop "textUnderlinePosition"
-
   let font_feature_settings = string_style_prop "fontFeatureSettings"
-
   let font_kerning = string_style_prop "fontKerning"
-
   let font_language_override = string_style_prop "fontLanguageOverride"
-
   let font_synthesis = string_style_prop "fontSynthesis"
-
   let fornt_variant_alternates = string_style_prop "forntVariantAlternates"
-
   let font_variant_caps = string_style_prop "fontVariantCaps"
-
   let font_variant_east_asian = string_style_prop "fontVariantEastAsian"
-
   let font_variant_ligatures = string_style_prop "fontVariantLigatures"
-
   let font_variant_numeric = string_style_prop "fontVariantNumeric"
-
   let font_variant_position = string_style_prop "fontVariantPosition"
-
   let all = string_style_prop "all"
-
   let glyph_orientation_vertical = string_style_prop "glyphOrientationVertical"
-
   let text_combine_upright = string_style_prop "textCombineUpright"
-
   let text_orientation = string_style_prop "textOrientation"
-
   let writing_mode = string_style_prop "writingMode"
-
   let shape_image_threshold = string_style_prop "shapeImageThreshold"
-
   let shape_margin = string_style_prop "shapeMargin"
-
   let shape_outside = string_style_prop "shapeOutside"
-
   let clip_path = string_style_prop "clipPath"
-
   let clip_rule = string_style_prop "clipRule"
-
   let mask = string_style_prop "mask"
-
   let mask_border = string_style_prop "maskBorder"
-
   let mask_border_mode = string_style_prop "maskBorderMode"
-
   let mask_border_outset = string_style_prop "maskBorderOutset"
-
   let mask_border_repeat = string_style_prop "maskBorderRepeat"
-
   let mask_border_slice = string_style_prop "maskBorderSlice"
-
   let mask_border_source = string_style_prop "maskBorderSource"
-
   let mask_border_width = string_style_prop "maskBorderWidth"
-
   let mask_clip = string_style_prop "maskClip"
-
   let mask_composite = string_style_prop "maskComposite"
-
   let mask_image = string_style_prop "maskImage"
-
   let mask_mode = string_style_prop "maskMode"
-
   let mask_origin = string_style_prop "maskOrigin"
-
   let mask_position = string_style_prop "maskPosition"
-
   let mask_repeat = string_style_prop "maskRepeat"
-
   let mask_size = string_style_prop "maskSize"
-
   let mask_type = string_style_prop "maskType"
-
   let background_blend_mode = string_style_prop "backgroundBlendMode"
-
   let isolation = string_style_prop "isolation"
-
   let mix_blend_mode = string_style_prop "mixBlendMode"
-
   let box_decoration_break = string_style_prop "boxDecorationBreak"
-
   let box_sizing = string_style_prop "boxSizing"
-
   let caret_color = string_style_prop "caretColor"
-
   let nav_down = string_style_prop "navDown"
-
   let nav_left = string_style_prop "navLeft"
-
   let nav_right = string_style_prop "navRight"
-
   let nav_up = string_style_prop "navUp"
-
   let outline_offset = string_style_prop "outlineOffset"
-
   let resize = string_style_prop "resize"
-
   let text_overflow = string_style_prop "textOverflow"
-
   let grid = string_style_prop "grid"
-
   let grid_area = string_style_prop "gridArea"
-
   let grid_auto_columns = string_style_prop "gridAutoColumns"
-
   let grid_auto_flow = string_style_prop "gridAutoFlow"
-
   let grid_auto_rows = string_style_prop "gridAutoRows"
-
   let grid_column = string_style_prop "gridColumn"
-
   let grid_column_end = string_style_prop "gridColumnEnd"
-
   let grid_column_gap = string_style_prop "gridColumnGap"
-
   let grid_column_start = string_style_prop "gridColumnStart"
-
   let grid_gap = string_style_prop "gridGap"
-
   let grid_row = string_style_prop "gridRow"
-
   let grid_row_end = string_style_prop "gridRowEnd"
-
   let grid_row_gap = string_style_prop "gridRowGap"
-
   let grid_row_start = string_style_prop "gridRowStart"
-
   let grid_template = string_style_prop "gridTemplate"
-
   let grid_template_areas = string_style_prop "gridTemplateAreas"
-
   let grid_template_columns = string_style_prop "gridTemplateColumns"
-
   let grid_template_rows = string_style_prop "gridTemplateRows"
-
   let will_change = string_style_prop "willChange"
-
   let hanging_punctuation = string_style_prop "hangingPunctuation"
-
   let hyphens = string_style_prop "hyphens"
-
   let line_break = string_style_prop "lineBreak"
-
   let overflow_wrap = string_style_prop "overflowWrap"
-
   let tab_size = string_style_prop "tabSize"
-
   let text_align_last = string_style_prop "textAlignLast"
-
   let text_justify = string_style_prop "textJustify"
-
   let word_break = string_style_prop "wordBreak"
-
   let word_wrap = string_style_prop "wordWrap"
-
   let animation = string_style_prop "animation"
-
   let animation_delay = string_style_prop "animationDelay"
-
   let animation_direction = string_style_prop "animationDirection"
-
   let animation_duration = string_style_prop "animationDuration"
-
   let animation_fill_mode = string_style_prop "animationFillMode"
-
   let animation_iteration_count = string_style_prop "animationIterationCount"
-
   let animation_name = string_style_prop "animationName"
-
   let animation_play_state = string_style_prop "animationPlayState"
-
   let animation_timing_function = string_style_prop "animationTimingFunction"
-
   let transition = string_style_prop "transition"
-
   let transition_delay = string_style_prop "transitionDelay"
-
   let transition_duration = string_style_prop "transitionDuration"
-
   let transition_property = string_style_prop "transitionProperty"
-
   let transition_timing_function = string_style_prop "transitionTimingFunction"
-
   let backface_visibility = string_style_prop "backfaceVisibility"
-
   let perspective = string_style_prop "perspective"
-
   let perspective_origin = string_style_prop "perspectiveOrigin"
-
   let transform = string_style_prop "transform"
-
   let transform_origin = string_style_prop "transformOrigin"
-
   let transform_style = string_style_prop "transformStyle"
-
   let justify_items = string_style_prop "justifyItems"
-
   let justify_self = string_style_prop "justifySelf"
-
   let place_content = string_style_prop "placeContent"
-
   let place_items = string_style_prop "placeItems"
-
   let place_self = string_style_prop "placeSelf"
-
   let appearance = string_style_prop "appearance"
-
   let caret = string_style_prop "caret"
-
   let caret_animation = string_style_prop "caretAnimation"
-
   let caret_shape = string_style_prop "caretShape"
-
   let user_select = string_style_prop "userSelect"
-
   let max_lines = string_style_prop "maxLines"
-
   let marquee_direction = string_style_prop "marqueeDirection"
-
   let marquee_loop = string_style_prop "marqueeLoop"
-
   let marquee_speed = string_style_prop "marqueeSpeed"
-
   let marquee_style = string_style_prop "marqueeStyle"
-
   let overflow_style = string_style_prop "overflowStyle"
-
   let rotation = string_style_prop "rotation"
-
   let rotation_point = string_style_prop "rotationPoint"
-
   let alignment_baseline = string_style_prop "alignmentBaseline"
-
   let baseline_shift = string_style_prop "baselineShift"
-
   let clip = string_style_prop "clip"
-
   let clip_path = string_style_prop "clipPath"
-
   let clip_rule = string_style_prop "clipRule"
-
   let color_interpolation = string_style_prop "colorInterpolation"
 
   let color_interpolation_filters =
     string_style_prop "colorInterpolationFilters"
 
   let color_profile = string_style_prop "colorProfile"
-
   let color_rendering = string_style_prop "colorRendering"
-
   let cursor = string_style_prop "cursor"
-
   let dominant_baseline = string_style_prop "dominantBaseline"
-
   let fill = string_style_prop "fill"
-
   let fill_opacity = string_style_prop "fillOpacity"
-
   let fill_rule = string_style_prop "fillRule"
-
   let filter = string_style_prop "filter"
-
   let flood_color = string_style_prop "floodColor"
-
   let flood_opacity = string_style_prop "floodOpacity"
 
   let glyph_orientation_horizontal =
     string_style_prop "glyphOrientationHorizontal"
 
   let glyph_orientation_vertical = string_style_prop "glyphOrientationVertical"
-
   let image_rendering = string_style_prop "imageRendering"
-
   let kerning = string_style_prop "kerning"
-
   let lighting_color = string_style_prop "lightingColor"
-
   let marker_end = string_style_prop "markerEnd"
-
   let marker_mid = string_style_prop "markerMid"
-
   let marker_start = string_style_prop "markerStart"
-
   let pointer_events = string_style_prop "pointerEvents"
-
   let shape_rendering = string_style_prop "shapeRendering"
-
   let stop_color = string_style_prop "stopColor"
-
   let stop_opacity = string_style_prop "stopOpacity"
-
   let stroke = string_style_prop "stroke"
-
   let stroke_dasharray = string_style_prop "strokeDasharray"
-
   let stroke_dashoffset = string_style_prop "strokeDashoffset"
-
   let stroke_linecap = string_style_prop "strokeLinecap"
-
   let stroke_linejoin = string_style_prop "strokeLinejoin"
-
   let stroke_miterlimit = string_style_prop "strokeMiterlimit"
-
   let stroke_opacity = string_style_prop "strokeOpacity"
-
   let stroke_width = string_style_prop "strokeWidth"
-
   let text_anchor = string_style_prop "textAnchor"
-
   let text_rendering = string_style_prop "textRendering"
-
   let ruby_align = string_style_prop "rubyAlign"
-
   let ruby_merge = string_style_prop "rubyMerge"
-
   let ruby_position = string_style_prop "rubyPosition"]
 end
 
@@ -1510,6 +816,5 @@ module SafeString : sig
   type t = private string
 
   val make_unchecked : string -> t [@@js.custom let make_unchecked str = str]
-
   val to_string : t -> string [@@js.custom let to_string str = str]
 end

--- a/lib/dom_aria_attributes.mli
+++ b/lib/dom_aria_attributes.mli
@@ -1,115 +1,59 @@
 type t = Dom_dsl_core.Prop.t
 
 val any : string -> 'a -> t
-
 val string : string -> string -> t
-
 val bool : string -> bool -> t
-
 val int : string -> int -> t
-
 val float_ : string -> float -> t
-
 val event : string -> ('a Event.synthetic -> unit) -> t
-
 val maybe : ('a -> t) -> 'a option -> t
-
 val key : string -> t
-
 val ref_ : Dom.dom_ref -> t
-
 val ariaActivedescendant : string -> t
-
 val ariaAtomic : string -> t
-
 val ariaAutocomplete : string -> t
-
 val ariaBusy : string -> t
-
 val ariaChecked : string -> t
-
 val ariaColcount : int -> t
-
 val ariaColindex : int -> t
-
 val ariaColspan : int -> t
-
 val ariaControls : string -> t
-
 val ariaCurrent : string -> t
-
 val ariaDescribedby : string -> t
-
 val ariaDetails : string -> t
-
 val ariaDisabled : string -> t
-
 val ariaDropeffect : string -> t
-
 val ariaErrormessage : string -> t
-
 val ariaExpanded : string -> t
-
 val ariaFlowto : string -> t
-
 val ariaGrabbed : string -> t
-
 val ariaHaspopup : string -> t
-
 val ariaHidden : string -> t
-
 val ariaInvalid : string -> t
-
 val ariaKeyshortcuts : string -> t
-
 val ariaLabel : string -> t
-
 val ariaLabelledby : string -> t
-
 val ariaLevel : int -> t
-
 val ariaLive : string -> t
-
 val ariaModal : string -> t
-
 val ariaMultiline : string -> t
-
 val ariaMultiselectable : string -> t
-
 val ariaOrientation : string -> t
-
 val ariaOwns : string -> t
-
 val ariaPlaceholder : string -> t
-
 val ariaPosinset : int -> t
-
 val ariaPressed : string -> t
-
 val ariaReadonly : string -> t
-
 val ariaRelevant : string -> t
-
 val ariaRequired : string -> t
-
 val ariaRoledescription : string -> t
-
 val ariaRowcount : int -> t
-
 val ariaRowindex : int -> t
-
 val ariaRowspan : int -> t
-
 val ariaSelected : string -> t
-
 val ariaSetsize : int -> t
-
 val ariaSort : string -> t
-
 val ariaValuemax : int -> t
-
 val ariaValuemin : int -> t
-
 val ariaValuenow : int -> t
-
 val ariaValuetext : string -> t

--- a/lib/dom_dsl_core.ml
+++ b/lib/dom_dsl_core.ml
@@ -2,22 +2,16 @@ module Prop = struct
   type t = string * Js_of_ocaml.Js.Unsafe.any
 
   let any key value = (key, Js_of_ocaml.Js.Unsafe.inject value)
-
   let string key value = any key (Js_of_ocaml.Js.string value)
-
   let bool key value = any key (Js_of_ocaml.Js.bool value)
-
   let int key (value : int) = any key value
-
   let float_ key (value : float) = any key value
 
   let event key (f : _ Event.synthetic -> unit) =
     any key (Js_of_ocaml.Js.wrap_callback f)
 
   let maybe prop = function Some value -> prop value | None -> any "" ""
-
   let key = string "key"
-
   let ref_ = (any "ref" : Dom.dom_ref -> t)
 end
 
@@ -35,10 +29,7 @@ module Common = struct
   end
 
   let fragment children = Core.Fragment.make ~children ()
-
   let string = Core.string
-
   let int = Core.int
-
   let float = Core.float
 end

--- a/lib/dom_dsl_core.mli
+++ b/lib/dom_dsl_core.mli
@@ -2,21 +2,13 @@ module Prop : sig
   type t
 
   val any : string -> _ -> t
-
   val string : string -> string -> t
-
   val bool : string -> bool -> t
-
   val int : string -> int -> t
-
   val float_ : string -> float -> t
-
   val event : string -> (_ Event.synthetic -> unit) -> t
-
   val maybe : ('a -> t) -> 'a option -> t
-
   val key : string -> t
-
   val ref_ : Dom.dom_ref -> t
 end
 
@@ -33,10 +25,7 @@ module Common : sig
   end
 
   val fragment : Core.element list -> Core.element
-
   val string : string -> Core.element
-
   val int : int -> Core.element
-
   val float : float -> Core.element
 end

--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -9,92 +9,63 @@ module Prop = struct
   (* react textarea/input *)
 
   let defaultChecked = bool "defaultChecked"
-
   let defaultValue = string "defaultValue"
 
   (* global html attributes *)
 
   let accessKey = string "accessKey"
-
   let className = string "className" (* substitute for "class" *)
 
   let contentEditable = bool "contentEditable"
-
   let contextMenu = string "contextMenu"
-
   let dir = string "dir" (* "ltr", "rtl" or "auto" *)
 
   let draggable = bool "draggable"
-
   let hidden = bool "hidden"
-
   let id = string "id"
-
   let lang = string "lang"
-
   let role = string "role" (* ARIA role *)
 
   let style = (any "style" : Dom.Style.t -> t)
-
   let spellCheck = bool "spellCheck"
-
   let tabIndex = int "tabIndex"
-
   let title = string "title"
 
   (* html5 microdata *)
 
   let itemID = string "itemID"
-
   let itemProp = string "itemProp"
-
   let itemRef = string "itemRef"
-
   let itemScope = bool "itemScope"
-
   let itemType = string "itemType" (* uri *)
 
   (* tag-specific html attributes *)
 
   let accept = string "accept"
-
   let acceptCharset = string "acceptCharset"
-
   let action = string "action" (* uri *)
 
   let allowFullScreen = bool "allowFullScreen"
-
   let alt = string "alt"
-
   let async = bool "async"
-
   let autoComplete = string "autoComplete"
   (* has a fixed, but large-ish, set of possible values *)
 
   let autoCapitalize = string "autoCapitalize" (* Mobile Safari specific *)
 
   let autoFocus = bool "autoFocus"
-
   let autoPlay = bool "autoPlay"
-
   let challenge = string "challenge"
-
   let charSet = string "charSet"
-
   let checked = bool "checked"
-
   let cite = string "cite" (* uri *)
 
   let crossOrigin = string "crossOrigin" (* anonymous, use-credentials *)
 
   let cols = int "cols"
-
   let colSpan = int "colSpan"
-
   let content = string "content"
-
   let controls = bool "controls"
-
   let coords = string "coords"
   (* set of values specifying the coordinates of a region *)
 
@@ -104,11 +75,8 @@ module Prop = struct
   (* "valid date string with optional time" *)
 
   let default = bool "default"
-
   let defer = bool "defer"
-
   let disabled = bool "disabled"
-
   let download = string "download"
   (* should really be either a boolean, signifying presence, or a string *)
 
@@ -116,7 +84,6 @@ module Prop = struct
   (* "application/x-www-form-urlencoded", "multipart/form-data" or "text/plain" *)
 
   let form = string "form"
-
   let formAction = string "formAction" (* uri *)
 
   let formTarget = string "formTarget" (* "_blank", "_self", etc. *)
@@ -124,16 +91,13 @@ module Prop = struct
   let formMethod = string "formMethod" (* "post", "get", "put" *)
 
   let headers = string "headers"
-
   let height = string "height"
   (* in html5 this can only be a number, but in html4 it can ba a percentage as well *)
 
   let high = int "high"
-
   let href = string "href" (* uri *)
 
   let hrefLang = string "hrefLang"
-
   let htmlFor = string "htmlFor" (* substitute for "for" *)
 
   let httpEquiv = string "httpEquiv"
@@ -145,117 +109,79 @@ module Prop = struct
   (* "verbatim", "latin", "numeric", etc. *)
 
   let integrity = string "integrity"
-
   let keyType = string "keyType"
-
   let kind = string "kind" (* has a fixed set of possible values *)
 
   let label = string "label"
-
   let list = string "list"
-
   let loop = bool "loop"
-
   let low = int "low"
-
   let manifest = string "manifest" (* uri *)
 
   let max = string "max" (* should be int or Js.Date.t *)
 
   let maxLength = int "maxLength"
-
   let media = string "media" (* a valid media query *)
 
   let mediaGroup = string "mediaGroup"
-
   let method_ = string "method" (* "post" or "get", reserved keyword *)
 
   let min = string "min"
-
   let minLength = int "minLength"
-
   let multiple = bool "multiple"
-
   let muted = bool "muted"
-
   let name = string "name"
-
   let nonce = string "nonce"
-
   let noValidate = bool "noValidate"
-
   let open_ = bool "open" (* reserved keyword *)
 
   let optimum = int "optimum"
-
   let pattern = string "pattern" (* valid Js RegExp *)
 
   let placeholder = string "placeholder"
-
   let playsInline = bool "playsInline"
-
   let poster = string "poster" (* uri *)
 
   let preload = string "preload"
   (* "none", "metadata" or "auto" (and "" as a synonym for "auto") *)
 
   let radioGroup = string "radioGroup"
-
   let readOnly = bool "readOnly"
-
   let rel = string "rel"
   (* a space- or comma-separated (depending on the element) list of a fixed set of "link types" *)
 
   let required = bool "required"
-
   let reversed = bool "reversed"
-
   let rows = int "rows"
-
   let rowSpan = int "rowSpan"
-
   let sandbox = string "sandbox" (* has a fixed set of possible values *)
 
   let scope = string "scope" (* has a fixed set of possible values *)
 
   let scoped = bool "scoped"
-
   let scrolling = string "scrolling"
   (* html4 only, "auto", "yes" or "no" *)
 
   let selected = bool "selected"
-
   let shape = string "shape"
-
   let size = int "size"
-
   let sizes = string "sizes"
-
   let span = int "span"
-
   let src = string "src" (* uri *)
 
   let srcDoc = string "srcDoc"
-
   let srcLang = string "srcLang"
-
   let srcSet = string "srcSet"
-
   let start = int "start"
-
   let step = float_ "step"
-
   let summary = string "summary" (* deprecated *)
 
   let target = string "target"
-
   let type_ = string "type"
   (* has a fixed but large-ish set of possible values, reserved keyword *)
 
   let useMap = string "useMap"
-
   let value = string "value"
-
   let width = string "width"
   (* in html5 this can only be a number, but in html4 it can ba a percentage as well *)
 
@@ -264,9 +190,7 @@ module Prop = struct
   (* Clipboard events *)
 
   let onCopy = (event "onCopy" : (Event.Clipboard.t -> unit) -> t)
-
   let onCut = (event "onCut" : (Event.Clipboard.t -> unit) -> t)
-
   let onPaste = (event "onPaste" : (Event.Clipboard.t -> unit) -> t)
 
   (* Composition events *)
@@ -283,63 +207,40 @@ module Prop = struct
   (* Keyboard events *)
 
   let onKeyDown = (event "onKeyDown" : (Event.Keyboard.t -> unit) -> t)
-
   let onKeyPress = (event "onKeyPress" : (Event.Keyboard.t -> unit) -> t)
-
   let onKeyUp = (event "onKeyUp" : (Event.Keyboard.t -> unit) -> t)
 
   (* Focus events *)
 
   let onFocus = (event "onFocus" : (Event.Focus.t -> unit) -> t)
-
   let onBlur = (event "onBlur" : (Event.Focus.t -> unit) -> t)
 
   (* Form events *)
 
   let onChange = (event "onChange" : (Event.Form.t -> unit) -> t)
-
   let onInput = (event "onInput" : (Event.Form.t -> unit) -> t)
-
   let onSubmit = (event "onSubmit" : (Event.Form.t -> unit) -> t)
-
   let onInvalid = (event "onInvalid" : (Event.Form.t -> unit) -> t)
 
   (* Mouse events *)
 
   let onClick = (event "onClick" : (Event.Mouse.t -> unit) -> t)
-
   let onContextMenu = (event "onContextMenu" : (Event.Mouse.t -> unit) -> t)
-
   let onDoubleClick = (event "onDoubleClick" : (Event.Mouse.t -> unit) -> t)
-
   let onDrag = (event "onDrag" : (Event.Mouse.t -> unit) -> t)
-
   let onDragEnd = (event "onDragEnd" : (Event.Mouse.t -> unit) -> t)
-
   let onDragEnter = (event "onDragEnter" : (Event.Mouse.t -> unit) -> t)
-
   let onDragExit = (event "onDragExit" : (Event.Mouse.t -> unit) -> t)
-
   let onDragLeave = (event "onDragLeave" : (Event.Mouse.t -> unit) -> t)
-
   let onDragOver = (event "onDragOver" : (Event.Mouse.t -> unit) -> t)
-
   let onDragStart = (event "onDragStart" : (Event.Mouse.t -> unit) -> t)
-
   let onDrop = (event "onDrop" : (Event.Mouse.t -> unit) -> t)
-
   let onMouseDown = (event "onMouseDown" : (Event.Mouse.t -> unit) -> t)
-
   let onMouseEnter = (event "onMouseEnter" : (Event.Mouse.t -> unit) -> t)
-
   let onMouseLeave = (event "onMouseLeave" : (Event.Mouse.t -> unit) -> t)
-
   let onMouseMove = (event "onMouseMove" : (Event.Mouse.t -> unit) -> t)
-
   let onMouseOut = (event "onMouseOut" : (Event.Mouse.t -> unit) -> t)
-
   let onMouseOver = (event "onMouseOver" : (Event.Mouse.t -> unit) -> t)
-
   let onMouseUp = (event "onMouseUp" : (Event.Mouse.t -> unit) -> t)
 
   (* Selection events *)
@@ -349,30 +250,22 @@ module Prop = struct
   (* Touch events *)
 
   let onTouchCancel = (event "onTouchCancel" : (Event.Touch.t -> unit) -> t)
-
   let onTouchEnd = (event "onTouchEnd" : (Event.Touch.t -> unit) -> t)
-
   let onTouchMove = (event "onTouchMove" : (Event.Touch.t -> unit) -> t)
-
   let onTouchStart = (event "onTouchStart" : (Event.Touch.t -> unit) -> t)
 
   (* Pointer events *)
 
   let onPointerOver = (event "onPointerOver" : (Event.Pointer.t -> unit) -> t)
-
   let onPointerEnter = (event "onPointerEnter" : (Event.Pointer.t -> unit) -> t)
-
   let onPointerDown = (event "onPointerDown" : (Event.Pointer.t -> unit) -> t)
-
   let onPointerMove = (event "onPointerMove" : (Event.Pointer.t -> unit) -> t)
-
   let onPointerUp = (event "onPointerUp" : (Event.Pointer.t -> unit) -> t)
 
   let onPointerCancel =
     (event "onPointerCancel" : (Event.Pointer.t -> unit) -> t)
 
   let onPointerOut = (event "onPointerOut" : (Event.Pointer.t -> unit) -> t)
-
   let onPointerLeave = (event "onPointerLeave" : (Event.Pointer.t -> unit) -> t)
 
   let onGotPointerCapture =
@@ -392,7 +285,6 @@ module Prop = struct
   (* Media events *)
 
   let onAbort = (event "onAbort" : (Event.Media.t -> unit) -> t)
-
   let onCanPlay = (event "onCanPlay" : (Event.Media.t -> unit) -> t)
 
   let onCanPlayThrough =
@@ -402,42 +294,26 @@ module Prop = struct
     (event "onDurationChange" : (Event.Media.t -> unit) -> t)
 
   let onEmptied = (event "onEmptied" : (Event.Media.t -> unit) -> t)
-
   let onEncrypted = (event "onEncrypted" : (Event.Media.t -> unit) -> t)
-
   let onEnded = (event "onEnded" : (Event.Media.t -> unit) -> t)
-
   let onError = (event "onError" : (Event.Media.t -> unit) -> t)
-
   let onLoadedData = (event "onLoadedData" : (Event.Media.t -> unit) -> t)
 
   let onLoadedMetadata =
     (event "onLoadedMetadata" : (Event.Media.t -> unit) -> t)
 
   let onLoadStart = (event "onLoadStart" : (Event.Media.t -> unit) -> t)
-
   let onPause = (event "onPause" : (Event.Media.t -> unit) -> t)
-
   let onPlay = (event "onPlay" : (Event.Media.t -> unit) -> t)
-
   let onPlaying = (event "onPlaying" : (Event.Media.t -> unit) -> t)
-
   let onProgress = (event "onProgress" : (Event.Media.t -> unit) -> t)
-
   let onRateChange = (event "onRateChange" : (Event.Media.t -> unit) -> t)
-
   let onSeeked = (event "onSeeked" : (Event.Media.t -> unit) -> t)
-
   let onSeeking = (event "onSeeking" : (Event.Media.t -> unit) -> t)
-
   let onStalled = (event "onStalled" : (Event.Media.t -> unit) -> t)
-
   let onSuspend = (event "onSuspend" : (Event.Media.t -> unit) -> t)
-
   let onTimeUpdate = (event "onTimeUpdate" : (Event.Media.t -> unit) -> t)
-
   let onVolumeChange = (event "onVolumeChange" : (Event.Media.t -> unit) -> t)
-
   let onWaiting = (event "onWaiting" : (Event.Media.t -> unit) -> t)
 
   (* Image events *)
@@ -483,225 +359,115 @@ include Dom_dsl_core.Common
 (* Elements *)
 
 let a = h "a"
-
 let abbr = h "abbr"
-
 let address = h "address"
-
 let area = h "area"
-
 let article = h "article"
-
 let aside = h "aside"
-
 let audio = h "audio"
-
 let b = h "b"
-
 let base = h "base"
-
 let bdi = h "bdi"
-
 let bdo = h "bdo"
-
 let big = h "big"
-
 let blockquote = h "blockquote"
-
 let body = h "body"
-
 let br = h "br"
-
 let button = h "button"
-
 let canvas = h "canvas"
-
 let caption = h "caption"
-
 let cite = h "cite"
-
 let code = h "code"
-
 let col = h "col"
-
 let colgroup = h "colgroup"
-
 let data = h "data"
-
 let datalist = h "datalist"
-
 let dd = h "dd"
-
 let del = h "del"
-
 let details = h "details"
-
 let dfn = h "dfn"
-
 let dialog = h "dialog"
-
 let div = h "div"
-
 let dl = h "dl"
-
 let dt = h "dt"
-
 let em = h "em"
-
 let embed = h "embed"
-
 let fieldset = h "fieldset"
-
 let figcaption = h "figcaption"
-
 let figure = h "figure"
-
 let footer = h "footer"
-
 let form = h "form"
-
 let h1 = h "h1"
-
 let h2 = h "h2"
-
 let h3 = h "h3"
-
 let h4 = h "h4"
-
 let h5 = h "h5"
-
 let h6 = h "h6"
-
 let head = h "head"
-
 let header = h "header"
-
 let hr = h "hr"
-
 let html = h "html"
-
 let i = h "i"
-
 let iframe = h "iframe"
-
 let img = h "img"
-
 let input = h "input"
-
 let ins = h "ins"
-
 let kbd = h "kbd"
-
 let keygen = h "keygen"
-
 let label = h "label"
-
 let legend = h "legend"
-
 let li = h "li"
-
 let link = h "link"
-
 let main = h "main"
-
 let map = h "map"
-
 let mark = h "mark"
-
 let menu = h "menu"
-
 let menuitem = h "menuitem"
-
 let meta = h "meta"
-
 let meter = h "meter"
-
 let nav = h "nav"
-
 let noscript = h "noscript"
-
 let object_ = h "object" (* reserved keyword *)
 
 let ol = h "ol"
-
 let optgroup = h "optgroup"
-
 let option = h "option"
-
 let output = h "output"
-
 let p = h "p"
-
 let param = h "param"
-
 let picture = h "picture"
-
 let pre = h "pre"
-
 let progress = h "progress"
-
 let q = h "q"
-
 let rp = h "rp"
-
 let rt = h "rt"
-
 let ruby = h "ruby"
-
 let s = h "s"
-
 let samp = h "samp"
-
 let script = h "script"
-
 let section = h "section"
-
 let select = h "select"
-
 let small = h "small"
-
 let source = h "source"
-
 let span = h "span"
-
 let strong = h "strong"
-
 let style = h "style"
-
 let sub = h "sub"
-
 let summary = h "summary"
-
 let sup = h "sup"
-
 let table = h "table"
-
 let tbody = h "tbody"
-
 let td = h "td"
-
 let textarea = h "textarea"
-
 let tfoot = h "tfoot"
-
 let th = h "th"
-
 let thead = h "thead"
-
 let time = h "time"
-
 let title = h "title"
-
 let tr = h "tr"
-
 let track = h "track"
-
 let u = h "u"
-
 let ul = h "ul"
-
 let var = h "var"
-
 let video = h "video"
-
 let wbr = h "wbr"

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -4,19 +4,12 @@ module Prop : sig
   (** Common *)
 
   val any : string -> 'a -> t
-
   val string : string -> string -> t
-
   val bool : string -> bool -> t
-
   val int : string -> int -> t
-
   val float_ : string -> float -> t
-
   val event : string -> ('a Event.synthetic -> unit) -> t
-
   val key : string -> t
-
   val ref_ : Dom.dom_ref -> t
 
   (** Modifiers *)
@@ -26,397 +19,201 @@ module Prop : sig
   (** HTML props *)
 
   val defaultChecked : bool -> t
-
   val defaultValue : string -> t
-
   val accessKey : string -> t
-
   val className : string -> t
-
   val contentEditable : bool -> t
-
   val contextMenu : string -> t
-
   val dir : string -> t
-
   val draggable : bool -> t
-
   val hidden : bool -> t
-
   val id : string -> t
-
   val lang : string -> t
-
   val role : string -> t
-
   val style : Dom.Style.t -> t
-
   val spellCheck : bool -> t
-
   val tabIndex : int -> t
-
   val title : string -> t
-
   val itemID : string -> t
-
   val itemProp : string -> t
-
   val itemRef : string -> t
-
   val itemScope : bool -> t
-
   val itemType : string -> t
-
   val accept : string -> t
-
   val acceptCharset : string -> t
-
   val action : string -> t
-
   val allowFullScreen : bool -> t
-
   val alt : string -> t
-
   val async : bool -> t
-
   val autoComplete : string -> t
-
   val autoCapitalize : string -> t
-
   val autoFocus : bool -> t
-
   val autoPlay : bool -> t
-
   val challenge : string -> t
-
   val charSet : string -> t
-
   val checked : bool -> t
-
   val cite : string -> t
-
   val crossOrigin : string -> t
-
   val cols : int -> t
-
   val colSpan : int -> t
-
   val content : string -> t
-
   val controls : bool -> t
-
   val coords : string -> t
-
   val data : string -> t
-
   val dateTime : string -> t
-
   val default : bool -> t
-
   val defer : bool -> t
-
   val disabled : bool -> t
-
   val download : string -> t
-
   val encType : string -> t
-
   val form : string -> t
-
   val formAction : string -> t
-
   val formTarget : string -> t
-
   val formMethod : string -> t
-
   val headers : string -> t
-
   val height : string -> t
-
   val high : int -> t
-
   val href : string -> t
-
   val hrefLang : string -> t
-
   val htmlFor : string -> t
-
   val httpEquiv : string -> t
-
   val icon : string -> t
-
   val inputMode : string -> t
-
   val integrity : string -> t
-
   val keyType : string -> t
-
   val kind : string -> t
-
   val label : string -> t
-
   val list : string -> t
-
   val loop : bool -> t
-
   val low : int -> t
-
   val manifest : string -> t
-
   val max : string -> t
-
   val maxLength : int -> t
-
   val media : string -> t
-
   val mediaGroup : string -> t
-
   val method_ : string -> t
-
   val min : string -> t
-
   val minLength : int -> t
-
   val multiple : bool -> t
-
   val muted : bool -> t
-
   val name : string -> t
-
   val nonce : string -> t
-
   val noValidate : bool -> t
-
   val open_ : bool -> t
-
   val optimum : int -> t
-
   val pattern : string -> t
-
   val placeholder : string -> t
-
   val playsInline : bool -> t
-
   val poster : string -> t
-
   val preload : string -> t
-
   val radioGroup : string -> t
-
   val readOnly : bool -> t
-
   val rel : string -> t
-
   val required : bool -> t
-
   val reversed : bool -> t
-
   val rows : int -> t
-
   val rowSpan : int -> t
-
   val sandbox : string -> t
-
   val scope : string -> t
-
   val scoped : bool -> t
-
   val scrolling : string -> t
-
   val selected : bool -> t
-
   val shape : string -> t
-
   val size : int -> t
-
   val sizes : string -> t
-
   val span : int -> t
-
   val src : string -> t
-
   val srcDoc : string -> t
-
   val srcLang : string -> t
-
   val srcSet : string -> t
-
   val start : int -> t
-
   val step : float -> t
-
   val summary : string -> t
-
   val target : string -> t
-
   val type_ : string -> t
-
   val useMap : string -> t
-
   val value : string -> t
-
   val width : string -> t
-
   val wrap : string -> t
-
   val onCopy : (Event.Clipboard.t -> unit) -> t
-
   val onCut : (Event.Clipboard.t -> unit) -> t
-
   val onPaste : (Event.Clipboard.t -> unit) -> t
-
   val onCompositionEnd : (Event.Composition.t -> unit) -> t
-
   val onCompositionStart : (Event.Composition.t -> unit) -> t
-
   val onCompositionUpdate : (Event.Composition.t -> unit) -> t
-
   val onKeyDown : (Event.Keyboard.t -> unit) -> t
-
   val onKeyPress : (Event.Keyboard.t -> unit) -> t
-
   val onKeyUp : (Event.Keyboard.t -> unit) -> t
-
   val onFocus : (Event.Focus.t -> unit) -> t
-
   val onBlur : (Event.Focus.t -> unit) -> t
-
   val onChange : (Event.Form.t -> unit) -> t
-
   val onInput : (Event.Form.t -> unit) -> t
-
   val onSubmit : (Event.Form.t -> unit) -> t
-
   val onInvalid : (Event.Form.t -> unit) -> t
-
   val onClick : (Event.Mouse.t -> unit) -> t
-
   val onContextMenu : (Event.Mouse.t -> unit) -> t
-
   val onDoubleClick : (Event.Mouse.t -> unit) -> t
-
   val onDrag : (Event.Mouse.t -> unit) -> t
-
   val onDragEnd : (Event.Mouse.t -> unit) -> t
-
   val onDragEnter : (Event.Mouse.t -> unit) -> t
-
   val onDragExit : (Event.Mouse.t -> unit) -> t
-
   val onDragLeave : (Event.Mouse.t -> unit) -> t
-
   val onDragOver : (Event.Mouse.t -> unit) -> t
-
   val onDragStart : (Event.Mouse.t -> unit) -> t
-
   val onDrop : (Event.Mouse.t -> unit) -> t
-
   val onMouseDown : (Event.Mouse.t -> unit) -> t
-
   val onMouseEnter : (Event.Mouse.t -> unit) -> t
-
   val onMouseLeave : (Event.Mouse.t -> unit) -> t
-
   val onMouseMove : (Event.Mouse.t -> unit) -> t
-
   val onMouseOut : (Event.Mouse.t -> unit) -> t
-
   val onMouseOver : (Event.Mouse.t -> unit) -> t
-
   val onMouseUp : (Event.Mouse.t -> unit) -> t
-
   val onSelect : (Event.Selection.t -> unit) -> t
-
   val onTouchCancel : (Event.Touch.t -> unit) -> t
-
   val onTouchEnd : (Event.Touch.t -> unit) -> t
-
   val onTouchMove : (Event.Touch.t -> unit) -> t
-
   val onTouchStart : (Event.Touch.t -> unit) -> t
-
   val onPointerOver : (Event.Pointer.t -> unit) -> t
-
   val onPointerEnter : (Event.Pointer.t -> unit) -> t
-
   val onPointerDown : (Event.Pointer.t -> unit) -> t
-
   val onPointerMove : (Event.Pointer.t -> unit) -> t
-
   val onPointerUp : (Event.Pointer.t -> unit) -> t
-
   val onPointerCancel : (Event.Pointer.t -> unit) -> t
-
   val onPointerOut : (Event.Pointer.t -> unit) -> t
-
   val onPointerLeave : (Event.Pointer.t -> unit) -> t
-
   val onGotPointerCapture : (Event.Pointer.t -> unit) -> t
-
   val onLostPointerCapture : (Event.Pointer.t -> unit) -> t
-
   val onScroll : (Event.UI.t -> unit) -> t
-
   val onWheel : (Event.Wheel.t -> unit) -> t
-
   val onAbort : (Event.Media.t -> unit) -> t
-
   val onCanPlay : (Event.Media.t -> unit) -> t
-
   val onCanPlayThrough : (Event.Media.t -> unit) -> t
-
   val onDurationChange : (Event.Media.t -> unit) -> t
-
   val onEmptied : (Event.Media.t -> unit) -> t
-
   val onEncrypted : (Event.Media.t -> unit) -> t
-
   val onEnded : (Event.Media.t -> unit) -> t
-
   val onError : (Event.Media.t -> unit) -> t
-
   val onLoadedData : (Event.Media.t -> unit) -> t
-
   val onLoadedMetadata : (Event.Media.t -> unit) -> t
-
   val onLoadStart : (Event.Media.t -> unit) -> t
-
   val onPause : (Event.Media.t -> unit) -> t
-
   val onPlay : (Event.Media.t -> unit) -> t
-
   val onPlaying : (Event.Media.t -> unit) -> t
-
   val onProgress : (Event.Media.t -> unit) -> t
-
   val onRateChange : (Event.Media.t -> unit) -> t
-
   val onSeeked : (Event.Media.t -> unit) -> t
-
   val onSeeking : (Event.Media.t -> unit) -> t
-
   val onStalled : (Event.Media.t -> unit) -> t
-
   val onSuspend : (Event.Media.t -> unit) -> t
-
   val onTimeUpdate : (Event.Media.t -> unit) -> t
-
   val onVolumeChange : (Event.Media.t -> unit) -> t
-
   val onWaiting : (Event.Media.t -> unit) -> t
-
   val onLoad : (Event.Image.t -> unit) -> t
-
   val onAnimationStart : (Event.Animation.t -> unit) -> t
-
   val onAnimationEnd : (Event.Animation.t -> unit) -> t
-
   val onAnimationIteration : (Event.Animation.t -> unit) -> t
-
   val onTransitionEnd : (Event.Transition.t -> unit) -> t
-
   val dangerouslySetInnerHTML : Dom.SafeString.t -> t
-
   val suppressContentEditableWarning : bool -> t
 end
 
@@ -432,237 +229,122 @@ module Context : sig
 end
 
 val fragment : Core.element list -> Core.element
-
 val string : string -> Core.element
-
 val int : int -> Core.element
-
 val float : float -> Core.element
-
 val h : string -> Prop.t array -> Core.element list -> Core.element
 
 (** HTML elements *)
 
 val a : Prop.t array -> Core.element list -> Core.element
-
 val abbr : Prop.t array -> Core.element list -> Core.element
-
 val address : Prop.t array -> Core.element list -> Core.element
-
 val area : Prop.t array -> Core.element list -> Core.element
-
 val article : Prop.t array -> Core.element list -> Core.element
-
 val aside : Prop.t array -> Core.element list -> Core.element
-
 val audio : Prop.t array -> Core.element list -> Core.element
-
 val b : Prop.t array -> Core.element list -> Core.element
-
 val base : Prop.t array -> Core.element list -> Core.element
-
 val bdi : Prop.t array -> Core.element list -> Core.element
-
 val bdo : Prop.t array -> Core.element list -> Core.element
-
 val big : Prop.t array -> Core.element list -> Core.element
-
 val blockquote : Prop.t array -> Core.element list -> Core.element
-
 val body : Prop.t array -> Core.element list -> Core.element
-
 val br : Prop.t array -> Core.element list -> Core.element
-
 val button : Prop.t array -> Core.element list -> Core.element
-
 val canvas : Prop.t array -> Core.element list -> Core.element
-
 val caption : Prop.t array -> Core.element list -> Core.element
-
 val cite : Prop.t array -> Core.element list -> Core.element
-
 val code : Prop.t array -> Core.element list -> Core.element
-
 val col : Prop.t array -> Core.element list -> Core.element
-
 val colgroup : Prop.t array -> Core.element list -> Core.element
-
 val data : Prop.t array -> Core.element list -> Core.element
-
 val datalist : Prop.t array -> Core.element list -> Core.element
-
 val dd : Prop.t array -> Core.element list -> Core.element
-
 val del : Prop.t array -> Core.element list -> Core.element
-
 val details : Prop.t array -> Core.element list -> Core.element
-
 val dfn : Prop.t array -> Core.element list -> Core.element
-
 val dialog : Prop.t array -> Core.element list -> Core.element
-
 val div : Prop.t array -> Core.element list -> Core.element
-
 val dl : Prop.t array -> Core.element list -> Core.element
-
 val dt : Prop.t array -> Core.element list -> Core.element
-
 val em : Prop.t array -> Core.element list -> Core.element
-
 val embed : Prop.t array -> Core.element list -> Core.element
-
 val fieldset : Prop.t array -> Core.element list -> Core.element
-
 val figcaption : Prop.t array -> Core.element list -> Core.element
-
 val figure : Prop.t array -> Core.element list -> Core.element
-
 val footer : Prop.t array -> Core.element list -> Core.element
-
 val form : Prop.t array -> Core.element list -> Core.element
-
 val h1 : Prop.t array -> Core.element list -> Core.element
-
 val h2 : Prop.t array -> Core.element list -> Core.element
-
 val h3 : Prop.t array -> Core.element list -> Core.element
-
 val h4 : Prop.t array -> Core.element list -> Core.element
-
 val h5 : Prop.t array -> Core.element list -> Core.element
-
 val h6 : Prop.t array -> Core.element list -> Core.element
-
 val head : Prop.t array -> Core.element list -> Core.element
-
 val header : Prop.t array -> Core.element list -> Core.element
-
 val hr : Prop.t array -> Core.element list -> Core.element
-
 val html : Prop.t array -> Core.element list -> Core.element
-
 val i : Prop.t array -> Core.element list -> Core.element
-
 val iframe : Prop.t array -> Core.element list -> Core.element
-
 val img : Prop.t array -> Core.element list -> Core.element
-
 val input : Prop.t array -> Core.element list -> Core.element
-
 val ins : Prop.t array -> Core.element list -> Core.element
-
 val kbd : Prop.t array -> Core.element list -> Core.element
-
 val keygen : Prop.t array -> Core.element list -> Core.element
-
 val label : Prop.t array -> Core.element list -> Core.element
-
 val legend : Prop.t array -> Core.element list -> Core.element
-
 val li : Prop.t array -> Core.element list -> Core.element
-
 val link : Prop.t array -> Core.element list -> Core.element
-
 val main : Prop.t array -> Core.element list -> Core.element
-
 val map : Prop.t array -> Core.element list -> Core.element
-
 val mark : Prop.t array -> Core.element list -> Core.element
-
 val menu : Prop.t array -> Core.element list -> Core.element
-
 val menuitem : Prop.t array -> Core.element list -> Core.element
-
 val meta : Prop.t array -> Core.element list -> Core.element
-
 val meter : Prop.t array -> Core.element list -> Core.element
-
 val nav : Prop.t array -> Core.element list -> Core.element
-
 val noscript : Prop.t array -> Core.element list -> Core.element
-
 val object_ : Prop.t array -> Core.element list -> Core.element
-
 val ol : Prop.t array -> Core.element list -> Core.element
-
 val optgroup : Prop.t array -> Core.element list -> Core.element
-
 val option : Prop.t array -> Core.element list -> Core.element
-
 val output : Prop.t array -> Core.element list -> Core.element
-
 val p : Prop.t array -> Core.element list -> Core.element
-
 val param : Prop.t array -> Core.element list -> Core.element
-
 val picture : Prop.t array -> Core.element list -> Core.element
-
 val pre : Prop.t array -> Core.element list -> Core.element
-
 val progress : Prop.t array -> Core.element list -> Core.element
-
 val q : Prop.t array -> Core.element list -> Core.element
-
 val rp : Prop.t array -> Core.element list -> Core.element
-
 val rt : Prop.t array -> Core.element list -> Core.element
-
 val ruby : Prop.t array -> Core.element list -> Core.element
-
 val s : Prop.t array -> Core.element list -> Core.element
-
 val samp : Prop.t array -> Core.element list -> Core.element
-
 val script : Prop.t array -> Core.element list -> Core.element
-
 val section : Prop.t array -> Core.element list -> Core.element
-
 val select : Prop.t array -> Core.element list -> Core.element
-
 val small : Prop.t array -> Core.element list -> Core.element
-
 val source : Prop.t array -> Core.element list -> Core.element
-
 val span : Prop.t array -> Core.element list -> Core.element
-
 val strong : Prop.t array -> Core.element list -> Core.element
-
 val style : Prop.t array -> Core.element list -> Core.element
-
 val sub : Prop.t array -> Core.element list -> Core.element
-
 val summary : Prop.t array -> Core.element list -> Core.element
-
 val sup : Prop.t array -> Core.element list -> Core.element
-
 val table : Prop.t array -> Core.element list -> Core.element
-
 val tbody : Prop.t array -> Core.element list -> Core.element
-
 val td : Prop.t array -> Core.element list -> Core.element
-
 val textarea : Prop.t array -> Core.element list -> Core.element
-
 val tfoot : Prop.t array -> Core.element list -> Core.element
-
 val th : Prop.t array -> Core.element list -> Core.element
-
 val thead : Prop.t array -> Core.element list -> Core.element
-
 val time : Prop.t array -> Core.element list -> Core.element
-
 val title : Prop.t array -> Core.element list -> Core.element
-
 val tr : Prop.t array -> Core.element list -> Core.element
-
 val track : Prop.t array -> Core.element list -> Core.element
-
 val u : Prop.t array -> Core.element list -> Core.element
-
 val ul : Prop.t array -> Core.element list -> Core.element
-
 val var : Prop.t array -> Core.element list -> Core.element
-
 val video : Prop.t array -> Core.element list -> Core.element
-
 val wbr : Prop.t array -> Core.element list -> Core.element

--- a/lib/dom_svg.ml
+++ b/lib/dom_svg.ml
@@ -7,497 +7,256 @@ module Prop = struct
   end
 
   let accentHeight = string_prop "accentHeight"
-
   let accumulate = string_prop "accumulate"
-
   let additive = string_prop "additive"
-
   let alignmentBaseline = string_prop "alignmentBaseline"
-
   let allowReorder = string_prop "allowReorder"
-
   let alphabetic = string_prop "alphabetic"
-
   let amplitude = string_prop "amplitude"
-
   let arabicForm = string_prop "arabicForm"
-
   let ascent = string_prop "ascent"
-
   let attributeName = string_prop "attributeName"
-
   let attributeType = string_prop "attributeType"
-
   let autoReverse = string_prop "autoReverse"
-
   let azimuth = string_prop "azimuth"
-
   let baseFrequency = string_prop "baseFrequency"
-
   let baseProfile = string_prop "baseProfile"
-
   let baselineShift = string_prop "baselineShift"
-
   let bbox = string_prop "bbox"
-
   let begin_ = string_prop "begin" (* reserved keyword *)
 
   let bias = string_prop "bias"
-
   let by = string_prop "by"
-
   let calcMode = string_prop "calcMode"
-
   let capHeight = string_prop "capHeight"
-
   let className = string_prop "className" (* substitute for "class" *)
 
   let clip = string_prop "clip"
-
   let clipPath = string_prop "clipPath"
-
   let clipPathUnits = string_prop "clipPathUnits"
-
   let clipRule = string_prop "clipRule"
-
   let colorInterpolation = string_prop "colorInterpolation"
-
   let colorInterpolationFilters = string_prop "colorInterpolationFilters"
-
   let colorProfile = string_prop "colorProfile"
-
   let colorRendering = string_prop "colorRendering"
-
   let contentScriptType = string_prop "contentScriptType"
-
   let contentStyleType = string_prop "contentStyleType"
-
   let cursor = string_prop "cursor"
-
   let cx = string_prop "cx"
-
   let cy = string_prop "cy"
-
   let d = string_prop "d"
-
   let decelerate = string_prop "decelerate"
-
   let descent = string_prop "descent"
-
   let diffuseConstant = string_prop "diffuseConstant"
-
   let direction = string_prop "direction"
-
   let display = string_prop "display"
-
   let divisor = string_prop "divisor"
-
   let dominantBaseline = string_prop "dominantBaseline"
-
   let dur = string_prop "dur"
-
   let dx = string_prop "dx"
-
   let dy = string_prop "dy"
-
   let edgeMode = string_prop "edgeMode"
-
   let elevation = string_prop "elevation"
-
   let enableBackground = string_prop "enableBackground"
-
   let end_ = string_prop "end" (* reserved keyword *)
 
   let exponent = string_prop "exponent"
-
   let externalResourcesRequired = string_prop "externalResourcesRequired"
-
   let fill = string_prop "fill"
-
   let fillOpacity = string_prop "fillOpacity"
-
   let fillRule = string_prop "fillRule"
-
   let filter = string_prop "filter"
-
   let filterRes = string_prop "filterRes"
-
   let filterUnits = string_prop "filterUnits"
-
   let floodColor = string_prop "floodColor"
-
   let floodOpacity = string_prop "floodOpacity"
-
   let focusable = string_prop "focusable"
-
   let fontFamily = string_prop "fontFamily"
-
   let fontSize = string_prop "fontSize"
-
   let fontSizeAdjust = string_prop "fontSizeAdjust"
-
   let fontStretch = string_prop "fontStretch"
-
   let fontStyle = string_prop "fontStyle"
-
   let fontVariant = string_prop "fontVariant"
-
   let fontWeight = string_prop "fontWeight"
-
   let fomat = string_prop "fomat"
-
   let from = string_prop "from"
-
   let fx = string_prop "fx"
-
   let fy = string_prop "fy"
-
   let g1 = string_prop "g1"
-
   let g2 = string_prop "g2"
-
   let glyphName = string_prop "glyphName"
-
   let glyphOrientationHorizontal = string_prop "glyphOrientationHorizontal"
-
   let glyphOrientationVertical = string_prop "glyphOrientationVertical"
-
   let glyphRef = string_prop "glyphRef"
-
   let gradientTransform = string_prop "gradientTransform"
-
   let gradientUnits = string_prop "gradientUnits"
-
   let hanging = string_prop "hanging"
-
   let horizAdvX = string_prop "horizAdvX"
-
   let horizOriginX = string_prop "horizOriginX"
-
   let id = string_prop "id"
-
   let ideographic = string_prop "ideographic"
-
   let imageRendering = string_prop "imageRendering"
-
   let in_ = string_prop "in" (* reserved keyword *)
 
   let in2 = string_prop "in2"
-
   let intercept = string_prop "intercept"
-
   let k = string_prop "k"
-
   let k1 = string_prop "k1"
-
   let k2 = string_prop "k2"
-
   let k3 = string_prop "k3"
-
   let k4 = string_prop "k4"
-
   let kernelMatrix = string_prop "kernelMatrix"
-
   let kernelUnitLength = string_prop "kernelUnitLength"
-
   let kerning = string_prop "kerning"
-
   let keyPoints = string_prop "keyPoints"
-
   let keySplines = string_prop "keySplines"
-
   let keyTimes = string_prop "keyTimes"
-
   let lang = string_prop "lang"
-
   let lengthAdjust = string_prop "lengthAdjust"
-
   let letterSpacing = string_prop "letterSpacing"
-
   let lightingColor = string_prop "lightingColor"
-
   let limitingConeAngle = string_prop "limitingConeAngle"
-
   let local = string_prop "local"
-
   let markerEnd = string_prop "markerEnd"
-
   let markerHeight = string_prop "markerHeight"
-
   let markerMid = string_prop "markerMid"
-
   let markerStart = string_prop "markerStart"
-
   let markerUnits = string_prop "markerUnits"
-
   let markerWidth = string_prop "markerWidth"
-
   let mask = string_prop "mask"
-
   let maskContentUnits = string_prop "maskContentUnits"
-
   let maskUnits = string_prop "maskUnits"
-
   let mathematical = string_prop "mathematical"
-
   let mode = string_prop "mode"
-
   let numOctaves = string_prop "numOctaves"
-
   let offset = string_prop "offset"
-
   let opacity = string_prop "opacity"
-
   let operator = string_prop "operator"
-
   let order = string_prop "order"
-
   let orient = string_prop "orient"
-
   let orientation = string_prop "orientation"
-
   let origin = string_prop "origin"
-
   let overflow = string_prop "overflow"
-
   let overflowX = string_prop "overflowX"
-
   let overflowY = string_prop "overflowY"
-
   let overlinePosition = string_prop "overlinePosition"
-
   let overlineThickness = string_prop "overlineThickness"
-
   let paintOrder = string_prop "paintOrder"
-
   let panose1 = string_prop "panose1"
-
   let pathLength = string_prop "pathLength"
-
   let patternContentUnits = string_prop "patternContentUnits"
-
   let patternTransform = string_prop "patternTransform"
-
   let patternUnits = string_prop "patternUnits"
-
   let pointerEvents = string_prop "pointerEvents"
-
   let points = string_prop "points"
-
   let pointsAtX = string_prop "pointsAtX"
-
   let pointsAtY = string_prop "pointsAtY"
-
   let pointsAtZ = string_prop "pointsAtZ"
-
   let preserveAlpha = string_prop "preserveAlpha"
-
   let preserveAspectRatio = string_prop "preserveAspectRatio"
-
   let primitiveUnits = string_prop "primitiveUnits"
-
   let r = string_prop "r"
-
   let radius = string_prop "radius"
-
   let refX = string_prop "refX"
-
   let refY = string_prop "refY"
-
   let renderingIntent = string_prop "renderingIntent"
-
   let repeatCount = string_prop "repeatCount"
-
   let repeatDur = string_prop "repeatDur"
-
   let requiredExtensions = string_prop "requiredExtensions"
-
   let requiredFeatures = string_prop "requiredFeatures"
-
   let restart = string_prop "restart"
-
   let result = string_prop "result"
-
   let rotate = string_prop "rotate"
-
   let rx = string_prop "rx"
-
   let ry = string_prop "ry"
-
   let scale = string_prop "scale"
-
   let seed = string_prop "seed"
-
   let shapeRendering = string_prop "shapeRendering"
-
   let slope = string_prop "slope"
-
   let spacing = string_prop "spacing"
-
   let specularConstant = string_prop "specularConstant"
-
   let specularExponent = string_prop "specularExponent"
-
   let speed = string_prop "speed"
-
   let spreadMethod = string_prop "spreadMethod"
-
   let startOffset = string_prop "startOffset"
-
   let stdDeviation = string_prop "stdDeviation"
-
   let stemh = string_prop "stemh"
-
   let stemv = string_prop "stemv"
-
   let stitchTiles = string_prop "stitchTiles"
-
   let stopColor = string_prop "stopColor"
-
   let stopOpacity = string_prop "stopOpacity"
-
   let strikethroughPosition = string_prop "strikethroughPosition"
-
   let strikethroughThickness = string_prop "strikethroughThickness"
-
   let string = string_prop "string"
-
   let stroke = string_prop "stroke"
-
   let strokeDasharray = string_prop "strokeDasharray"
-
   let strokeDashoffset = string_prop "strokeDashoffset"
-
   let strokeLinecap = string_prop "strokeLinecap"
-
   let strokeLinejoin = string_prop "strokeLinejoin"
-
   let strokeMiterlimit = string_prop "strokeMiterlimit"
-
   let strokeOpacity = string_prop "strokeOpacity"
-
   let strokeWidth = string_prop "strokeWidth"
-
   let style = (any "style" : Dom.Style.t -> t)
-
   let surfaceScale = string_prop "surfaceScale"
-
   let systemLanguage = string_prop "systemLanguage"
-
   let tabIndex = int "tabIndex"
-
   let tableValues = string_prop "tableValues"
-
   let targetX = string_prop "targetX"
-
   let targetY = string_prop "targetY"
-
   let textAnchor = string_prop "textAnchor"
-
   let textDecoration = string_prop "textDecoration"
-
   let textLength = string_prop "textLength"
-
   let textRendering = string_prop "textRendering"
-
   let to_ = string_prop "to" (* reserved keyword *)
 
   let transform = string_prop "transform"
-
   let u1 = string_prop "u1"
-
   let u2 = string_prop "u2"
-
   let underlinePosition = string_prop "underlinePosition"
-
   let underlineThickness = string_prop "underlineThickness"
-
   let unicode = string_prop "unicode"
-
   let unicodeBidi = string_prop "unicodeBidi"
-
   let unicodeRange = string_prop "unicodeRange"
-
   let unitsPerEm = string_prop "unitsPerEm"
-
   let vAlphabetic = string_prop "vAlphabetic"
-
   let vHanging = string_prop "vHanging"
-
   let vIdeographic = string_prop "vIdeographic"
-
   let vMathematical = string_prop "vMathematical"
-
   let values = string_prop "values"
-
   let vectorEffect = string_prop "vectorEffect"
-
   let version = string_prop "version"
-
   let vertAdvX = string_prop "vertAdvX"
-
   let vertAdvY = string_prop "vertAdvY"
-
   let vertOriginX = string_prop "vertOriginX"
-
   let vertOriginY = string_prop "vertOriginY"
-
   let viewBox = string_prop "viewBox"
-
   let viewTarget = string_prop "viewTarget"
-
   let visibility = string_prop "visibility"
-
   let widths = string_prop "widths"
-
   let wordSpacing = string_prop "wordSpacing"
-
   let writingMode = string_prop "writingMode"
-
   let x = string_prop "x"
-
   let x1 = string_prop "x1"
-
   let x2 = string_prop "x2"
-
   let xChannelSelector = string_prop "xChannelSelector"
-
   let xHeight = string_prop "xHeight"
-
   let xlinkActuate = string_prop "xlinkActuate"
-
   let xlinkArcrole = string_prop "xlinkArcrole"
-
   let xlinkHref = string_prop "xlinkHref"
-
   let xlinkRole = string_prop "xlinkRole"
-
   let xlinkShow = string_prop "xlinkShow"
-
   let xlinkTitle = string_prop "xlinkTitle"
-
   let xlinkType = string_prop "xlinkType"
-
   let xmlns = string_prop "xmlns"
-
   let xmlnsXlink = string_prop "xmlnsXlink"
-
   let xmlBase = string_prop "xmlBase"
-
   let xmlLang = string_prop "xmlLang"
-
   let xmlSpace = string_prop "xmlSpace"
-
   let y = string_prop "y"
-
   let y1 = string_prop "y1"
-
   let y2 = string_prop "y2"
-
   let yChannelSelector = string_prop "yChannelSelector"
-
   let z = string_prop "z"
-
   let zoomAndPan = string_prop "zoomAndPan"
 end
 
@@ -506,133 +265,68 @@ include Dom_dsl_core.Element
 include Dom_dsl_core.Common
 
 let a = h "a"
-
 let animate = h "animate"
-
 let animateMotion = h "animateMotion"
-
 let animateTransform = h "animateTransform"
-
 let circle = h "circle"
-
 let clipPath = h "clipPath"
-
 let defs = h "defs"
-
 let desc = h "desc"
-
 let discard = h "discard"
-
 let ellipse = h "ellipse"
-
 let feBlend = h "feBlend"
-
 let feColorMatrix = h "feColorMatrix"
-
 let feComponentTransfer = h "feComponentTransfer"
-
 let feComposite = h "feComposite"
-
 let feConvolveMatrix = h "feConvolveMatrix"
-
 let feDiffuseLighting = h "feDiffuseLighting"
-
 let feDisplacementMap = h "feDisplacementMap"
-
 let feDistantLight = h "feDistantLight"
-
 let feDropShadow = h "feDropShadow"
-
 let feFlood = h "feFlood"
-
 let feFuncA = h "feFuncA"
-
 let feFuncB = h "feFuncB"
-
 let feFuncG = h "feFuncG"
-
 let feFuncR = h "feFuncR"
-
 let feGaussianBlur = h "feGaussianBlur"
-
 let feImage = h "feImage"
-
 let feMerge = h "feMerge"
-
 let feMergeNode = h "feMergeNode"
-
 let feMorphology = h "feMorphology"
-
 let feOffset = h "feOffset"
-
 let fePointLight = h "fePointLight"
-
 let feSpecularLighting = h "feSpecularLighting"
-
 let feSpotLight = h "feSpotLight"
-
 let feTile = h "feTile"
-
 let feTurbulence = h "feTurbulence"
-
 let filter = h "filter"
-
 let foreignObject = h "foreignObject"
-
 let g = h "g"
-
 let hatch = h "hatch"
-
 let hatchpath = h "hatchpath"
-
 let image = h "image"
-
 let line = h "line"
-
 let linearGradient = h "linearGradient"
-
 let marker = h "marker"
-
 let mask = h "mask"
-
 let metadata = h "metadata"
-
 let mpath = h "mpath"
-
 let path = h "path"
-
 let pattern = h "pattern"
-
 let polygon = h "polygon"
-
 let polyline = h "polyline"
-
 let radialGradient = h "radialGradient"
-
 let rect = h "rect"
-
 let script = h "script"
-
 let set = h "set"
-
 let stop = h "stop"
-
 let style = h "style"
-
 let svg = h "svg"
-
 let switch = h "switch"
-
 let symbol = h "symbol"
-
 let text = h "text"
-
 let textPath = h "textPath"
-
 let title = h "title"
-
 let tspan = h "tspan"
-
 let use = h "use"
-
 let view = h "view"

--- a/lib/dom_svg.mli
+++ b/lib/dom_svg.mli
@@ -4,17 +4,11 @@ module Prop : sig
   (** Common *)
 
   val any : string -> 'a -> t
-
   val bool : string -> bool -> t
-
   val int : string -> int -> t
-
   val float_ : string -> float -> t
-
   val event : string -> ('a Event.synthetic -> unit) -> t
-
   val key : string -> t
-
   val ref_ : Dom.dom_ref -> t
 
   (** Modifiers *)
@@ -24,497 +18,251 @@ module Prop : sig
   (** SVG props *)
 
   val accentHeight : string -> t
-
   val accumulate : string -> t
-
   val additive : string -> t
-
   val alignmentBaseline : string -> t
-
   val allowReorder : string -> t
-
   val alphabetic : string -> t
-
   val amplitude : string -> t
-
   val arabicForm : string -> t
-
   val ascent : string -> t
-
   val attributeName : string -> t
-
   val attributeType : string -> t
-
   val autoReverse : string -> t
-
   val azimuth : string -> t
-
   val baseFrequency : string -> t
-
   val baseProfile : string -> t
-
   val baselineShift : string -> t
-
   val bbox : string -> t
-
   val begin_ : string -> t
-
   val bias : string -> t
-
   val by : string -> t
-
   val calcMode : string -> t
-
   val capHeight : string -> t
-
   val className : string -> t
-
   val clip : string -> t
-
   val clipPath : string -> t
-
   val clipPathUnits : string -> t
-
   val clipRule : string -> t
-
   val colorInterpolation : string -> t
-
   val colorInterpolationFilters : string -> t
-
   val colorProfile : string -> t
-
   val colorRendering : string -> t
-
   val contentScriptType : string -> t
-
   val contentStyleType : string -> t
-
   val cursor : string -> t
-
   val cx : string -> t
-
   val cy : string -> t
-
   val d : string -> t
-
   val decelerate : string -> t
-
   val descent : string -> t
-
   val diffuseConstant : string -> t
-
   val direction : string -> t
-
   val display : string -> t
-
   val divisor : string -> t
-
   val dominantBaseline : string -> t
-
   val dur : string -> t
-
   val dx : string -> t
-
   val dy : string -> t
-
   val edgeMode : string -> t
-
   val elevation : string -> t
-
   val enableBackground : string -> t
-
   val end_ : string -> t
-
   val exponent : string -> t
-
   val externalResourcesRequired : string -> t
-
   val fill : string -> t
-
   val fillOpacity : string -> t
-
   val fillRule : string -> t
-
   val filter : string -> t
-
   val filterRes : string -> t
-
   val filterUnits : string -> t
-
   val floodColor : string -> t
-
   val floodOpacity : string -> t
-
   val focusable : string -> t
-
   val fontFamily : string -> t
-
   val fontSize : string -> t
-
   val fontSizeAdjust : string -> t
-
   val fontStretch : string -> t
-
   val fontStyle : string -> t
-
   val fontVariant : string -> t
-
   val fontWeight : string -> t
-
   val fomat : string -> t
-
   val from : string -> t
-
   val fx : string -> t
-
   val fy : string -> t
-
   val g1 : string -> t
-
   val g2 : string -> t
-
   val glyphName : string -> t
-
   val glyphOrientationHorizontal : string -> t
-
   val glyphOrientationVertical : string -> t
-
   val glyphRef : string -> t
-
   val gradientTransform : string -> t
-
   val gradientUnits : string -> t
-
   val hanging : string -> t
-
   val horizAdvX : string -> t
-
   val horizOriginX : string -> t
-
   val id : string -> t
-
   val ideographic : string -> t
-
   val imageRendering : string -> t
-
   val in_ : string -> t
-
   val in2 : string -> t
-
   val intercept : string -> t
-
   val k : string -> t
-
   val k1 : string -> t
-
   val k2 : string -> t
-
   val k3 : string -> t
-
   val k4 : string -> t
-
   val kernelMatrix : string -> t
-
   val kernelUnitLength : string -> t
-
   val kerning : string -> t
-
   val keyPoints : string -> t
-
   val keySplines : string -> t
-
   val keyTimes : string -> t
-
   val lang : string -> t
-
   val lengthAdjust : string -> t
-
   val letterSpacing : string -> t
-
   val lightingColor : string -> t
-
   val limitingConeAngle : string -> t
-
   val local : string -> t
-
   val markerEnd : string -> t
-
   val markerHeight : string -> t
-
   val markerMid : string -> t
-
   val markerStart : string -> t
-
   val markerUnits : string -> t
-
   val markerWidth : string -> t
-
   val mask : string -> t
-
   val maskContentUnits : string -> t
-
   val maskUnits : string -> t
-
   val mathematical : string -> t
-
   val mode : string -> t
-
   val numOctaves : string -> t
-
   val offset : string -> t
-
   val opacity : string -> t
-
   val operator : string -> t
-
   val order : string -> t
-
   val orient : string -> t
-
   val orientation : string -> t
-
   val origin : string -> t
-
   val overflow : string -> t
-
   val overflowX : string -> t
-
   val overflowY : string -> t
-
   val overlinePosition : string -> t
-
   val overlineThickness : string -> t
-
   val paintOrder : string -> t
-
   val panose1 : string -> t
-
   val pathLength : string -> t
-
   val patternContentUnits : string -> t
-
   val patternTransform : string -> t
-
   val patternUnits : string -> t
-
   val pointerEvents : string -> t
-
   val points : string -> t
-
   val pointsAtX : string -> t
-
   val pointsAtY : string -> t
-
   val pointsAtZ : string -> t
-
   val preserveAlpha : string -> t
-
   val preserveAspectRatio : string -> t
-
   val primitiveUnits : string -> t
-
   val r : string -> t
-
   val radius : string -> t
-
   val refX : string -> t
-
   val refY : string -> t
-
   val renderingIntent : string -> t
-
   val repeatCount : string -> t
-
   val repeatDur : string -> t
-
   val requiredExtensions : string -> t
-
   val requiredFeatures : string -> t
-
   val restart : string -> t
-
   val result : string -> t
-
   val rotate : string -> t
-
   val rx : string -> t
-
   val ry : string -> t
-
   val scale : string -> t
-
   val seed : string -> t
-
   val shapeRendering : string -> t
-
   val slope : string -> t
-
   val spacing : string -> t
-
   val specularConstant : string -> t
-
   val specularExponent : string -> t
-
   val speed : string -> t
-
   val spreadMethod : string -> t
-
   val startOffset : string -> t
-
   val stdDeviation : string -> t
-
   val stemh : string -> t
-
   val stemv : string -> t
-
   val stitchTiles : string -> t
-
   val stopColor : string -> t
-
   val stopOpacity : string -> t
-
   val strikethroughPosition : string -> t
-
   val strikethroughThickness : string -> t
-
   val string : string -> t
-
   val stroke : string -> t
-
   val strokeDasharray : string -> t
-
   val strokeDashoffset : string -> t
-
   val strokeLinecap : string -> t
-
   val strokeLinejoin : string -> t
-
   val strokeMiterlimit : string -> t
-
   val strokeOpacity : string -> t
-
   val strokeWidth : string -> t
-
   val style : Dom.Style.t -> t
-
   val surfaceScale : string -> t
-
   val systemLanguage : string -> t
-
   val tabIndex : int -> t
-
   val tableValues : string -> t
-
   val targetX : string -> t
-
   val targetY : string -> t
-
   val textAnchor : string -> t
-
   val textDecoration : string -> t
-
   val textLength : string -> t
-
   val textRendering : string -> t
-
   val to_ : string -> t
-
   val transform : string -> t
-
   val u1 : string -> t
-
   val u2 : string -> t
-
   val underlinePosition : string -> t
-
   val underlineThickness : string -> t
-
   val unicode : string -> t
-
   val unicodeBidi : string -> t
-
   val unicodeRange : string -> t
-
   val unitsPerEm : string -> t
-
   val vAlphabetic : string -> t
-
   val vHanging : string -> t
-
   val vIdeographic : string -> t
-
   val vMathematical : string -> t
-
   val values : string -> t
-
   val vectorEffect : string -> t
-
   val version : string -> t
-
   val vertAdvX : string -> t
-
   val vertAdvY : string -> t
-
   val vertOriginX : string -> t
-
   val vertOriginY : string -> t
-
   val viewBox : string -> t
-
   val viewTarget : string -> t
-
   val visibility : string -> t
-
   val widths : string -> t
-
   val wordSpacing : string -> t
-
   val writingMode : string -> t
-
   val x : string -> t
-
   val x1 : string -> t
-
   val x2 : string -> t
-
   val xChannelSelector : string -> t
-
   val xHeight : string -> t
-
   val xlinkActuate : string -> t
-
   val xlinkArcrole : string -> t
-
   val xlinkHref : string -> t
-
   val xlinkRole : string -> t
-
   val xlinkShow : string -> t
-
   val xlinkTitle : string -> t
-
   val xlinkType : string -> t
-
   val xmlns : string -> t
-
   val xmlnsXlink : string -> t
-
   val xmlBase : string -> t
-
   val xmlLang : string -> t
-
   val xmlSpace : string -> t
-
   val y : string -> t
-
   val y1 : string -> t
-
   val y2 : string -> t
-
   val yChannelSelector : string -> t
-
   val z : string -> t
-
   val zoomAndPan : string -> t
 end
 
@@ -530,145 +278,76 @@ module Context : sig
 end
 
 val fragment : Core.element list -> Core.element
-
 val string : string -> Core.element
-
 val int : int -> Core.element
-
 val float : float -> Core.element
-
 val h : string -> Prop.t array -> Core.element list -> Core.element
 
 (** SVG elements *)
 
 val a : Prop.t array -> Core.element list -> Core.element
-
 val animate : Prop.t array -> Core.element list -> Core.element
-
 val animateMotion : Prop.t array -> Core.element list -> Core.element
-
 val animateTransform : Prop.t array -> Core.element list -> Core.element
-
 val circle : Prop.t array -> Core.element list -> Core.element
-
 val clipPath : Prop.t array -> Core.element list -> Core.element
-
 val defs : Prop.t array -> Core.element list -> Core.element
-
 val desc : Prop.t array -> Core.element list -> Core.element
-
 val discard : Prop.t array -> Core.element list -> Core.element
-
 val ellipse : Prop.t array -> Core.element list -> Core.element
-
 val feBlend : Prop.t array -> Core.element list -> Core.element
-
 val feColorMatrix : Prop.t array -> Core.element list -> Core.element
-
 val feComponentTransfer : Prop.t array -> Core.element list -> Core.element
-
 val feComposite : Prop.t array -> Core.element list -> Core.element
-
 val feConvolveMatrix : Prop.t array -> Core.element list -> Core.element
-
 val feDiffuseLighting : Prop.t array -> Core.element list -> Core.element
-
 val feDisplacementMap : Prop.t array -> Core.element list -> Core.element
-
 val feDistantLight : Prop.t array -> Core.element list -> Core.element
-
 val feDropShadow : Prop.t array -> Core.element list -> Core.element
-
 val feFlood : Prop.t array -> Core.element list -> Core.element
-
 val feFuncA : Prop.t array -> Core.element list -> Core.element
-
 val feFuncB : Prop.t array -> Core.element list -> Core.element
-
 val feFuncG : Prop.t array -> Core.element list -> Core.element
-
 val feFuncR : Prop.t array -> Core.element list -> Core.element
-
 val feGaussianBlur : Prop.t array -> Core.element list -> Core.element
-
 val feImage : Prop.t array -> Core.element list -> Core.element
-
 val feMerge : Prop.t array -> Core.element list -> Core.element
-
 val feMergeNode : Prop.t array -> Core.element list -> Core.element
-
 val feMorphology : Prop.t array -> Core.element list -> Core.element
-
 val feOffset : Prop.t array -> Core.element list -> Core.element
-
 val fePointLight : Prop.t array -> Core.element list -> Core.element
-
 val feSpecularLighting : Prop.t array -> Core.element list -> Core.element
-
 val feSpotLight : Prop.t array -> Core.element list -> Core.element
-
 val feTile : Prop.t array -> Core.element list -> Core.element
-
 val feTurbulence : Prop.t array -> Core.element list -> Core.element
-
 val filter : Prop.t array -> Core.element list -> Core.element
-
 val foreignObject : Prop.t array -> Core.element list -> Core.element
-
 val g : Prop.t array -> Core.element list -> Core.element
-
 val hatch : Prop.t array -> Core.element list -> Core.element
-
 val hatchpath : Prop.t array -> Core.element list -> Core.element
-
 val image : Prop.t array -> Core.element list -> Core.element
-
 val line : Prop.t array -> Core.element list -> Core.element
-
 val linearGradient : Prop.t array -> Core.element list -> Core.element
-
 val marker : Prop.t array -> Core.element list -> Core.element
-
 val mask : Prop.t array -> Core.element list -> Core.element
-
 val metadata : Prop.t array -> Core.element list -> Core.element
-
 val mpath : Prop.t array -> Core.element list -> Core.element
-
 val path : Prop.t array -> Core.element list -> Core.element
-
 val pattern : Prop.t array -> Core.element list -> Core.element
-
 val polygon : Prop.t array -> Core.element list -> Core.element
-
 val polyline : Prop.t array -> Core.element list -> Core.element
-
 val radialGradient : Prop.t array -> Core.element list -> Core.element
-
 val rect : Prop.t array -> Core.element list -> Core.element
-
 val script : Prop.t array -> Core.element list -> Core.element
-
 val set : Prop.t array -> Core.element list -> Core.element
-
 val stop : Prop.t array -> Core.element list -> Core.element
-
 val style : Prop.t array -> Core.element list -> Core.element
-
 val svg : Prop.t array -> Core.element list -> Core.element
-
 val switch : Prop.t array -> Core.element list -> Core.element
-
 val symbol : Prop.t array -> Core.element list -> Core.element
-
 val text : Prop.t array -> Core.element list -> Core.element
-
 val textPath : Prop.t array -> Core.element list -> Core.element
-
 val title : Prop.t array -> Core.element list -> Core.element
-
 val tspan : Prop.t array -> Core.element list -> Core.element
-
 val use : Prop.t array -> Core.element list -> Core.element
-
 val view : Prop.t array -> Core.element list -> Core.element

--- a/lib/event.ml
+++ b/lib/event.ml
@@ -5,44 +5,30 @@ module CommonApi = struct
   include
     [%js:
     type tag = Ojs.t
-
     type t = Ojs.t
 
     val t_of_js : Ojs.t -> t
-
     val t_to_js : t -> Ojs.t
-
     val bubbles : Ojs.t -> bool [@@js.get "bubbles"]
-
     val cancelable : t -> bool [@@js.get "cancelable"]
-
     val current_target : t -> Ojs.t [@@js.get "currentTarget"]
     (* Should return Dom.eventTarget *)
 
     val default_prevented : t -> bool [@@js.get "defaultPrevented"]
-
     val event_phase : t -> int [@@js.get "eventPhase"]
-
     val is_trusted : t -> bool [@@js.get "isTrusted"]
-
     val native_event : t -> Ojs.t [@@js.get "nativeEvent"]
     (* Should return Dom.event *)
 
     val prevent_default : t -> unit [@@js.call "preventDefault"]
-
     val is_default_prevented : t -> bool [@@js.call "isDefaultPrevented"]
-
     val stop_propagation : t -> unit [@@js.call "stopPropagation"]
-
     val is_propagation_stopped : t -> bool [@@js.call "isPropagationStopped"]
-
     val target : t -> Ojs.t [@@js.get "target"]
     (* Should return Dom.eventTarget *)
 
     val time_stamp : t -> float [@@js.get "timeStamp"]
-
     val type_ : t -> string [@@js.get "type"]
-
     val persist : t -> unit [@@js.call "persist"]]
 end
 
@@ -53,7 +39,6 @@ external to_synthetic_event : 'a synthetic -> Synthetic.t = "%identity"
 
 module Clipboard = struct
   include CommonApi
-
   include [%js: val clipboard_data : t -> Ojs.t [@@js.get "clipboardData"]]
 
   (* Should return Dom.dataTransfer *)
@@ -61,7 +46,6 @@ end
 
 module Composition = struct
   include CommonApi
-
   include [%js: val data : t -> string [@@js.get "data"]]
 end
 
@@ -71,27 +55,16 @@ module Keyboard = struct
   include
     [%js:
     val alt_key : t -> bool [@@js.get "altKey"]
-
     val char_code : t -> int [@@js.get "charCode"]
-
     val ctrl_key : t -> bool [@@js.get "ctrlKey"]
-
     val get_modifier_state : t -> string -> bool [@@js.call "getModifierState"]
-
     val key : t -> string [@@js.get "key"]
-
     val key_code : t -> int [@@js.get "keyCode"]
-
     val locale : t -> string [@@js.get "locale"]
-
     val location : t -> int [@@js.get "location"]
-
     val meta_key : t -> bool [@@js.get "metaKey"]
-
     val repeat : t -> bool [@@js.get "repeat"]
-
     val shift_key : t -> bool [@@js.get "shiftKey"]
-
     val which : t -> int [@@js.get "which"]]
 end
 
@@ -115,33 +88,21 @@ module Mouse = struct
   include
     [%js:
     val alt_key : t -> bool [@@js.get "altKey"]
-
     val button : t -> int [@@js.get "button"]
-
     val buttons : t -> int [@@js.get "buttons"]
-
     val client_x : t -> int [@@js.get "clientX"]
-
     val client_y : t -> int [@@js.get "clientY"]
-
     val ctrl_key : t -> bool [@@js.get "ctrlKey"]
-
     val get_modifier_state : t -> string -> bool [@@js.call "getModifierState"]
-
     val meta_key : t -> bool [@@js.get "metaKey"]
-
     val page_x : t -> int [@@js.get "pageX"]
-
     val page_y : t -> int [@@js.get "pageY"]
-
     val related_target : t -> Ojs.t option [@@js.get "relatedTarget"]
 
     (* Should return Dom.eventTarget *)
 
     val screen_x : t -> int [@@js.get "screenX"]
-
     val screen_y : t -> int [@@js.get "screenY"]
-
     val shift_key : t -> bool [@@js.get "shiftKey"]]
 end
 
@@ -155,18 +116,13 @@ module Touch = struct
   include
     [%js:
     val alt_key : t -> bool [@@js.get "altKey"]
-
     val changed_touches : t -> Ojs.t [@@js.get "changedTouches"]
     (* Should return Dom.touchList *)
 
     val ctrl_key : t -> bool [@@js.get "ctrlKey"]
-
     val get_modifier_state : t -> string -> bool [@@js.call "getModifierState"]
-
     val meta_key : t -> bool [@@js.get "metaKey"]
-
     val shift_key : t -> bool [@@js.get "shiftKey"]
-
     val target_touches : t -> Ojs.t [@@js.get "targetTouches"]
     (* Should return Dom.touchList *)
 
@@ -181,23 +137,14 @@ module Pointer = struct
   include
     [%js:
     val pointerId : t -> int [@@js.get]
-
     val pressure : t -> float [@@js.get]
-
     val tangentialPressure : t -> float [@@js.get]
-
     val tiltX : t -> float [@@js.get]
-
     val tiltY : t -> float [@@js.get]
-
     val twist : t -> float [@@js.get]
-
     val width : t -> float [@@js.get]
-
     val height : t -> float [@@js.get]
-
     val pointerType : t -> string [@@js.get]
-
     val isPrimary : t -> bool [@@js.get]]
 end
 
@@ -211,7 +158,6 @@ module UI = struct
   include
     [%js:
     val detail : t -> int [@@js.get "detail"]
-
     val view : t -> window [@@js.get "view"]]
 
   (* Should return DOMAbstractView/WindowProxy *)
@@ -223,11 +169,8 @@ module Wheel = struct
   include
     [%js:
     val delta_mode : t -> int [@@js.get "deltaMode"]
-
     val delta_x : t -> float [@@js.get "deltaX"]
-
     val delta_y : t -> float [@@js.get "deltaY"]
-
     val delta_z : t -> float [@@js.get "deltaZ"]]
 end
 
@@ -245,9 +188,7 @@ module Animation = struct
   include
     [%js:
     val animation_name : t -> string [@@js.get "animationName"]
-
     val pseudo_element : t -> string [@@js.get "pseudoElement"]
-
     val elapsed_time : t -> float [@@js.get "elapsedTime"]]
 end
 
@@ -257,8 +198,6 @@ module Transition = struct
   include
     [%js:
     val property_name : t -> string [@@js.get "propertyName"]
-
     val pseudo_element : t -> string [@@js.get "pseudoElement"]
-
     val elapsed_time : t -> float [@@js.get "elapsedTime"]]
 end

--- a/lib/event.mli
+++ b/lib/event.mli
@@ -3,37 +3,22 @@ type 'a synthetic
 
 module Synthetic : sig
   type tag
-
   type t = tag synthetic
 
   val bubbles : 'a synthetic -> bool
-
   val cancelable : 'a synthetic -> bool
-
   val current_target : 'a synthetic -> Ojs.t
-
   val default_prevented : 'a synthetic -> bool
-
   val event_phase : 'a synthetic -> int
-
   val is_trusted : 'a synthetic -> bool
-
   val native_event : 'a synthetic -> Ojs.t
-
   val prevent_default : 'a synthetic -> unit
-
   val is_default_prevented : 'a synthetic -> bool
-
   val stop_propagation : 'a synthetic -> unit
-
   val is_propagation_stopped : 'a synthetic -> bool
-
   val target : 'a synthetic -> Ojs.t
-
   val time_stamp : 'a synthetic -> float
-
   val type_ : 'a synthetic -> string
-
   val persist : 'a synthetic -> unit
 end
 
@@ -42,423 +27,239 @@ val to_synthetic_event : 'a synthetic -> Synthetic.t
 
 module Clipboard : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val clipboard_data : t -> Ojs.t
 end
 
 module Composition : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val data : t -> string
 end
 
 module Keyboard : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val alt_key : t -> bool
-
   val char_code : t -> int
-
   val ctrl_key : t -> bool
-
   val get_modifier_state : t -> string -> bool
-
   val key : t -> string
-
   val key_code : t -> int
-
   val locale : t -> string
-
   val location : t -> int
-
   val meta_key : t -> bool
-
   val repeat : t -> bool
-
   val shift_key : t -> bool
-
   val which : t -> int
 end
 
 module Focus : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val related_target : t -> Ojs.t option
 end
 
 module Form : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
 end
 
 module Mouse : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val alt_key : t -> bool
-
   val button : t -> int
-
   val buttons : t -> int
-
   val client_x : t -> int
-
   val client_y : t -> int
-
   val ctrl_key : t -> bool
-
   val get_modifier_state : t -> string -> bool
-
   val meta_key : t -> bool
-
   val page_x : t -> int
-
   val page_y : t -> int
-
   val related_target : t -> Ojs.t option
-
   val screen_x : t -> int
-
   val screen_y : t -> int
-
   val shift_key : t -> bool
 end
 
 module Selection : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
 end
 
 module Touch : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val alt_key : t -> bool
-
   val changed_touches : t -> Ojs.t
-
   val ctrl_key : t -> bool
-
   val get_modifier_state : t -> string -> bool
-
   val meta_key : t -> bool
-
   val shift_key : t -> bool
-
   val target_touches : t -> Ojs.t
-
   val touches : t -> Ojs.t
 end
 
 module Pointer : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val pointerId : t -> int
-
   val pressure : t -> float
-
   val tangentialPressure : t -> float
-
   val tiltX : t -> float
-
   val tiltY : t -> float
-
   val twist : t -> float
-
   val width : t -> float
-
   val height : t -> float
-
   val pointerType : t -> string (* 'mouse' | 'pen' | 'touch' *)
 
   val isPrimary : t -> bool
@@ -466,324 +267,182 @@ module Pointer : sig
   (** Inherited from Mouse *)
 
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val alt_key : t -> bool
-
   val button : t -> int
-
   val buttons : t -> int
-
   val client_x : t -> int
-
   val client_y : t -> int
-
   val ctrl_key : t -> bool
-
   val get_modifier_state : t -> string -> bool
-
   val meta_key : t -> bool
-
   val page_x : t -> int
-
   val page_y : t -> int
-
   val related_target : t -> Ojs.t option
-
   val screen_x : t -> int
-
   val screen_y : t -> int
-
   val shift_key : t -> bool
 end
 
 module UI : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val detail : t -> int
-
   val view : t -> Js_of_ocaml.Dom_html.window
 end
 
 module Wheel : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val delta_mode : t -> int
-
   val delta_x : t -> float
-
   val delta_y : t -> float
-
   val delta_z : t -> float
 end
 
 module Media : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
 end
 
 module Image : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
 end
 
 module Animation : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val animation_name : t -> string
-
   val pseudo_element : t -> string
-
   val elapsed_time : t -> float
 end
 
 module Transition : sig
   type tag
-
   type t = tag synthetic
 
   val t_of_js : Ojs.t -> t
-
   val t_to_js : t -> Ojs.t
-
   val bubbles : t -> bool
-
   val cancelable : t -> bool
-
   val current_target : t -> Ojs.t
-
   val default_prevented : t -> bool
-
   val event_phase : t -> int
-
   val is_trusted : t -> bool
-
   val native_event : t -> Ojs.t
-
   val prevent_default : t -> unit
-
   val is_default_prevented : t -> bool
-
   val stop_propagation : t -> unit
-
   val is_propagation_stopped : t -> bool
-
   val target : t -> Ojs.t
-
   val time_stamp : t -> float
-
   val type_ : t -> string
-
   val persist : t -> unit
-
   val property_name : t -> string
-
   val pseudo_element : t -> string
-
   val elapsed_time : t -> float
 end

--- a/lib/imports.ml
+++ b/lib/imports.ml
@@ -1,11 +1,8 @@
 type react = Ojs.t
-
 type react_dom = Ojs.t
 
 let react_to_js v = v
-
 let react_dom_to_js v = v
-
 let react : react = Js_of_ocaml.Js.Unsafe.js_expr {|require("react")|}
 
 let react_dom : react_dom =

--- a/lib/router.mli
+++ b/lib/router.mli
@@ -10,11 +10,12 @@ type watcher_id
 
 type url =
   { (* path takes window.location.path, like "/book/title/edit" and turns it into `["book", "title", "edit"]` *)
-    path: string list
+    path : string list
   ; (* the url's hash, if any. The # symbol is stripped out for you *)
-    hash: string
+    hash : string
   ; (* the url's query params, if any. The ? symbol is stripped out for you *)
-    search: string }
+    search : string
+  }
 
 val watch_url : (url -> unit) -> watcher_id
 (** start watching for URL changes. Returns a subscription token. Upon url change, calls the callback and passes it the url record *)

--- a/lib/test_utils/reactDOMTestUtils.mli
+++ b/lib/test_utils/reactDOMTestUtils.mli
@@ -1,15 +1,11 @@
 [@@@js.stop]
 
 type undefined
-
 type element
-
 type 'a node_list = 'a Js_of_ocaml.Dom.nodeList
 
 val node_list_of_js : (Ojs.t -> 'value) -> Ojs.t -> 'value node_list
-
 val node_list_to_js : ('value -> Ojs.t) -> 'value node_list -> Ojs.t
-
 val unsafe_to_element : 'a Js_of_ocaml.Js.t -> element
 
 [@@@js.start]
@@ -18,25 +14,20 @@ val unsafe_to_element : 'a Js_of_ocaml.Js.t -> element
 type undefined = Ojs.t
 
 let undefined = Ojs.variable "undefined"
-
 let undefined_to_js x = x
-
 let undefined_of_js x = x
 
 type element = Js_of_ocaml.Dom_html.element
 
 external element_of_js : Ojs.t -> Js_of_ocaml.Dom_html.element = "%identity"
-
 external element_to_js : Js_of_ocaml.Dom_html.element -> Ojs.t = "%identity"
 
 type 'a node_list = 'a Js_of_ocaml.Dom.nodeList
 
 external node_list_of_ojs : Ojs.t -> 'value node_list = "%identity"
-
 external node_list_to_js : 'value node_list -> Ojs.t = "%identity"
 
 let node_list_of_js _f x = node_list_of_ojs x
-
 let node_list_to_js _f x = node_list_to_js x
 
 external unsafe_to_element : 'a Js_of_ocaml.Js.t -> element = "%identity"]
@@ -46,7 +37,10 @@ val act : (unit -> unit) -> unit
     val act : (unit -> undefined) -> unit
       [@@js.global "__LIB__reactDOMTestUtils.act"]
 
-    let act f = act (fun () -> f () ; undefined)]
+    let act f =
+      act (fun () ->
+          f ();
+          undefined)]
 
 module Simulate : sig
   val click : element -> unit
@@ -72,7 +66,6 @@ module DOM : sig
         find a f 0
 
       val textContent : element -> string [@@js.get]
-
       val includes : string -> string -> bool [@@js.call]
 
       let findBySelectorAndPartialTextContent element selector content =

--- a/ppx/.ocamlformat
+++ b/ppx/.ocamlformat
@@ -1,1 +1,0 @@
-profile = ocamlformat

--- a/ppx/html.ml
+++ b/ppx/html.ml
@@ -1,6 +1,13 @@
 let ( & ) = List.append
 
-type attributeType = String | Int | Float | Bool | Style | Ref | InnerHtml
+type attributeType =
+  | String
+  | Int
+  | Float
+  | Bool
+  | Style
+  | Ref
+  | InnerHtml
 
 type eventType =
   | Clipboard
@@ -20,13 +27,25 @@ type eventType =
   | Pointer
   | Drag
 
-type attribute = {type_: attributeType; name: string; jsxName: string}
+type attribute =
+  { type_ : attributeType
+  ; name : string
+  ; jsxName : string
+  }
 
-type event = {type_: eventType; name: string}
+type event =
+  { type_ : eventType
+  ; name : string
+  }
 
-type prop = Attribute of attribute | Event of event
+type prop =
+  | Attribute of attribute
+  | Event of event
 
-type element = {tag: string; attributes: prop list}
+type element =
+  { tag : string
+  ; attributes : prop list
+  }
 
 let attributeReferrerPolicy = String
 (* | Empty
@@ -48,219 +67,226 @@ let attributeAnchorTarget = String
 
 let globalEventHandlers =
   (* https://developer.mozilla.org/en-US/docs/Web/Events/Event_handlers *)
-  [ Event {name= "onCopy"; type_= Clipboard}
-  ; Event {name= "onCopyCapture"; type_= Clipboard}
-  ; Event {name= "onCut"; type_= Clipboard}
-  ; Event {name= "onCutCapture"; type_= Clipboard}
-  ; Event {name= "onPaste"; type_= Clipboard}
-  ; Event {name= "onPasteCapture"; type_= Clipboard}
-  ; Event {name= "onCompositionEnd"; type_= Composition}
-  ; Event {name= "onCompositionEndCapture"; type_= Composition}
-  ; Event {name= "onCompositionStart"; type_= Composition}
-  ; Event {name= "onCompositionStartCapture"; type_= Composition}
-  ; Event {name= "onCompositionUpdate"; type_= Composition}
-  ; Event {name= "onCompositionUpdateCapture"; type_= Composition}
-  ; Event {name= "onFocus"; type_= Focus}
-  ; Event {name= "onFocusCapture"; type_= Focus}
-  ; Event {name= "onBlur"; type_= Focus}
-  ; Event {name= "onBlurCapture"; type_= Focus}
-  ; Event {name= "onChange"; type_= Form}
-  ; Event {name= "onChangeCapture"; type_= Form}
-  ; Event {name= "onBeforeInput"; type_= Form}
-  ; Event {name= "onBeforeInputCapture"; type_= Form}
-  ; Event {name= "onInput"; type_= Form}
-  ; Event {name= "onInputCapture"; type_= Form}
-  ; Event {name= "onReset"; type_= Form}
-  ; Event {name= "onResetCapture"; type_= Form}
-  ; Event {name= "onSubmit"; type_= Form}
-  ; Event {name= "onSubmitCapture"; type_= Form}
-  ; Event {name= "onInvalid"; type_= Form}
-  ; Event {name= "onInvalidCapture"; type_= Form}
-  ; Event {name= "onLoad"; type_= Media}
-  ; Event {name= "onLoadCapture"; type_= Media}
-  ; Event {name= "onError"; type_= Media}
-  ; Event {name= "onErrorCapture"; type_= Media}
-  ; Event {name= "onKeyDown"; type_= Keyboard}
-  ; Event {name= "onKeyDownCapture"; type_= Keyboard}
-  ; Event {name= "onKeyPress"; type_= Keyboard}
-  ; Event {name= "onKeyPressCapture"; type_= Keyboard}
-  ; Event {name= "onKeyUp"; type_= Keyboard}
-  ; Event {name= "onKeyUpCapture"; type_= Keyboard}
-  ; Event {name= "onAbort"; type_= Media}
-  ; Event {name= "onAbortCapture"; type_= Media}
-  ; Event {name= "onCanPlay"; type_= Media}
-  ; Event {name= "onCanPlayCapture"; type_= Media}
-  ; Event {name= "onCanPlayThrough"; type_= Media}
-  ; Event {name= "onCanPlayThroughCapture"; type_= Media}
-  ; Event {name= "onDurationChange"; type_= Media}
-  ; Event {name= "onDurationChangeCapture"; type_= Media}
-  ; Event {name= "onEmptied"; type_= Media}
-  ; Event {name= "onEmptiedCapture"; type_= Media}
-  ; Event {name= "onEncrypted"; type_= Media}
-  ; Event {name= "onEncryptedCapture"; type_= Media}
-  ; Event {name= "onEnded"; type_= Media}
-  ; Event {name= "onEndedCapture"; type_= Media}
-  ; Event {name= "onLoadedData"; type_= Media}
-  ; Event {name= "onLoadedDataCapture"; type_= Media}
-  ; Event {name= "onLoadedMetadata"; type_= Media}
-  ; Event {name= "onLoadedMetadataCapture"; type_= Media}
-  ; Event {name= "onLoadStart"; type_= Media}
-  ; Event {name= "onLoadStartCapture"; type_= Media}
-  ; Event {name= "onPause"; type_= Media}
-  ; Event {name= "onPauseCapture"; type_= Media}
-  ; Event {name= "onPlay"; type_= Media}
-  ; Event {name= "onPlayCapture"; type_= Media}
-  ; Event {name= "onPlaying"; type_= Media}
-  ; Event {name= "onPlayingCapture"; type_= Media}
-  ; Event {name= "onProgress"; type_= Media}
-  ; Event {name= "onProgressCapture"; type_= Media}
-  ; Event {name= "onRateChange"; type_= Media}
-  ; Event {name= "onRateChangeCapture"; type_= Media}
-  ; Event {name= "onSeeked"; type_= Media}
-  ; Event {name= "onSeekedCapture"; type_= Media}
-  ; Event {name= "onSeeking"; type_= Media}
-  ; Event {name= "onSeekingCapture"; type_= Media}
-  ; Event {name= "onStalled"; type_= Media}
-  ; Event {name= "onStalledCapture"; type_= Media}
-  ; Event {name= "onSuspend"; type_= Media}
-  ; Event {name= "onSuspendCapture"; type_= Media}
-  ; Event {name= "onTimeUpdate"; type_= Media}
-  ; Event {name= "onTimeUpdateCapture"; type_= Media}
-  ; Event {name= "onVolumeChange"; type_= Media}
-  ; Event {name= "onVolumeChangeCapture"; type_= Media}
-  ; Event {name= "onWaiting"; type_= Media}
-  ; Event {name= "onWaitingCapture"; type_= Media}
-  ; Event {name= "onAuxClick"; type_= Mouse}
-  ; Event {name= "onAuxClickCapture"; type_= Mouse}
-  ; Event {name= "onClick"; type_= Mouse}
-  ; Event {name= "onClickCapture"; type_= Mouse}
-  ; Event {name= "onContextMenu"; type_= Mouse}
-  ; Event {name= "onContextMenuCapture"; type_= Mouse}
-  ; Event {name= "onDoubleClick"; type_= Mouse}
-  ; Event {name= "onDoubleClickCapture"; type_= Mouse}
-  ; Event {name= "onDrag"; type_= Drag}
-  ; Event {name= "onDragCapture"; type_= Drag}
-  ; Event {name= "onDragEnd"; type_= Drag}
-  ; Event {name= "onDragEndCapture"; type_= Drag}
-  ; Event {name= "onDragEnter"; type_= Drag}
-  ; Event {name= "onDragEnterCapture"; type_= Drag}
-  ; Event {name= "onDragExit"; type_= Drag}
-  ; Event {name= "onDragExitCapture"; type_= Drag}
-  ; Event {name= "onDragLeave"; type_= Drag}
-  ; Event {name= "onDragLeaveCapture"; type_= Drag}
-  ; Event {name= "onDragOver"; type_= Drag}
-  ; Event {name= "onDragOverCapture"; type_= Drag}
-  ; Event {name= "onDragStart"; type_= Drag}
-  ; Event {name= "onDragStartCapture"; type_= Drag}
-  ; Event {name= "onDrop"; type_= Drag}
-  ; Event {name= "onDropCapture"; type_= Drag}
-  ; Event {name= "onMouseDown"; type_= Mouse}
-  ; Event {name= "onMouseDownCapture"; type_= Mouse}
-  ; Event {name= "onMouseEnter"; type_= Mouse}
-  ; Event {name= "onMouseLeave"; type_= Mouse}
-  ; Event {name= "onMouseMove"; type_= Mouse}
-  ; Event {name= "onMouseMoveCapture"; type_= Mouse}
-  ; Event {name= "onMouseOut"; type_= Mouse}
-  ; Event {name= "onMouseOutCapture"; type_= Mouse}
-  ; Event {name= "onMouseOver"; type_= Mouse}
-  ; Event {name= "onMouseOverCapture"; type_= Mouse}
-  ; Event {name= "onMouseUp"; type_= Mouse}
-  ; Event {name= "onMouseUpCapture"; type_= Mouse}
-  ; Event {name= "onSelect"; type_= Selection}
-  ; Event {name= "onSelectCapture"; type_= Selection}
-  ; Event {name= "onTouchCancel"; type_= Touch}
-  ; Event {name= "onTouchCancelCapture"; type_= Touch}
-  ; Event {name= "onTouchEnd"; type_= Touch}
-  ; Event {name= "onTouchEndCapture"; type_= Touch}
-  ; Event {name= "onTouchMove"; type_= Touch}
-  ; Event {name= "onTouchMoveCapture"; type_= Touch}
-  ; Event {name= "onTouchStart"; type_= Touch}
-  ; Event {name= "onTouchStartCapture"; type_= Touch}
-  ; Event {name= "onPointerDown"; type_= Pointer}
-  ; Event {name= "onPointerDownCapture"; type_= Pointer}
-  ; Event {name= "onPointerMove"; type_= Pointer}
-  ; Event {name= "onPointerMoveCapture"; type_= Pointer}
-  ; Event {name= "onPointerUp"; type_= Pointer}
-  ; Event {name= "onPointerUpCapture"; type_= Pointer}
-  ; Event {name= "onPointerCancel"; type_= Pointer}
-  ; Event {name= "onPointerCancelCapture"; type_= Pointer}
-  ; Event {name= "onPointerEnter"; type_= Pointer}
-  ; Event {name= "onPointerEnterCapture"; type_= Pointer}
-  ; Event {name= "onPointerLeave"; type_= Pointer}
-  ; Event {name= "onPointerLeaveCapture"; type_= Pointer}
-  ; Event {name= "onPointerOver"; type_= Pointer}
-  ; Event {name= "onPointerOverCapture"; type_= Pointer}
-  ; Event {name= "onPointerOut"; type_= Pointer}
-  ; Event {name= "onPointerOutCapture"; type_= Pointer}
-  ; Event {name= "onGotPointerCapture"; type_= Pointer}
-  ; Event {name= "onGotPointerCaptureCapture"; type_= Pointer}
-  ; Event {name= "onLostPointerCapture"; type_= Pointer}
-  ; Event {name= "onLostPointerCaptureCapture"; type_= Pointer}
-  ; Event {name= "onScroll"; type_= UI}
-  ; Event {name= "onScrollCapture"; type_= UI}
-  ; Event {name= "onWheel"; type_= Wheel}
-  ; Event {name= "onWheelCapture"; type_= Wheel}
-  ; Event {name= "onAnimationStart"; type_= Animation}
-  ; Event {name= "onAnimationStartCapture"; type_= Animation}
-  ; Event {name= "onAnimationEnd"; type_= Animation}
-  ; Event {name= "onAnimationEndCapture"; type_= Animation}
-  ; Event {name= "onAnimationIteration"; type_= Animation}
-  ; Event {name= "onAnimationIterationCapture"; type_= Animation}
-  ; Event {name= "onTransitionEnd"; type_= Transition}
-  ; Event {name= "onTransitionEndCapture"; type_= Transition} ]
+  [ Event { name = "onCopy"; type_ = Clipboard }
+  ; Event { name = "onCopyCapture"; type_ = Clipboard }
+  ; Event { name = "onCut"; type_ = Clipboard }
+  ; Event { name = "onCutCapture"; type_ = Clipboard }
+  ; Event { name = "onPaste"; type_ = Clipboard }
+  ; Event { name = "onPasteCapture"; type_ = Clipboard }
+  ; Event { name = "onCompositionEnd"; type_ = Composition }
+  ; Event { name = "onCompositionEndCapture"; type_ = Composition }
+  ; Event { name = "onCompositionStart"; type_ = Composition }
+  ; Event { name = "onCompositionStartCapture"; type_ = Composition }
+  ; Event { name = "onCompositionUpdate"; type_ = Composition }
+  ; Event { name = "onCompositionUpdateCapture"; type_ = Composition }
+  ; Event { name = "onFocus"; type_ = Focus }
+  ; Event { name = "onFocusCapture"; type_ = Focus }
+  ; Event { name = "onBlur"; type_ = Focus }
+  ; Event { name = "onBlurCapture"; type_ = Focus }
+  ; Event { name = "onChange"; type_ = Form }
+  ; Event { name = "onChangeCapture"; type_ = Form }
+  ; Event { name = "onBeforeInput"; type_ = Form }
+  ; Event { name = "onBeforeInputCapture"; type_ = Form }
+  ; Event { name = "onInput"; type_ = Form }
+  ; Event { name = "onInputCapture"; type_ = Form }
+  ; Event { name = "onReset"; type_ = Form }
+  ; Event { name = "onResetCapture"; type_ = Form }
+  ; Event { name = "onSubmit"; type_ = Form }
+  ; Event { name = "onSubmitCapture"; type_ = Form }
+  ; Event { name = "onInvalid"; type_ = Form }
+  ; Event { name = "onInvalidCapture"; type_ = Form }
+  ; Event { name = "onLoad"; type_ = Media }
+  ; Event { name = "onLoadCapture"; type_ = Media }
+  ; Event { name = "onError"; type_ = Media }
+  ; Event { name = "onErrorCapture"; type_ = Media }
+  ; Event { name = "onKeyDown"; type_ = Keyboard }
+  ; Event { name = "onKeyDownCapture"; type_ = Keyboard }
+  ; Event { name = "onKeyPress"; type_ = Keyboard }
+  ; Event { name = "onKeyPressCapture"; type_ = Keyboard }
+  ; Event { name = "onKeyUp"; type_ = Keyboard }
+  ; Event { name = "onKeyUpCapture"; type_ = Keyboard }
+  ; Event { name = "onAbort"; type_ = Media }
+  ; Event { name = "onAbortCapture"; type_ = Media }
+  ; Event { name = "onCanPlay"; type_ = Media }
+  ; Event { name = "onCanPlayCapture"; type_ = Media }
+  ; Event { name = "onCanPlayThrough"; type_ = Media }
+  ; Event { name = "onCanPlayThroughCapture"; type_ = Media }
+  ; Event { name = "onDurationChange"; type_ = Media }
+  ; Event { name = "onDurationChangeCapture"; type_ = Media }
+  ; Event { name = "onEmptied"; type_ = Media }
+  ; Event { name = "onEmptiedCapture"; type_ = Media }
+  ; Event { name = "onEncrypted"; type_ = Media }
+  ; Event { name = "onEncryptedCapture"; type_ = Media }
+  ; Event { name = "onEnded"; type_ = Media }
+  ; Event { name = "onEndedCapture"; type_ = Media }
+  ; Event { name = "onLoadedData"; type_ = Media }
+  ; Event { name = "onLoadedDataCapture"; type_ = Media }
+  ; Event { name = "onLoadedMetadata"; type_ = Media }
+  ; Event { name = "onLoadedMetadataCapture"; type_ = Media }
+  ; Event { name = "onLoadStart"; type_ = Media }
+  ; Event { name = "onLoadStartCapture"; type_ = Media }
+  ; Event { name = "onPause"; type_ = Media }
+  ; Event { name = "onPauseCapture"; type_ = Media }
+  ; Event { name = "onPlay"; type_ = Media }
+  ; Event { name = "onPlayCapture"; type_ = Media }
+  ; Event { name = "onPlaying"; type_ = Media }
+  ; Event { name = "onPlayingCapture"; type_ = Media }
+  ; Event { name = "onProgress"; type_ = Media }
+  ; Event { name = "onProgressCapture"; type_ = Media }
+  ; Event { name = "onRateChange"; type_ = Media }
+  ; Event { name = "onRateChangeCapture"; type_ = Media }
+  ; Event { name = "onSeeked"; type_ = Media }
+  ; Event { name = "onSeekedCapture"; type_ = Media }
+  ; Event { name = "onSeeking"; type_ = Media }
+  ; Event { name = "onSeekingCapture"; type_ = Media }
+  ; Event { name = "onStalled"; type_ = Media }
+  ; Event { name = "onStalledCapture"; type_ = Media }
+  ; Event { name = "onSuspend"; type_ = Media }
+  ; Event { name = "onSuspendCapture"; type_ = Media }
+  ; Event { name = "onTimeUpdate"; type_ = Media }
+  ; Event { name = "onTimeUpdateCapture"; type_ = Media }
+  ; Event { name = "onVolumeChange"; type_ = Media }
+  ; Event { name = "onVolumeChangeCapture"; type_ = Media }
+  ; Event { name = "onWaiting"; type_ = Media }
+  ; Event { name = "onWaitingCapture"; type_ = Media }
+  ; Event { name = "onAuxClick"; type_ = Mouse }
+  ; Event { name = "onAuxClickCapture"; type_ = Mouse }
+  ; Event { name = "onClick"; type_ = Mouse }
+  ; Event { name = "onClickCapture"; type_ = Mouse }
+  ; Event { name = "onContextMenu"; type_ = Mouse }
+  ; Event { name = "onContextMenuCapture"; type_ = Mouse }
+  ; Event { name = "onDoubleClick"; type_ = Mouse }
+  ; Event { name = "onDoubleClickCapture"; type_ = Mouse }
+  ; Event { name = "onDrag"; type_ = Drag }
+  ; Event { name = "onDragCapture"; type_ = Drag }
+  ; Event { name = "onDragEnd"; type_ = Drag }
+  ; Event { name = "onDragEndCapture"; type_ = Drag }
+  ; Event { name = "onDragEnter"; type_ = Drag }
+  ; Event { name = "onDragEnterCapture"; type_ = Drag }
+  ; Event { name = "onDragExit"; type_ = Drag }
+  ; Event { name = "onDragExitCapture"; type_ = Drag }
+  ; Event { name = "onDragLeave"; type_ = Drag }
+  ; Event { name = "onDragLeaveCapture"; type_ = Drag }
+  ; Event { name = "onDragOver"; type_ = Drag }
+  ; Event { name = "onDragOverCapture"; type_ = Drag }
+  ; Event { name = "onDragStart"; type_ = Drag }
+  ; Event { name = "onDragStartCapture"; type_ = Drag }
+  ; Event { name = "onDrop"; type_ = Drag }
+  ; Event { name = "onDropCapture"; type_ = Drag }
+  ; Event { name = "onMouseDown"; type_ = Mouse }
+  ; Event { name = "onMouseDownCapture"; type_ = Mouse }
+  ; Event { name = "onMouseEnter"; type_ = Mouse }
+  ; Event { name = "onMouseLeave"; type_ = Mouse }
+  ; Event { name = "onMouseMove"; type_ = Mouse }
+  ; Event { name = "onMouseMoveCapture"; type_ = Mouse }
+  ; Event { name = "onMouseOut"; type_ = Mouse }
+  ; Event { name = "onMouseOutCapture"; type_ = Mouse }
+  ; Event { name = "onMouseOver"; type_ = Mouse }
+  ; Event { name = "onMouseOverCapture"; type_ = Mouse }
+  ; Event { name = "onMouseUp"; type_ = Mouse }
+  ; Event { name = "onMouseUpCapture"; type_ = Mouse }
+  ; Event { name = "onSelect"; type_ = Selection }
+  ; Event { name = "onSelectCapture"; type_ = Selection }
+  ; Event { name = "onTouchCancel"; type_ = Touch }
+  ; Event { name = "onTouchCancelCapture"; type_ = Touch }
+  ; Event { name = "onTouchEnd"; type_ = Touch }
+  ; Event { name = "onTouchEndCapture"; type_ = Touch }
+  ; Event { name = "onTouchMove"; type_ = Touch }
+  ; Event { name = "onTouchMoveCapture"; type_ = Touch }
+  ; Event { name = "onTouchStart"; type_ = Touch }
+  ; Event { name = "onTouchStartCapture"; type_ = Touch }
+  ; Event { name = "onPointerDown"; type_ = Pointer }
+  ; Event { name = "onPointerDownCapture"; type_ = Pointer }
+  ; Event { name = "onPointerMove"; type_ = Pointer }
+  ; Event { name = "onPointerMoveCapture"; type_ = Pointer }
+  ; Event { name = "onPointerUp"; type_ = Pointer }
+  ; Event { name = "onPointerUpCapture"; type_ = Pointer }
+  ; Event { name = "onPointerCancel"; type_ = Pointer }
+  ; Event { name = "onPointerCancelCapture"; type_ = Pointer }
+  ; Event { name = "onPointerEnter"; type_ = Pointer }
+  ; Event { name = "onPointerEnterCapture"; type_ = Pointer }
+  ; Event { name = "onPointerLeave"; type_ = Pointer }
+  ; Event { name = "onPointerLeaveCapture"; type_ = Pointer }
+  ; Event { name = "onPointerOver"; type_ = Pointer }
+  ; Event { name = "onPointerOverCapture"; type_ = Pointer }
+  ; Event { name = "onPointerOut"; type_ = Pointer }
+  ; Event { name = "onPointerOutCapture"; type_ = Pointer }
+  ; Event { name = "onGotPointerCapture"; type_ = Pointer }
+  ; Event { name = "onGotPointerCaptureCapture"; type_ = Pointer }
+  ; Event { name = "onLostPointerCapture"; type_ = Pointer }
+  ; Event { name = "onLostPointerCaptureCapture"; type_ = Pointer }
+  ; Event { name = "onScroll"; type_ = UI }
+  ; Event { name = "onScrollCapture"; type_ = UI }
+  ; Event { name = "onWheel"; type_ = Wheel }
+  ; Event { name = "onWheelCapture"; type_ = Wheel }
+  ; Event { name = "onAnimationStart"; type_ = Animation }
+  ; Event { name = "onAnimationStartCapture"; type_ = Animation }
+  ; Event { name = "onAnimationEnd"; type_ = Animation }
+  ; Event { name = "onAnimationEndCapture"; type_ = Animation }
+  ; Event { name = "onAnimationIteration"; type_ = Animation }
+  ; Event { name = "onAnimationIterationCapture"; type_ = Animation }
+  ; Event { name = "onTransitionEnd"; type_ = Transition }
+  ; Event { name = "onTransitionEndCapture"; type_ = Transition }
+  ]
 
 (* All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/ *)
 let ariaAttributes =
   [ (* Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. *)
     Attribute
-      { name= "ariaActivedescendant"
-      ; jsxName= "aria-activedescendant"
-      ; type_= String }
+      { name = "ariaActivedescendant"
+      ; jsxName = "aria-activedescendant"
+      ; type_ = String
+      }
     (* Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. *)
   ; Attribute
-      { name= "ariaAtomic"
-      ; jsxName= "aria-atomic"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaAtomic"
+      ; jsxName = "aria-atomic"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
      * presented if they are made.
      *)
   ; Attribute
-      { name= "ariaAutocomplete"
-      ; jsxName= "aria-autocomplete"
-      ; type_= String (* 'none' | 'inline' | 'list' | 'both' *) }
+      { name = "ariaAutocomplete"
+      ; jsxName = "aria-autocomplete"
+      ; type_ = String (* 'none' | 'inline' | 'list' | 'both' *)
+      }
     (* Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. *)
   ; Attribute
-      { name= "ariaBusy"
-      ; jsxName= "aria-busy"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaBusy"
+      ; jsxName = "aria-busy"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
      * @see aria-pressed @see aria-selected.
      *)
   ; Attribute
-      { name= "ariaChecked"
-      ; jsxName= "aria-checked"
-      ; type_= String (* Bool | 'false' | 'mixed' | 'true' *) }
+      { name = "ariaChecked"
+      ; jsxName = "aria-checked"
+      ; type_ = String (* Bool | 'false' | 'mixed' | 'true' *)
+      }
     (* Defines the total number of columns in a table, grid, or treegrid.
      * @see aria-colindex.
      *)
-  ; Attribute {name= "ariaColcount"; jsxName= "aria-colcount"; type_= Int}
+  ; Attribute { name = "ariaColcount"; jsxName = "aria-colcount"; type_ = Int }
     (* Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
      * @see aria-colcount @see aria-colspan.
      *)
-  ; Attribute {name= "ariaColindex"; jsxName= "aria-colindex"; type_= Int}
+  ; Attribute { name = "ariaColindex"; jsxName = "aria-colindex"; type_ = Int }
     (* Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
      * @see aria-colindex @see aria-rowspan.
      *)
-  ; Attribute {name= "ariaColspan"; jsxName= "aria-colspan"; type_= Int}
+  ; Attribute { name = "ariaColspan"; jsxName = "aria-colspan"; type_ = Int }
     (* Identifies the element (or elements) whose contents or presence are controlled by the current element.
      * @see aria-owns.
      *)
-  ; Attribute {name= "ariaControls"; jsxName= "aria-controls"; type_= String}
+  ; Attribute
+      { name = "ariaControls"; jsxName = "aria-controls"; type_ = String }
     (* Indicates the element that represents the current item within a container or set of related elements. *)
   ; Attribute
-      { name= "ariaCurrent"
-      ; jsxName= "aria-current"
-      ; type_=
+      { name = "ariaCurrent"
+      ; jsxName = "aria-current"
+      ; type_ =
           String
           (* Bool | 'false' | 'true' |  'page' | 'step' | 'location' | 'date' | 'time' *)
       }
@@ -268,53 +294,59 @@ let ariaAttributes =
      * @see aria-labelledby
      *)
   ; Attribute
-      {name= "ariaDescribedby"; jsxName= "aria-describedby"; type_= String}
+      { name = "ariaDescribedby"; jsxName = "aria-describedby"; type_ = String }
     (* Identifies the element that provides a detailed, extended description for the object.
      * @see aria-describedby.
      *)
-  ; Attribute {name= "ariaDetails"; jsxName= "aria-details"; type_= String}
+  ; Attribute { name = "ariaDetails"; jsxName = "aria-details"; type_ = String }
     (* Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
      * @see aria-hidden @see aria-readonly.
      *)
   ; Attribute
-      { name= "ariaDisabled"
-      ; jsxName= "aria-disabled"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaDisabled"
+      ; jsxName = "aria-disabled"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Indicates what functions can be performed when a dragged object is released on the drop target.
      * @deprecated in ARIA 1.1
      *)
   ; Attribute
-      { name= "ariaDropeffect"
-      ; jsxName= "aria-dropeffect"
-      ; type_=
+      { name = "ariaDropeffect"
+      ; jsxName = "aria-dropeffect"
+      ; type_ =
           String (* 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' *)
       }
     (* Identifies the element that provides an error message for the object.
      * @see aria-invalid @see aria-describedby.
      *)
   ; Attribute
-      {name= "ariaErrormessage"; jsxName= "aria-errormessage"; type_= String}
+      { name = "ariaErrormessage"
+      ; jsxName = "aria-errormessage"
+      ; type_ = String
+      }
     (* Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. *)
   ; Attribute
-      { name= "ariaExpanded"
-      ; jsxName= "aria-expanded"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaExpanded"
+      ; jsxName = "aria-expanded"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
      * allows assistive technology to override the general default of reading in document source order.
      *)
-  ; Attribute {name= "ariaFlowto"; jsxName= "aria-flowto"; type_= String}
+  ; Attribute { name = "ariaFlowto"; jsxName = "aria-flowto"; type_ = String }
     (* Indicates an element's "grabbed" state in a drag-and-drop operation.
      * @deprecated in ARIA 1.1
      *)
   ; Attribute
-      { name= "ariaGrabbed"
-      ; jsxName= "aria-grabbed"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaGrabbed"
+      ; jsxName = "aria-grabbed"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. *)
   ; Attribute
-      { name= "ariaHaspopup"
-      ; jsxName= "aria-haspopup"
-      ; type_=
+      { name = "ariaHaspopup"
+      ; jsxName = "aria-haspopup"
+      ; type_ =
           String
           (* Bool | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog'; *)
       }
@@ -322,141 +354,158 @@ let ariaAttributes =
      * @see aria-disabled.
      *)
   ; Attribute
-      { name= "ariaHidden"
-      ; jsxName= "aria-hidden"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaHidden"
+      ; jsxName = "aria-hidden"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Indicates the entered value does not conform to the format expected by the application.
      * @see aria-errormessage.
      *)
   ; Attribute
-      { name= "ariaInvalid"
-      ; jsxName= "aria-invalid"
-      ; type_= String (* Bool | 'false' | 'true' |  'grammar' | 'spelling'; *)
+      { name = "ariaInvalid"
+      ; jsxName = "aria-invalid"
+      ; type_ = String (* Bool | 'false' | 'true' |  'grammar' | 'spelling'; *)
       }
     (* Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. *)
   ; Attribute
-      {name= "ariaKeyshortcuts"; jsxName= "aria-keyshortcuts"; type_= String}
+      { name = "ariaKeyshortcuts"
+      ; jsxName = "aria-keyshortcuts"
+      ; type_ = String
+      }
     (* Defines a String value that labels the current element.
      * @see aria-labelledby.
      *)
-  ; Attribute {name= "ariaLabel"; jsxName= "aria-label"; type_= String}
+  ; Attribute { name = "ariaLabel"; jsxName = "aria-label"; type_ = String }
     (* Identifies the element (or elements) that labels the current element.
      * @see aria-describedby.
      *)
-  ; Attribute {name= "ariaLabelledby"; jsxName= "aria-labelledby"; type_= String}
+  ; Attribute
+      { name = "ariaLabelledby"; jsxName = "aria-labelledby"; type_ = String }
     (* Defines the hierarchical level of an element within a structure. *)
-  ; Attribute {name= "ariaLevel"; jsxName= "aria-level"; type_= Int}
+  ; Attribute { name = "ariaLevel"; jsxName = "aria-level"; type_ = Int }
     (* Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect ;rom the live region. *)
   ; Attribute
-      { name= "ariaLive"
-      ; jsxName= "aria-live"
-      ; type_= String (* 'off' | 'assertive' | 'polite' *) }
+      { name = "ariaLive"
+      ; jsxName = "aria-live"
+      ; type_ = String (* 'off' | 'assertive' | 'polite' *)
+      }
     (* Indicates whether an element is modal when displayed. *)
   ; Attribute
-      { name= "ariaModal"
-      ; jsxName= "aria-modal"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaModal"
+      ; jsxName = "aria-modal"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Indicates whether a text box accepts multiple lines of input or only a single line. *)
   ; Attribute
-      { name= "ariaMultiline"
-      ; jsxName= "aria-multiline"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaMultiline"
+      ; jsxName = "aria-multiline"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Indicates that the user may select more than one item from the current selectable descendants. *)
   ; Attribute
-      { name= "ariaMultiselectable"
-      ; jsxName= "aria-multiselectable"
-      ; type_= String (* Bool |  'false' | 'true' *) }
+      { name = "ariaMultiselectable"
+      ; jsxName = "aria-multiselectable"
+      ; type_ = String (* Bool |  'false' | 'true' *)
+      }
     (* Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. *)
   ; Attribute
-      { name= "ariaOrientation"
-      ; jsxName= "aria-orientation"
-      ; type_= String (* 'horizontal' | 'vertical' *) }
+      { name = "ariaOrientation"
+      ; jsxName = "aria-orientation"
+      ; type_ = String (* 'horizontal' | 'vertical' *)
+      }
     (* Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
      * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
      * @see aria-controls.
      *)
-  ; Attribute {name= "ariaOwns"; jsxName= "aria-owns"; type_= String}
+  ; Attribute { name = "ariaOwns"; jsxName = "aria-owns"; type_ = String }
     (* Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
      * A hint could be a sample value or a brief description of the expected format.
      *)
   ; Attribute
-      {name= "ariaPlaceholder"; jsxName= "aria-placeholder"; type_= String}
+      { name = "ariaPlaceholder"; jsxName = "aria-placeholder"; type_ = String }
     (* Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
      * @see aria-setsize.
      *)
-  ; Attribute {name= "ariaPosinset"; jsxName= "aria-posinset"; type_= Int}
+  ; Attribute { name = "ariaPosinset"; jsxName = "aria-posinset"; type_ = Int }
     (* Indicates the current "pressed" state of toggle buttons.
      * @see aria-checked @see aria-selected.
      *)
   ; Attribute
-      { name= "ariaPressed"
-      ; jsxName= "aria-pressed"
-      ; type_= String (* Bool | 'false' | 'mixed' | 'true' *) }
+      { name = "ariaPressed"
+      ; jsxName = "aria-pressed"
+      ; type_ = String (* Bool | 'false' | 'mixed' | 'true' *)
+      }
     (* Indicates that the element is not editable, but is otherwise operable.
      * @see aria-disabled.
      *)
   ; Attribute
-      { name= "ariaReadonly"
-      ; jsxName= "aria-readonly"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaReadonly"
+      ; jsxName = "aria-readonly"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
      * @see aria-atomic.
      *)
   ; Attribute
-      { name= "ariaRelevant"
-      ; jsxName= "aria-relevant"
-      ; type_=
+      { name = "ariaRelevant"
+      ; jsxName = "aria-relevant"
+      ; type_ =
           String
           (* 'additions' | 'additions removals' | 'additions text' | 'all' | 'removals' | 'removals additions' | 'removals text' | 'text' | 'text additions' | 'text removals' *)
       }
     (* Indicates that user input is required on the element before a form may be submitted. *)
   ; Attribute
-      { name= "ariaRequired"
-      ; jsxName= "aria-required"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaRequired"
+      ; jsxName = "aria-required"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Defines a human-readable, author-localized description for the role of an element. *)
   ; Attribute
-      { name= "ariaRoledescription"
-      ; jsxName= "aria-roledescription"
-      ; type_= String }
+      { name = "ariaRoledescription"
+      ; jsxName = "aria-roledescription"
+      ; type_ = String
+      }
     (* Defines the total number of rows in a table, grid, or treegrid.
      * @see aria-rowindex.
      *)
-  ; Attribute {name= "ariaRowcount"; jsxName= "aria-rowcount"; type_= Int}
+  ; Attribute { name = "ariaRowcount"; jsxName = "aria-rowcount"; type_ = Int }
     (* Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
      * @see aria-rowcount @see aria-rowspan.
      *)
-  ; Attribute {name= "ariaRowindex"; jsxName= "aria-rowindex"; type_= Int}
+  ; Attribute { name = "ariaRowindex"; jsxName = "aria-rowindex"; type_ = Int }
     (* Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
      * @see aria-rowindex @see aria-colspan.
      *)
-  ; Attribute {name= "ariaRowspan"; jsxName= "aria-rowspan"; type_= Int}
+  ; Attribute { name = "ariaRowspan"; jsxName = "aria-rowspan"; type_ = Int }
     (* Indicates the current "selected" state of various widgets.
      * @see aria-checked @see aria-pressed.
      *)
   ; Attribute
-      { name= "ariaSelected"
-      ; jsxName= "aria-selected"
-      ; type_= String (* Bool | 'false' | 'true' *) }
+      { name = "ariaSelected"
+      ; jsxName = "aria-selected"
+      ; type_ = String (* Bool | 'false' | 'true' *)
+      }
     (* Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
      * @see aria-posinset.
      *)
-  ; Attribute {name= "ariaSetsize"; jsxName= "aria-setsize"; type_= Int}
+  ; Attribute { name = "ariaSetsize"; jsxName = "aria-setsize"; type_ = Int }
     (* Indicates if items in a table or grid are sorted in ascending or descending order. *)
   ; Attribute
-      { name= "ariaSort"
-      ; jsxName= "aria-sort"
-      ; type_= String (* 'none' | 'ascending' | 'descending' | 'other' *) }
+      { name = "ariaSort"
+      ; jsxName = "aria-sort"
+      ; type_ = String (* 'none' | 'ascending' | 'descending' | 'other' *)
+      }
     (* Defines the maximum allowed value for a range widget. *)
-  ; Attribute {name= "ariaValuemax"; jsxName= "aria-valuemax"; type_= Int}
+  ; Attribute { name = "ariaValuemax"; jsxName = "aria-valuemax"; type_ = Int }
     (* Defines the minimum allowed value for a range widget. *)
-  ; Attribute {name= "ariaValuemin"; jsxName= "aria-valuemin"; type_= Int}
+  ; Attribute { name = "ariaValuemin"; jsxName = "aria-valuemin"; type_ = Int }
     (* Defines the current value for a range widget.
      * @see aria-valuetext.
      *)
-  ; Attribute {name= "ariaValuenow"; jsxName= "aria-valuenow"; type_= Int}
+  ; Attribute { name = "ariaValuenow"; jsxName = "aria-valuenow"; type_ = Int }
     (* Defines the human readable text alternative of aria-valuenow for a range widget. *)
-  ; Attribute {name= "ariaValuetext"; jsxName= "aria-valuetext"; type_= String}
+  ; Attribute
+      { name = "ariaValuetext"; jsxName = "aria-valuetext"; type_ = String }
   ]
 
 (* All the WAI-ARIA 1.1 role attribute values from https://www.w3.org/TR/wai-aria-1.1/#role_definitions *)
@@ -535,251 +584,312 @@ let ariaRole = String
 let reactAttributes =
   [ (* https://reactjs.org/docs/dom-elements.html *)
     Attribute
-      { name= "dangerouslySetInnerHTML"
-      ; jsxName= "dangerouslySetInnerHTML"
-      ; type_= InnerHtml }
-  ; Attribute {name= "ref"; jsxName= "ref"; type_= Ref}
-  ; Attribute {name= "key"; jsxName= "key"; type_= String}
-  ; Attribute {name= "className"; jsxName= "className"; type_= String}
-  ; Attribute {name= "defaultChecked"; jsxName= "defaultChecked"; type_= Bool}
+      { name = "dangerouslySetInnerHTML"
+      ; jsxName = "dangerouslySetInnerHTML"
+      ; type_ = InnerHtml
+      }
+  ; Attribute { name = "ref"; jsxName = "ref"; type_ = Ref }
+  ; Attribute { name = "key"; jsxName = "key"; type_ = String }
+  ; Attribute { name = "className"; jsxName = "className"; type_ = String }
   ; Attribute
-      { name= "defaultValue"
-      ; jsxName= "defaultValue"
-      ; type_= String (* | number | ReadonlyArray<String> *) }
+      { name = "defaultChecked"; jsxName = "defaultChecked"; type_ = Bool }
   ; Attribute
-      { name= "suppressContentEditableWarning"
-      ; jsxName= "suppressContentEditableWarning"
-      ; type_= Bool }
+      { name = "defaultValue"
+      ; jsxName = "defaultValue"
+      ; type_ = String (* | number | ReadonlyArray<String> *)
+      }
   ; Attribute
-      { name= "suppressHydrationWarning"
-      ; jsxName= "suppressHydrationWarning"
-      ; type_= Bool } ]
+      { name = "suppressContentEditableWarning"
+      ; jsxName = "suppressContentEditableWarning"
+      ; type_ = Bool
+      }
+  ; Attribute
+      { name = "suppressHydrationWarning"
+      ; jsxName = "suppressHydrationWarning"
+      ; type_ = Bool
+      }
+  ]
 
 let globalAttributes =
   [ (* https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes *)
     (* Standard HTML Attributes *)
-    Attribute {name= "accessKey"; jsxName= "accessKey"; type_= String}
-  ; Attribute {name= "autoCapitalize"; jsxName= "autoCapitalize"; type_= String}
-  ; Attribute {name= "contextMenu"; jsxName= "contextMenu"; type_= String}
+    Attribute { name = "accessKey"; jsxName = "accessKey"; type_ = String }
   ; Attribute
-      {name= "contentEditable"; jsxName= "contentEditable"; type_= String}
-  ; Attribute {name= "dir"; jsxName= "dir"; type_= String}
+      { name = "autoCapitalize"; jsxName = "autoCapitalize"; type_ = String }
+  ; Attribute { name = "contextMenu"; jsxName = "contextMenu"; type_ = String }
   ; Attribute
-      {name= "draggable"; jsxName= "draggable"; type_= String (* Booleanish *)}
-  ; Attribute {name= "hidden"; jsxName= "hidden"; type_= Bool}
-  ; Attribute {name= "id"; jsxName= "id"; type_= String}
-  ; Attribute {name= "itemProp"; jsxName= "itemProp"; type_= String}
-  ; Attribute {name= "itemScope"; jsxName= "itemScope"; type_= Bool}
-  ; Attribute {name= "itemType"; jsxName= "itemType"; type_= String}
-  ; Attribute {name= "itemID"; jsxName= "itemID"; type_= String}
-  ; Attribute {name= "itemRef"; jsxName= "itemRef"; type_= String}
-  ; Attribute {name= "lang"; jsxName= "lang"; type_= String}
-  ; Attribute {name= "placeholder"; jsxName= "placeholder"; type_= String}
-  ; Attribute {name= "part"; jsxName= "part"; type_= String}
-  ; Attribute {name= "nonce"; jsxName= "nonce"; type_= String}
-  ; Attribute {name= "slot"; jsxName= "slot"; type_= String}
+      { name = "contentEditable"; jsxName = "contentEditable"; type_ = String }
+  ; Attribute { name = "dir"; jsxName = "dir"; type_ = String }
   ; Attribute
-      {name= "spellCheck"; jsxName= "spellCheck"; type_= String (* Booleanish *)}
-  ; Attribute {name= "style"; jsxName= "style"; type_= Style}
-  ; Attribute {name= "tabIndex"; jsxName= "tabIndex"; type_= Int}
-  ; Attribute {name= "enterKeyHint"; jsxName= "enterKeyHint"; type_= Int}
+      { name = "draggable"
+      ; jsxName = "draggable"
+      ; type_ = String (* Booleanish *)
+      }
+  ; Attribute { name = "hidden"; jsxName = "hidden"; type_ = Bool }
+  ; Attribute { name = "id"; jsxName = "id"; type_ = String }
+  ; Attribute { name = "itemProp"; jsxName = "itemProp"; type_ = String }
+  ; Attribute { name = "itemScope"; jsxName = "itemScope"; type_ = Bool }
+  ; Attribute { name = "itemType"; jsxName = "itemType"; type_ = String }
+  ; Attribute { name = "itemID"; jsxName = "itemID"; type_ = String }
+  ; Attribute { name = "itemRef"; jsxName = "itemRef"; type_ = String }
+  ; Attribute { name = "lang"; jsxName = "lang"; type_ = String }
+  ; Attribute { name = "placeholder"; jsxName = "placeholder"; type_ = String }
+  ; Attribute { name = "part"; jsxName = "part"; type_ = String }
+  ; Attribute { name = "nonce"; jsxName = "nonce"; type_ = String }
+  ; Attribute { name = "slot"; jsxName = "slot"; type_ = String }
+  ; Attribute
+      { name = "spellCheck"
+      ; jsxName = "spellCheck"
+      ; type_ = String (* Booleanish *)
+      }
+  ; Attribute { name = "style"; jsxName = "style"; type_ = Style }
+  ; Attribute { name = "tabIndex"; jsxName = "tabIndex"; type_ = Int }
+  ; Attribute { name = "enterKeyHint"; jsxName = "enterKeyHint"; type_ = Int }
     (* data-* attributes are globaly available *)
     (* Experimental ; Attribute {name= "exportParts"; jsxName= "exportParts"; type_= Int} *)
-  ; Attribute {name= "title"; jsxName= "title"; type_= String}
+  ; Attribute { name = "title"; jsxName = "title"; type_ = String }
   ; Attribute
-      {name= "translate"; jsxName= "translate"; type_= String (* 'yes' | 'no' *)}
+      { name = "translate"
+      ; jsxName = "translate"
+      ; type_ = String (* 'yes' | 'no' *)
+      }
     (* Living Standard
        * Hints at the type of data that might be entered by the user while editing the element or its contents
        * @see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute *)
   ; Attribute
-      { name= "inputMode"
-      ; jsxName= "inputmode"
-      ; type_=
+      { name = "inputMode"
+      ; jsxName = "inputmode"
+      ; type_ =
           String
           (* 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search' *)
       }
     (* Specify that a standard HTML element should behave like a defined custom built-in element
         * @see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is *)
-  ; Attribute {name= "is"; jsxName= "is"; type_= String} ]
+  ; Attribute { name = "is"; jsxName = "is"; type_ = String }
+  ]
 
 let elementAttributes =
-  [ Attribute {name= "radioGroup"; jsxName= "radioGroup"; type_= String}
+  [ Attribute { name = "radioGroup"; jsxName = "radioGroup"; type_ = String }
     (* WAI-ARIA *)
-  ; Attribute {name= "role"; jsxName= "role"; type_= ariaRole}
+  ; Attribute { name = "role"; jsxName = "role"; type_ = ariaRole }
     (* RDFa Attributes *)
-  ; Attribute {name= "about"; jsxName= "about"; type_= String}
-  ; Attribute {name= "dataType"; jsxName= "dataType"; type_= String}
-  ; Attribute {name= "inlist"; jsxName= "inlist"; type_= String (* any *)}
-  ; Attribute {name= "prefix"; jsxName= "prefix"; type_= String}
-  ; Attribute {name= "property"; jsxName= "property"; type_= String}
-  ; Attribute {name= "resource"; jsxName= "resource"; type_= String}
-  ; Attribute {name= "typeof"; jsxName= "typeof"; type_= String}
-  ; Attribute {name= "vocab"; jsxName= "vocab"; type_= String}
+  ; Attribute { name = "about"; jsxName = "about"; type_ = String }
+  ; Attribute { name = "dataType"; jsxName = "dataType"; type_ = String }
+  ; Attribute { name = "inlist"; jsxName = "inlist"; type_ = String (* any *) }
+  ; Attribute { name = "prefix"; jsxName = "prefix"; type_ = String }
+  ; Attribute { name = "property"; jsxName = "property"; type_ = String }
+  ; Attribute { name = "resource"; jsxName = "resource"; type_ = String }
+  ; Attribute { name = "typeof"; jsxName = "typeof"; type_ = String }
+  ; Attribute { name = "vocab"; jsxName = "vocab"; type_ = String }
     (* Non-standard Attributes *)
-  ; Attribute {name= "autoCorrect"; jsxName= "autoCorrect"; type_= String}
-  ; Attribute {name= "autoSave"; jsxName= "autoSave"; type_= String}
-  ; Attribute {name= "color"; jsxName= "color"; type_= String}
-  ; Attribute {name= "results"; jsxName= "results"; type_= Int}
-  ; Attribute {name= "security"; jsxName= "security"; type_= String} ]
+  ; Attribute { name = "autoCorrect"; jsxName = "autoCorrect"; type_ = String }
+  ; Attribute { name = "autoSave"; jsxName = "autoSave"; type_ = String }
+  ; Attribute { name = "color"; jsxName = "color"; type_ = String }
+  ; Attribute { name = "results"; jsxName = "results"; type_ = Int }
+  ; Attribute { name = "security"; jsxName = "security"; type_ = String }
+  ]
 
 let anchorHTMLAttributes =
-  [ Attribute {name= "download"; jsxName= "download"; type_= String (* any; *)}
-  ; Attribute {name= "href"; jsxName= "href"; type_= String}
-  ; Attribute {name= "hrefLang"; jsxName= "hrefLang"; type_= String}
-  ; Attribute {name= "media"; jsxName= "media"; type_= String}
-  ; Attribute {name= "ping"; jsxName= "ping"; type_= String}
-  ; Attribute {name= "rel"; jsxName= "rel"; type_= String}
-  ; Attribute {name= "target"; jsxName= "target"; type_= attributeAnchorTarget}
-  ; Attribute {name= "type_"; jsxName= "type"; type_= String}
+  [ Attribute
+      { name = "download"; jsxName = "download"; type_ = String (* any; *) }
+  ; Attribute { name = "href"; jsxName = "href"; type_ = String }
+  ; Attribute { name = "hrefLang"; jsxName = "hrefLang"; type_ = String }
+  ; Attribute { name = "media"; jsxName = "media"; type_ = String }
+  ; Attribute { name = "ping"; jsxName = "ping"; type_ = String }
+  ; Attribute { name = "rel"; jsxName = "rel"; type_ = String }
   ; Attribute
-      { name= "referrerPolicy"
-      ; jsxName= "referrerPolicy"
-      ; type_= attributeReferrerPolicy } ]
+      { name = "target"; jsxName = "target"; type_ = attributeAnchorTarget }
+  ; Attribute { name = "type_"; jsxName = "type"; type_ = String }
+  ; Attribute
+      { name = "referrerPolicy"
+      ; jsxName = "referrerPolicy"
+      ; type_ = attributeReferrerPolicy
+      }
+  ]
 
 let areaHTMLAttributes =
-  [ Attribute {name= "alt"; jsxName= "alt"; type_= String}
-  ; Attribute {name= "coords"; jsxName= "coords"; type_= String}
-  ; Attribute {name= "download"; jsxName= "download"; type_= String (* any *)}
-  ; Attribute {name= "href"; jsxName= "href"; type_= String}
-  ; Attribute {name= "hrefLang"; jsxName= "hrefLang"; type_= String}
-  ; Attribute {name= "media"; jsxName= "media"; type_= String}
+  [ Attribute { name = "alt"; jsxName = "alt"; type_ = String }
+  ; Attribute { name = "coords"; jsxName = "coords"; type_ = String }
   ; Attribute
-      { name= "referrerPolicy"
-      ; jsxName= "referrerPolicy"
-      ; type_= attributeReferrerPolicy }
-  ; Attribute {name= "rel"; jsxName= "rel"; type_= String}
-  ; Attribute {name= "shape"; jsxName= "shape"; type_= String}
-  ; Attribute {name= "target"; jsxName= "target"; type_= String} ]
+      { name = "download"; jsxName = "download"; type_ = String (* any *) }
+  ; Attribute { name = "href"; jsxName = "href"; type_ = String }
+  ; Attribute { name = "hrefLang"; jsxName = "hrefLang"; type_ = String }
+  ; Attribute { name = "media"; jsxName = "media"; type_ = String }
+  ; Attribute
+      { name = "referrerPolicy"
+      ; jsxName = "referrerPolicy"
+      ; type_ = attributeReferrerPolicy
+      }
+  ; Attribute { name = "rel"; jsxName = "rel"; type_ = String }
+  ; Attribute { name = "shape"; jsxName = "shape"; type_ = String }
+  ; Attribute { name = "target"; jsxName = "target"; type_ = String }
+  ]
 
 let baseHTMLAttributes =
-  [ Attribute {name= "href"; jsxName= "href"; type_= String}
-  ; Attribute {name= "target"; jsxName= "target"; type_= String} ]
+  [ Attribute { name = "href"; jsxName = "href"; type_ = String }
+  ; Attribute { name = "target"; jsxName = "target"; type_ = String }
+  ]
 
 let blockquoteHTMLAttributes =
-  [Attribute {name= "cite"; jsxName= "cite"; type_= String}]
+  [ Attribute { name = "cite"; jsxName = "cite"; type_ = String } ]
 
 let buttonHTMLAttributes =
-  [ Attribute {name= "autoFocus"; jsxName= "autofocus"; type_= Bool}
-  ; Attribute {name= "disabled"; jsxName= "disabled"; type_= Bool}
-  ; Attribute {name= "form"; jsxName= "form"; type_= String}
-  ; Attribute {name= "formAction"; jsxName= "formAction"; type_= String}
-  ; Attribute {name= "formEncType"; jsxName= "formEncType"; type_= String}
-  ; Attribute {name= "formMethod"; jsxName= "formMethod"; type_= String}
-  ; Attribute {name= "formNoValidate"; jsxName= "formNoValidate"; type_= Bool}
-  ; Attribute {name= "formTarget"; jsxName= "formTarget"; type_= String}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String}
+  [ Attribute { name = "autoFocus"; jsxName = "autofocus"; type_ = Bool }
+  ; Attribute { name = "disabled"; jsxName = "disabled"; type_ = Bool }
+  ; Attribute { name = "form"; jsxName = "form"; type_ = String }
+  ; Attribute { name = "formAction"; jsxName = "formAction"; type_ = String }
+  ; Attribute { name = "formEncType"; jsxName = "formEncType"; type_ = String }
+  ; Attribute { name = "formMethod"; jsxName = "formMethod"; type_ = String }
   ; Attribute
-      { name= "type_"
-      ; jsxName= "type"
-      ; type_= String (* 'submit' | 'reset' | 'button' *) }
+      { name = "formNoValidate"; jsxName = "formNoValidate"; type_ = Bool }
+  ; Attribute { name = "formTarget"; jsxName = "formTarget"; type_ = String }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
   ; Attribute
-      { name= "value"
-      ; jsxName= "value"
-      ; type_= String (* | ReadonlyArray<String> | number *) } ]
+      { name = "type_"
+      ; jsxName = "type"
+      ; type_ = String (* 'submit' | 'reset' | 'button' *)
+      }
+  ; Attribute
+      { name = "value"
+      ; jsxName = "value"
+      ; type_ = String (* | ReadonlyArray<String> | number *)
+      }
+  ]
 
 let canvasHTMLAttributes =
-  [ Attribute {name= "height"; jsxName= "height"; type_= String (* number |  *)}
-  ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
+  [ Attribute
+      { name = "height"; jsxName = "height"; type_ = String (* number |  *) }
+  ; Attribute
+      { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
   ]
 
 let colHTMLAttributes =
-  [ Attribute {name= "span"; jsxName= "span"; type_= Int (* number *)}
-  ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
+  [ Attribute { name = "span"; jsxName = "span"; type_ = Int (* number *) }
+  ; Attribute
+      { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
   ]
 
 let colgroupHTMLAttributes =
-  [Attribute {name= "span"; jsxName= "span"; type_= Int (* number *)}]
+  [ Attribute { name = "span"; jsxName = "span"; type_ = Int (* number *) } ]
 
 let dataHTMLAttributes =
   [ Attribute
-      { name= "value"
-      ; jsxName= "value"
-      ; type_= String (* | ReadonlyArray<String> | number *) } ]
+      { name = "value"
+      ; jsxName = "value"
+      ; type_ = String (* | ReadonlyArray<String> | number *)
+      }
+  ]
 
 let detailsHTMLAttributes =
-  [ Attribute {name= "open"; jsxName= "open"; type_= Bool}
-  ; Event {name= "onToggle"; type_= Media} ]
+  [ Attribute { name = "open"; jsxName = "open"; type_ = Bool }
+  ; Event { name = "onToggle"; type_ = Media }
+  ]
 
 let delHTMLAttributes =
-  [ Attribute {name= "cite"; type_= String; jsxName= "cite"}
-  ; Attribute {name= "dateTime"; type_= String; jsxName= "dateTime"} ]
+  [ Attribute { name = "cite"; type_ = String; jsxName = "cite" }
+  ; Attribute { name = "dateTime"; type_ = String; jsxName = "dateTime" }
+  ]
 
 let dialogHTMLAttributes =
-  [Attribute {name= "open"; jsxName= "open"; type_= Bool}]
+  [ Attribute { name = "open"; jsxName = "open"; type_ = Bool } ]
 
 let embedHTMLAttributes =
-  [ Attribute {name= "height"; type_= String (* number |  *); jsxName= "height"}
-  ; Attribute {name= "src"; type_= String; jsxName= "src"}
-  ; Attribute {name= "type_"; type_= String; jsxName= "type"}
-  ; Attribute {name= "width"; type_= String (* number |  *); jsxName= "width"}
+  [ Attribute
+      { name = "height"; type_ = String (* number |  *); jsxName = "height" }
+  ; Attribute { name = "src"; type_ = String; jsxName = "src" }
+  ; Attribute { name = "type_"; type_ = String; jsxName = "type" }
+  ; Attribute
+      { name = "width"; type_ = String (* number |  *); jsxName = "width" }
   ]
 
 let fieldsetHTMLAttributes =
-  [ Attribute {name= "disabled"; jsxName= "disabled"; type_= Bool}
-  ; Attribute {name= "form"; jsxName= "form"; type_= String}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String} ]
+  [ Attribute { name = "disabled"; jsxName = "disabled"; type_ = Bool }
+  ; Attribute { name = "form"; jsxName = "form"; type_ = String }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+  ]
 
 let formHTMLAttributes =
-  [ Attribute {name= "acceptCharset"; jsxName= "acceptCharset"; type_= String}
-  ; Attribute {name= "action"; jsxName= "action"; type_= String}
-  ; Attribute {name= "autoComplete"; jsxName= "autoComplete"; type_= String}
-  ; Attribute {name= "encType"; jsxName= "encType"; type_= String}
-  ; Attribute {name= "method"; jsxName= "method"; type_= String}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String}
-  ; Attribute {name= "noValidate"; jsxName= "noValidate"; type_= Bool}
-  ; Attribute {name= "target"; jsxName= "target"; type_= String} ]
+  [ Attribute
+      { name = "acceptCharset"; jsxName = "acceptCharset"; type_ = String }
+  ; Attribute { name = "action"; jsxName = "action"; type_ = String }
+  ; Attribute
+      { name = "autoComplete"; jsxName = "autoComplete"; type_ = String }
+  ; Attribute { name = "encType"; jsxName = "encType"; type_ = String }
+  ; Attribute { name = "method"; jsxName = "method"; type_ = String }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+  ; Attribute { name = "noValidate"; jsxName = "noValidate"; type_ = Bool }
+  ; Attribute { name = "target"; jsxName = "target"; type_ = String }
+  ]
 
 let htmlHTMLAttributes =
-  [Attribute {name= "manifest"; jsxName= "manifest"; type_= String}]
+  [ Attribute { name = "manifest"; jsxName = "manifest"; type_ = String } ]
 
 let iframeHTMLAttributes =
-  [ Attribute {name= "allow"; jsxName= "allow"; type_= String}
-  ; Attribute {name= "allowFullScreen"; jsxName= "allowFullScreen"; type_= Bool}
+  [ Attribute { name = "allow"; jsxName = "allow"; type_ = String }
   ; Attribute
-      {name= "allowTransparency"; jsxName= "allowTransparency"; type_= Bool}
+      { name = "allowFullScreen"; jsxName = "allowFullScreen"; type_ = Bool }
+  ; Attribute
+      { name = "allowTransparency"
+      ; jsxName = "allowTransparency"
+      ; type_ = Bool
+      }
   ; (* deprecated *)
     Attribute
-      { name= "frameBorder"
-      ; jsxName= "frameBorder"
-      ; type_= String (* number |  *) }
-  ; Attribute {name= "height"; jsxName= "height"; type_= String (* number |  *)}
+      { name = "frameBorder"
+      ; jsxName = "frameBorder"
+      ; type_ = String (* number |  *)
+      }
+  ; Attribute
+      { name = "height"; jsxName = "height"; type_ = String (* number |  *) }
   ; (* deprecated *)
     Attribute
-      {name= "marginHeight"; jsxName= "marginHeight"; type_= Int (* number *)}
+      { name = "marginHeight"
+      ; jsxName = "marginHeight"
+      ; type_ = Int (* number *)
+      }
   ; (* deprecated *)
     Attribute
-      {name= "marginWidth"; jsxName= "marginWidth"; type_= Int (* number *)}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String}
-  ; Attribute {name= "sandbox"; jsxName= "sandbox"; type_= String}
+      { name = "marginWidth"
+      ; jsxName = "marginWidth"
+      ; type_ = Int (* number *)
+      }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+  ; Attribute { name = "sandbox"; jsxName = "sandbox"; type_ = String }
   ; (* deprecated *)
-    Attribute {name= "scrolling"; jsxName= "scrolling"; type_= String}
-  ; Attribute {name= "seamless"; jsxName= "seamless"; type_= Bool}
-  ; Attribute {name= "src"; jsxName= "src"; type_= String}
-  ; Attribute {name= "srcDoc"; jsxName= "srcDoc"; type_= String}
-  ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
+    Attribute { name = "scrolling"; jsxName = "scrolling"; type_ = String }
+  ; Attribute { name = "seamless"; jsxName = "seamless"; type_ = Bool }
+  ; Attribute { name = "src"; jsxName = "src"; type_ = String }
+  ; Attribute { name = "srcDoc"; jsxName = "srcDoc"; type_ = String }
+  ; Attribute
+      { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
   ]
 
 let imgHTMLAttributes =
-  [ Attribute {name= "alt"; jsxName= "alt"; type_= String}
+  [ Attribute { name = "alt"; jsxName = "alt"; type_ = String }
   ; Attribute
-      { name= "crossOrigin"
-      ; jsxName= "crossOrigin"
-      ; type_= String (* "anonymous" | "use-credentials" | "" *) }
+      { name = "crossOrigin"
+      ; jsxName = "crossOrigin"
+      ; type_ = String (* "anonymous" | "use-credentials" | "" *)
+      }
   ; Attribute
-      { name= "decoding"
-      ; jsxName= "decoding"
-      ; type_= String (* "async" | "auto" | "sync" *) }
-  ; Attribute {name= "height"; jsxName= "height"; type_= String (* number |  *)}
-  ; Attribute {name= "sizes"; jsxName= "sizes"; type_= String}
-  ; Attribute {name= "src"; jsxName= "src"; type_= String}
-  ; Attribute {name= "srcSet"; jsxName= "srcset"; type_= String}
-  ; Attribute {name= "useMap"; jsxName= "usemap"; type_= String}
-  ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
+      { name = "decoding"
+      ; jsxName = "decoding"
+      ; type_ = String (* "async" | "auto" | "sync" *)
+      }
+  ; Attribute
+      { name = "height"; jsxName = "height"; type_ = String (* number |  *) }
+  ; Attribute { name = "sizes"; jsxName = "sizes"; type_ = String }
+  ; Attribute { name = "src"; jsxName = "src"; type_ = String }
+  ; Attribute { name = "srcSet"; jsxName = "srcset"; type_ = String }
+  ; Attribute { name = "useMap"; jsxName = "usemap"; type_ = String }
+  ; Attribute
+      { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
   ]
 
 let insHTMLAttributes =
-  [ Attribute {name= "cite"; jsxName= "cite"; type_= String}
-  ; Attribute {name= "dateTime"; jsxName= "datetime"; type_= String} ]
+  [ Attribute { name = "cite"; jsxName = "cite"; type_ = String }
+  ; Attribute { name = "dateTime"; jsxName = "datetime"; type_ = String }
+  ]
 
 let inputTypeAttribute = String
 (*
@@ -808,812 +918,1111 @@ let inputTypeAttribute = String
         | (String & {}); *)
 
 let inputHTMLAttributes =
-  [ Attribute {name= "accept"; jsxName= "accept"; type_= String}
-  ; Attribute {name= "alt"; jsxName= "alt"; type_= String}
-  ; Attribute {name= "autoComplete"; jsxName= "autoComplete"; type_= String}
-  ; Attribute {name= "autoFocus"; jsxName= "autoFocus"; type_= Bool}
+  [ Attribute { name = "accept"; jsxName = "accept"; type_ = String }
+  ; Attribute { name = "alt"; jsxName = "alt"; type_ = String }
   ; Attribute
-      { name= "capture"
-      ; jsxName= "capture"
-      ; type_=
+      { name = "autoComplete"; jsxName = "autoComplete"; type_ = String }
+  ; Attribute { name = "autoFocus"; jsxName = "autoFocus"; type_ = Bool }
+  ; Attribute
+      { name = "capture"
+      ; jsxName = "capture"
+      ; type_ =
           String
           (* Bool | *)
-          (* https://www.w3.org/TR/html-media-capture/ *) }
-  ; Attribute {name= "checked"; jsxName= "checked"; type_= Bool}
-  ; Attribute {name= "crossOrigin"; jsxName= "crossOrigin"; type_= String}
-  ; Attribute {name= "disabled"; jsxName= "disabled"; type_= Bool}
-  ; Attribute {name= "form"; jsxName= "form"; type_= String}
-  ; Attribute {name= "formAction"; jsxName= "formAction"; type_= String}
-  ; Attribute {name= "formEncType"; jsxName= "formEncType"; type_= String}
-  ; Attribute {name= "formMethod"; jsxName= "formMethod"; type_= String}
-  ; Attribute {name= "formNoValidate"; jsxName= "formNoValidate"; type_= Bool}
-  ; Attribute {name= "formTarget"; jsxName= "formTarget"; type_= String}
-  ; Attribute {name= "height"; jsxName= "height"; type_= String (* number |  *)}
-  ; Attribute {name= "list"; jsxName= "list"; type_= String}
-  ; Attribute {name= "max"; jsxName= "max"; type_= String (* number |  *)}
-  ; Attribute {name= "maxLength"; jsxName= "maxLength"; type_= Int (* number *)}
-  ; Attribute {name= "min"; jsxName= "min"; type_= String (* number |  *)}
-  ; Attribute {name= "minLength"; jsxName= "minLength"; type_= Int (* number *)}
-  ; Attribute {name= "multiple"; jsxName= "multiple"; type_= Bool}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String}
-  ; Attribute {name= "pattern"; jsxName= "pattern"; type_= String}
-  ; Attribute {name= "placeholder"; jsxName= "placeholder"; type_= String}
-  ; Attribute {name= "readOnly"; jsxName= "readOnly"; type_= Bool}
-  ; Attribute {name= "required"; jsxName= "required"; type_= Bool}
-  ; Attribute {name= "size"; jsxName= "size"; type_= Int (* number *)}
-  ; Attribute {name= "src"; jsxName= "src"; type_= String}
-  ; Attribute {name= "step"; jsxName= "step"; type_= String (* number |  *)}
-  ; Attribute {name= "type_"; jsxName= "type"; type_= inputTypeAttribute}
+          (* https://www.w3.org/TR/html-media-capture/ *)
+      }
+  ; Attribute { name = "checked"; jsxName = "checked"; type_ = Bool }
+  ; Attribute { name = "crossOrigin"; jsxName = "crossOrigin"; type_ = String }
+  ; Attribute { name = "disabled"; jsxName = "disabled"; type_ = Bool }
+  ; Attribute { name = "form"; jsxName = "form"; type_ = String }
+  ; Attribute { name = "formAction"; jsxName = "formAction"; type_ = String }
+  ; Attribute { name = "formEncType"; jsxName = "formEncType"; type_ = String }
+  ; Attribute { name = "formMethod"; jsxName = "formMethod"; type_ = String }
   ; Attribute
-      { name= "value"
-      ; jsxName= "value"
-      ; type_= String (* | ReadonlyArray<String> | number *) }
-  ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
-  ; Event {name= "onChange"; type_= Form} ]
+      { name = "formNoValidate"; jsxName = "formNoValidate"; type_ = Bool }
+  ; Attribute { name = "formTarget"; jsxName = "formTarget"; type_ = String }
+  ; Attribute
+      { name = "height"; jsxName = "height"; type_ = String (* number |  *) }
+  ; Attribute { name = "list"; jsxName = "list"; type_ = String }
+  ; Attribute { name = "max"; jsxName = "max"; type_ = String (* number |  *) }
+  ; Attribute
+      { name = "maxLength"; jsxName = "maxLength"; type_ = Int (* number *) }
+  ; Attribute { name = "min"; jsxName = "min"; type_ = String (* number |  *) }
+  ; Attribute
+      { name = "minLength"; jsxName = "minLength"; type_ = Int (* number *) }
+  ; Attribute { name = "multiple"; jsxName = "multiple"; type_ = Bool }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+  ; Attribute { name = "pattern"; jsxName = "pattern"; type_ = String }
+  ; Attribute { name = "placeholder"; jsxName = "placeholder"; type_ = String }
+  ; Attribute { name = "readOnly"; jsxName = "readOnly"; type_ = Bool }
+  ; Attribute { name = "required"; jsxName = "required"; type_ = Bool }
+  ; Attribute { name = "size"; jsxName = "size"; type_ = Int (* number *) }
+  ; Attribute { name = "src"; jsxName = "src"; type_ = String }
+  ; Attribute
+      { name = "step"; jsxName = "step"; type_ = String (* number |  *) }
+  ; Attribute { name = "type_"; jsxName = "type"; type_ = inputTypeAttribute }
+  ; Attribute
+      { name = "value"
+      ; jsxName = "value"
+      ; type_ = String (* | ReadonlyArray<String> | number *)
+      }
+  ; Attribute
+      { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
+  ; Event { name = "onChange"; type_ = Form }
+  ]
 
 let keygenHTMLAttributes =
-  [ Attribute {name= "autoFocus"; jsxName= "autoFocus"; type_= Bool}
-  ; Attribute {name= "challenge"; jsxName= "challenge"; type_= String}
-  ; Attribute {name= "disabled"; jsxName= "disabled"; type_= Bool}
-  ; Attribute {name= "form"; jsxName= "form"; type_= String}
-  ; Attribute {name= "keyType"; jsxName= "keyType"; type_= String}
-  ; Attribute {name= "keyParams"; jsxName= "keyParams"; type_= String}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String} ]
+  [ Attribute { name = "autoFocus"; jsxName = "autoFocus"; type_ = Bool }
+  ; Attribute { name = "challenge"; jsxName = "challenge"; type_ = String }
+  ; Attribute { name = "disabled"; jsxName = "disabled"; type_ = Bool }
+  ; Attribute { name = "form"; jsxName = "form"; type_ = String }
+  ; Attribute { name = "keyType"; jsxName = "keyType"; type_ = String }
+  ; Attribute { name = "keyParams"; jsxName = "keyParams"; type_ = String }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+  ]
 
 let labelHTMLAttributes =
-  [ Attribute {name= "form"; jsxName= "form"; type_= String}
-  ; Attribute {name= "htmlFor"; jsxName= "htmlFor"; type_= String} ]
+  [ Attribute { name = "form"; jsxName = "form"; type_ = String }
+  ; Attribute { name = "htmlFor"; jsxName = "htmlFor"; type_ = String }
+  ]
 
 let liHTMLAttributes =
   [ Attribute
-      { name= "value"
-      ; jsxName= "value"
-      ; type_= String (* | ReadonlyArray<String> | number *) } ]
+      { name = "value"
+      ; jsxName = "value"
+      ; type_ = String (* | ReadonlyArray<String> | number *)
+      }
+  ]
 
 let linkHTMLAttributes =
-  [ Attribute {name= "as"; jsxName= "as"; type_= String}
-  ; Attribute {name= "crossOrigin"; jsxName= "crossOrigin"; type_= String}
-  ; Attribute {name= "href"; jsxName= "href"; type_= String}
-  ; Attribute {name= "hrefLang"; jsxName= "hrefLang"; type_= String}
-  ; Attribute {name= "integrity"; jsxName= "integrity"; type_= String}
-  ; Attribute {name= "imageSrcSet"; jsxName= "imageSrcSet"; type_= String}
-  ; Attribute {name= "media"; jsxName= "media"; type_= String}
-  ; Attribute {name= "rel"; jsxName= "rel"; type_= String}
-  ; Attribute {name= "sizes"; jsxName= "sizes"; type_= String}
-  ; Attribute {name= "type_"; jsxName= "type"; type_= String}
-  ; Attribute {name= "charSet"; jsxName= "charSet"; type_= String} ]
+  [ Attribute { name = "as"; jsxName = "as"; type_ = String }
+  ; Attribute { name = "crossOrigin"; jsxName = "crossOrigin"; type_ = String }
+  ; Attribute { name = "href"; jsxName = "href"; type_ = String }
+  ; Attribute { name = "hrefLang"; jsxName = "hrefLang"; type_ = String }
+  ; Attribute { name = "integrity"; jsxName = "integrity"; type_ = String }
+  ; Attribute { name = "imageSrcSet"; jsxName = "imageSrcSet"; type_ = String }
+  ; Attribute { name = "media"; jsxName = "media"; type_ = String }
+  ; Attribute { name = "rel"; jsxName = "rel"; type_ = String }
+  ; Attribute { name = "sizes"; jsxName = "sizes"; type_ = String }
+  ; Attribute { name = "type_"; jsxName = "type"; type_ = String }
+  ; Attribute { name = "charSet"; jsxName = "charSet"; type_ = String }
+  ]
 
 let mapHTMLAttributes =
-  [Attribute {name= "name"; jsxName= "name"; type_= String}]
+  [ Attribute { name = "name"; jsxName = "name"; type_ = String } ]
 
 let menuHTMLAttributes =
-  [Attribute {name= "type_"; jsxName= "type"; type_= String}]
+  [ Attribute { name = "type_"; jsxName = "type"; type_ = String } ]
 
 let mediaHTMLAttributes =
-  [ Attribute {name= "autoPlay"; jsxName= "autoPlay"; type_= Bool}
-  ; Attribute {name= "controls"; jsxName= "controls"; type_= Bool}
-  ; Attribute {name= "controlsList"; jsxName= "controlsList"; type_= String}
-  ; Attribute {name= "crossOrigin"; jsxName= "crossOrigin"; type_= String}
-  ; Attribute {name= "loop"; jsxName= "loop"; type_= Bool}
+  [ Attribute { name = "autoPlay"; jsxName = "autoPlay"; type_ = Bool }
+  ; Attribute { name = "controls"; jsxName = "controls"; type_ = Bool }
+  ; Attribute
+      { name = "controlsList"; jsxName = "controlsList"; type_ = String }
+  ; Attribute { name = "crossOrigin"; jsxName = "crossOrigin"; type_ = String }
+  ; Attribute { name = "loop"; jsxName = "loop"; type_ = Bool }
   ; (* deprecated *)
-    Attribute {name= "mediaGroup"; jsxName= "mediaGroup"; type_= String}
-  ; Attribute {name= "muted"; jsxName= "muted"; type_= Bool}
-  ; Attribute {name= "playsInline"; jsxName= "playsInline"; type_= Bool}
-  ; Attribute {name= "preload"; jsxName= "preload"; type_= String}
-  ; Attribute {name= "src"; jsxName= "src"; type_= String} ]
+    Attribute { name = "mediaGroup"; jsxName = "mediaGroup"; type_ = String }
+  ; Attribute { name = "muted"; jsxName = "muted"; type_ = Bool }
+  ; Attribute { name = "playsInline"; jsxName = "playsInline"; type_ = Bool }
+  ; Attribute { name = "preload"; jsxName = "preload"; type_ = String }
+  ; Attribute { name = "src"; jsxName = "src"; type_ = String }
+  ]
 
 let metaHTMLAttributes =
-  [ Attribute {name= "charSet"; jsxName= "charSet"; type_= String}
-  ; Attribute {name= "content"; jsxName= "content"; type_= String}
-  ; Attribute {name= "httpEquiv"; jsxName= "httpEquiv"; type_= String}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String}
-  ; Attribute {name= "media"; jsxName= "media"; type_= String} ]
+  [ Attribute { name = "charSet"; jsxName = "charSet"; type_ = String }
+  ; Attribute { name = "content"; jsxName = "content"; type_ = String }
+  ; Attribute { name = "httpEquiv"; jsxName = "httpEquiv"; type_ = String }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+  ; Attribute { name = "media"; jsxName = "media"; type_ = String }
+  ]
 
 let meterHTMLAttributes =
-  [ Attribute {name= "form"; jsxName= "form"; type_= String}
-  ; Attribute {name= "high"; jsxName= "high"; type_= Int (* number *)}
-  ; Attribute {name= "low"; jsxName= "low"; type_= Int (* number *)}
-  ; Attribute {name= "max"; jsxName= "max"; type_= String (* number |  *)}
-  ; Attribute {name= "min"; jsxName= "min"; type_= String (* number |  *)}
-  ; Attribute {name= "optimum"; jsxName= "optimum"; type_= Int (* number *)}
+  [ Attribute { name = "form"; jsxName = "form"; type_ = String }
+  ; Attribute { name = "high"; jsxName = "high"; type_ = Int (* number *) }
+  ; Attribute { name = "low"; jsxName = "low"; type_ = Int (* number *) }
+  ; Attribute { name = "max"; jsxName = "max"; type_ = String (* number |  *) }
+  ; Attribute { name = "min"; jsxName = "min"; type_ = String (* number |  *) }
   ; Attribute
-      { name= "value"
-      ; jsxName= "value"
-      ; type_= String (* | ReadonlyArray<String> | number *) } ]
+      { name = "optimum"; jsxName = "optimum"; type_ = Int (* number *) }
+  ; Attribute
+      { name = "value"
+      ; jsxName = "value"
+      ; type_ = String (* | ReadonlyArray<String> | number *)
+      }
+  ]
 
 let quoteHTMLAttributes =
-  [Attribute {name= "cite"; jsxName= "cite"; type_= String}]
+  [ Attribute { name = "cite"; jsxName = "cite"; type_ = String } ]
 
 let objectHTMLAttributes =
-  [ Attribute {name= "classID"; jsxName= "classID"; type_= String}
-  ; Attribute {name= "data"; jsxName= "data"; type_= String}
-  ; Attribute {name= "form"; jsxName= "form"; type_= String}
-  ; Attribute {name= "height"; jsxName= "height"; type_= String (* number |  *)}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String}
-  ; Attribute {name= "type_"; jsxName= "type"; type_= String}
-  ; Attribute {name= "useMap"; jsxName= "useMap"; type_= String}
-  ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
-  ; Attribute {name= "wmode"; jsxName= "wmode"; type_= String} ]
+  [ Attribute { name = "classID"; jsxName = "classID"; type_ = String }
+  ; Attribute { name = "data"; jsxName = "data"; type_ = String }
+  ; Attribute { name = "form"; jsxName = "form"; type_ = String }
+  ; Attribute
+      { name = "height"; jsxName = "height"; type_ = String (* number |  *) }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+  ; Attribute { name = "type_"; jsxName = "type"; type_ = String }
+  ; Attribute { name = "useMap"; jsxName = "useMap"; type_ = String }
+  ; Attribute
+      { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
+  ; Attribute { name = "wmode"; jsxName = "wmode"; type_ = String }
+  ]
 
 let olHTMLAttributes =
-  [ Attribute {name= "reversed"; jsxName= "reversed"; type_= Bool}
-  ; Attribute {name= "start"; jsxName= "start"; type_= Int (* number *)}
+  [ Attribute { name = "reversed"; jsxName = "reversed"; type_ = Bool }
+  ; Attribute { name = "start"; jsxName = "start"; type_ = Int (* number *) }
   ; Attribute
-      { name= "type_"
-      ; jsxName= "type"
-      ; type_= String (* '1' | 'a' | 'A' | 'i' | 'I' *) } ]
+      { name = "type_"
+      ; jsxName = "type"
+      ; type_ = String (* '1' | 'a' | 'A' | 'i' | 'I' *)
+      }
+  ]
 
 let optgroupHTMLAttributes =
-  [ Attribute {name= "disabled"; jsxName= "disabled"; type_= Bool}
-  ; Attribute {name= "label"; jsxName= "label"; type_= String} ]
+  [ Attribute { name = "disabled"; jsxName = "disabled"; type_ = Bool }
+  ; Attribute { name = "label"; jsxName = "label"; type_ = String }
+  ]
 
 let optionHTMLAttributes =
-  [ Attribute {name= "disabled"; jsxName= "disabled"; type_= Bool}
-  ; Attribute {name= "label"; jsxName= "label"; type_= String}
-  ; Attribute {name= "selected"; jsxName= "selected"; type_= Bool}
+  [ Attribute { name = "disabled"; jsxName = "disabled"; type_ = Bool }
+  ; Attribute { name = "label"; jsxName = "label"; type_ = String }
+  ; Attribute { name = "selected"; jsxName = "selected"; type_ = Bool }
   ; Attribute
-      { name= "value"
-      ; jsxName= "value"
-      ; type_= String (* | ReadonlyArray<String> | number *) } ]
+      { name = "value"
+      ; jsxName = "value"
+      ; type_ = String (* | ReadonlyArray<String> | number *)
+      }
+  ]
 
 let outputHTMLAttributes =
-  [ Attribute {name= "form"; jsxName= "form"; type_= String}
-  ; Attribute {name= "htmlFor"; jsxName= "htmlFor"; type_= String}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String} ]
+  [ Attribute { name = "form"; jsxName = "form"; type_ = String }
+  ; Attribute { name = "htmlFor"; jsxName = "htmlFor"; type_ = String }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+  ]
 
 let paramHTMLAttributes =
-  [ Attribute {name= "name"; jsxName= "name"; type_= String}
+  [ Attribute { name = "name"; jsxName = "name"; type_ = String }
   ; Attribute
-      { name= "value"
-      ; jsxName= "value"
-      ; type_= String (* | ReadonlyArray<String> | number *) } ]
+      { name = "value"
+      ; jsxName = "value"
+      ; type_ = String (* | ReadonlyArray<String> | number *)
+      }
+  ]
 
 let progressHTMLAttributes =
-  [ Attribute {name= "max"; jsxName= "max"; type_= String (* number |  *)}
+  [ Attribute { name = "max"; jsxName = "max"; type_ = String (* number |  *) }
   ; Attribute
-      { name= "value"
-      ; jsxName= "value"
-      ; type_= String (* | ReadonlyArray<String> | number *) } ]
+      { name = "value"
+      ; jsxName = "value"
+      ; type_ = String (* | ReadonlyArray<String> | number *)
+      }
+  ]
 
 let slotHTMLAttributes =
-  [Attribute {name= "name"; jsxName= "name"; type_= String}]
+  [ Attribute { name = "name"; jsxName = "name"; type_ = String } ]
 
 let scriptHTMLAttributes =
   [ (* deprecated *)
-    Attribute {name= "async"; jsxName= "async"; type_= Bool}
-  ; Attribute {name= "charSet"; jsxName= "charSet"; type_= String}
-  ; Attribute {name= "crossOrigin"; jsxName= "crossOrigin"; type_= String}
-  ; Attribute {name= "defer"; jsxName= "defer"; type_= Bool}
-  ; Attribute {name= "integrity"; jsxName= "integrity"; type_= String}
-  ; Attribute {name= "noModule"; jsxName= "noModule"; type_= Bool}
-  ; Attribute {name= "nonce"; jsxName= "nonce"; type_= String}
-  ; Attribute {name= "src"; jsxName= "src"; type_= String}
-  ; Attribute {name= "type_"; jsxName= "type"; type_= String} ]
+    Attribute { name = "async"; jsxName = "async"; type_ = Bool }
+  ; Attribute { name = "charSet"; jsxName = "charSet"; type_ = String }
+  ; Attribute { name = "crossOrigin"; jsxName = "crossOrigin"; type_ = String }
+  ; Attribute { name = "defer"; jsxName = "defer"; type_ = Bool }
+  ; Attribute { name = "integrity"; jsxName = "integrity"; type_ = String }
+  ; Attribute { name = "noModule"; jsxName = "noModule"; type_ = Bool }
+  ; Attribute { name = "nonce"; jsxName = "nonce"; type_ = String }
+  ; Attribute { name = "src"; jsxName = "src"; type_ = String }
+  ; Attribute { name = "type_"; jsxName = "type"; type_ = String }
+  ]
 
 let selectHTMLAttributes =
-  [ Attribute {name= "autoComplete"; jsxName= "autoComplete"; type_= String}
-  ; Attribute {name= "autoFocus"; jsxName= "autoFocus"; type_= Bool}
-  ; Attribute {name= "disabled"; jsxName= "disabled"; type_= Bool}
-  ; Attribute {name= "form"; jsxName= "form"; type_= String}
-  ; Attribute {name= "multiple"; jsxName= "multiple"; type_= Bool}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String}
-  ; Attribute {name= "required"; jsxName= "required"; type_= Bool}
-  ; Attribute {name= "size"; jsxName= "size"; type_= Int (* number *)}
+  [ Attribute
+      { name = "autoComplete"; jsxName = "autoComplete"; type_ = String }
+  ; Attribute { name = "autoFocus"; jsxName = "autoFocus"; type_ = Bool }
+  ; Attribute { name = "disabled"; jsxName = "disabled"; type_ = Bool }
+  ; Attribute { name = "form"; jsxName = "form"; type_ = String }
+  ; Attribute { name = "multiple"; jsxName = "multiple"; type_ = Bool }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+  ; Attribute { name = "required"; jsxName = "required"; type_ = Bool }
+  ; Attribute { name = "size"; jsxName = "size"; type_ = Int (* number *) }
   ; Attribute
-      { name= "value"
-      ; jsxName= "value"
-      ; type_= String (* | ReadonlyArray<String> | number *) }
-  ; Event {name= "onChange"; type_= Form} ]
+      { name = "value"
+      ; jsxName = "value"
+      ; type_ = String (* | ReadonlyArray<String> | number *)
+      }
+  ; Event { name = "onChange"; type_ = Form }
+  ]
 
 let sourceHTMLAttributes =
-  [ Attribute {name= "height"; jsxName= "height"; type_= String (* number |  *)}
-  ; Attribute {name= "media"; jsxName= "media"; type_= String}
-  ; Attribute {name= "sizes"; jsxName= "sizes"; type_= String}
-  ; Attribute {name= "src"; jsxName= "src"; type_= String}
-  ; Attribute {name= "srcSet"; jsxName= "srcSet"; type_= String}
-  ; Attribute {name= "type_"; jsxName= "type"; type_= String}
-  ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
+  [ Attribute
+      { name = "height"; jsxName = "height"; type_ = String (* number |  *) }
+  ; Attribute { name = "media"; jsxName = "media"; type_ = String }
+  ; Attribute { name = "sizes"; jsxName = "sizes"; type_ = String }
+  ; Attribute { name = "src"; jsxName = "src"; type_ = String }
+  ; Attribute { name = "srcSet"; jsxName = "srcSet"; type_ = String }
+  ; Attribute { name = "type_"; jsxName = "type"; type_ = String }
+  ; Attribute
+      { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
   ]
 
 let styleHTMLAttributes =
-  [ Attribute {name= "media"; jsxName= "media"; type_= String}
-  ; Attribute {name= "nonce"; jsxName= "nonce"; type_= String}
-  ; Attribute {name= "scoped"; jsxName= "scoped"; type_= Bool}
-  ; Attribute {name= "type_"; jsxName= "type"; type_= String} ]
+  [ Attribute { name = "media"; jsxName = "media"; type_ = String }
+  ; Attribute { name = "nonce"; jsxName = "nonce"; type_ = String }
+  ; Attribute { name = "scoped"; jsxName = "scoped"; type_ = Bool }
+  ; Attribute { name = "type_"; jsxName = "type"; type_ = String }
+  ]
 
 let tableHTMLAttributes =
   [ Attribute
-      { name= "cellPadding"
-      ; jsxName= "cellPadding"
-      ; type_= String (* number |  *) }
+      { name = "cellPadding"
+      ; jsxName = "cellPadding"
+      ; type_ = String (* number |  *)
+      }
   ; Attribute
-      { name= "cellSpacing"
-      ; jsxName= "cellSpacing"
-      ; type_= String (* number |  *) }
-  ; Attribute {name= "summary"; jsxName= "summary"; type_= String}
-  ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
+      { name = "cellSpacing"
+      ; jsxName = "cellSpacing"
+      ; type_ = String (* number |  *)
+      }
+  ; Attribute { name = "summary"; jsxName = "summary"; type_ = String }
+  ; Attribute
+      { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
   ]
 
 let textareaHTMLAttributes =
-  [ Attribute {name= "autoComplete"; jsxName= "autoComplete"; type_= String}
-  ; Attribute {name= "autoFocus"; jsxName= "autoFocus"; type_= String}
-  ; Attribute {name= "cols"; jsxName= "cols"; type_= Int (* number *)}
-  ; Attribute {name= "dirName"; jsxName= "dirName"; type_= String}
-  ; Attribute {name= "disabled"; jsxName= "disabled"; type_= Bool}
-  ; Attribute {name= "form"; jsxName= "form"; type_= String}
-  ; Attribute {name= "maxLength"; jsxName= "maxLength"; type_= Int (* number *)}
-  ; Attribute {name= "minLength"; jsxName= "minLength"; type_= Int (* number *)}
-  ; Attribute {name= "name"; jsxName= "name"; type_= String}
-  ; Attribute {name= "placeholder"; jsxName= "placeholder"; type_= String}
-  ; Attribute {name= "readOnly"; jsxName= "readOnly"; type_= Bool}
-  ; Attribute {name= "required"; jsxName= "required"; type_= Bool}
-  ; Attribute {name= "rows"; jsxName= "rows"; type_= Int (* number *)}
+  [ Attribute
+      { name = "autoComplete"; jsxName = "autoComplete"; type_ = String }
+  ; Attribute { name = "autoFocus"; jsxName = "autoFocus"; type_ = String }
+  ; Attribute { name = "cols"; jsxName = "cols"; type_ = Int (* number *) }
+  ; Attribute { name = "dirName"; jsxName = "dirName"; type_ = String }
+  ; Attribute { name = "disabled"; jsxName = "disabled"; type_ = Bool }
+  ; Attribute { name = "form"; jsxName = "form"; type_ = String }
   ; Attribute
-      { name= "value"
-      ; jsxName= "value"
-      ; type_= String (* | ReadonlyArray<String> | number *) }
-  ; Attribute {name= "wrap"; jsxName= "wrap"; type_= String}
-  ; Event {name= "onChange"; type_= Form} ]
+      { name = "maxLength"; jsxName = "maxLength"; type_ = Int (* number *) }
+  ; Attribute
+      { name = "minLength"; jsxName = "minLength"; type_ = Int (* number *) }
+  ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+  ; Attribute { name = "placeholder"; jsxName = "placeholder"; type_ = String }
+  ; Attribute { name = "readOnly"; jsxName = "readOnly"; type_ = Bool }
+  ; Attribute { name = "required"; jsxName = "required"; type_ = Bool }
+  ; Attribute { name = "rows"; jsxName = "rows"; type_ = Int (* number *) }
+  ; Attribute
+      { name = "value"
+      ; jsxName = "value"
+      ; type_ = String (* | ReadonlyArray<String> | number *)
+      }
+  ; Attribute { name = "wrap"; jsxName = "wrap"; type_ = String }
+  ; Event { name = "onChange"; type_ = Form }
+  ]
 
 let tdHTMLAttributes =
   [ Attribute
-      { name= "align"
-      ; jsxName= "align"
-      ; type_=
+      { name = "align"
+      ; jsxName = "align"
+      ; type_ =
           String (* type_= "left" | "center" | "right" | "justify" | "char" *)
       }
-  ; Attribute {name= "colSpan"; jsxName= "colSpan"; type_= Int (* number *)}
-  ; Attribute {name= "headers"; jsxName= "headers"; type_= String}
-  ; Attribute {name= "rowSpan"; jsxName= "rowspan"; type_= Int (* number *)}
-  ; Attribute {name= "scope"; jsxName= "scope"; type_= String}
-  ; Attribute {name= "abbr"; jsxName= "abbr"; type_= String}
-  ; Attribute {name= "height"; jsxName= "height"; type_= String (* number |  *)}
-  ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
   ; Attribute
-      { name= "valign"
-      ; jsxName= "valign"
-      ; type_= String (* "top" | "middle" | "bottom" | "baseline" *) } ]
+      { name = "colSpan"; jsxName = "colSpan"; type_ = Int (* number *) }
+  ; Attribute { name = "headers"; jsxName = "headers"; type_ = String }
+  ; Attribute
+      { name = "rowSpan"; jsxName = "rowspan"; type_ = Int (* number *) }
+  ; Attribute { name = "scope"; jsxName = "scope"; type_ = String }
+  ; Attribute { name = "abbr"; jsxName = "abbr"; type_ = String }
+  ; Attribute
+      { name = "height"; jsxName = "height"; type_ = String (* number |  *) }
+  ; Attribute
+      { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
+  ; Attribute
+      { name = "valign"
+      ; jsxName = "valign"
+      ; type_ = String (* "top" | "middle" | "bottom" | "baseline" *)
+      }
+  ]
 
 let thHTMLAttributes =
   [ Attribute
-      { name= "align"
-      ; jsxName= "align"
-      ; type_= String (* "left" | "center" | "right" | "justify" | "char" *) }
-  ; Attribute {name= "colSpan"; jsxName= "colSpan"; type_= Int (* number *)}
-  ; Attribute {name= "headers"; jsxName= "headers"; type_= String}
-  ; Attribute {name= "rowSpan"; jsxName= "rowSpan"; type_= Int (* number *)}
-  ; Attribute {name= "scope"; jsxName= "scope"; type_= String}
-  ; Attribute {name= "abbr"; jsxName= "abbr"; type_= String} ]
+      { name = "align"
+      ; jsxName = "align"
+      ; type_ = String (* "left" | "center" | "right" | "justify" | "char" *)
+      }
+  ; Attribute
+      { name = "colSpan"; jsxName = "colSpan"; type_ = Int (* number *) }
+  ; Attribute { name = "headers"; jsxName = "headers"; type_ = String }
+  ; Attribute
+      { name = "rowSpan"; jsxName = "rowSpan"; type_ = Int (* number *) }
+  ; Attribute { name = "scope"; jsxName = "scope"; type_ = String }
+  ; Attribute { name = "abbr"; jsxName = "abbr"; type_ = String }
+  ]
 
 let timeHTMLAttributes =
-  [Attribute {name= "dateTime"; jsxName= "datetime"; type_= String}]
+  [ Attribute { name = "dateTime"; jsxName = "datetime"; type_ = String } ]
 
 let trackHTMLAttributes =
-  [ Attribute {name= "default"; jsxName= "default"; type_= Bool}
-  ; Attribute {name= "kind"; jsxName= "kind"; type_= String}
-  ; Attribute {name= "label"; jsxName= "label"; type_= String}
-  ; Attribute {name= "src"; jsxName= "src"; type_= String}
-  ; Attribute {name= "srcLang"; jsxName= "srclang"; type_= String} ]
+  [ Attribute { name = "default"; jsxName = "default"; type_ = Bool }
+  ; Attribute { name = "kind"; jsxName = "kind"; type_ = String }
+  ; Attribute { name = "label"; jsxName = "label"; type_ = String }
+  ; Attribute { name = "src"; jsxName = "src"; type_ = String }
+  ; Attribute { name = "srcLang"; jsxName = "srclang"; type_ = String }
+  ]
 
 let videoHTMLAttributes =
-  [ Attribute {name= "height"; jsxName= "height"; type_= String (* number |  *)}
-  ; Attribute {name= "playsInline"; jsxName= "playsinline"; type_= Bool}
-  ; Attribute {name= "poster"; jsxName= "poster"; type_= String}
-  ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
+  [ Attribute
+      { name = "height"; jsxName = "height"; type_ = String (* number |  *) }
+  ; Attribute { name = "playsInline"; jsxName = "playsinline"; type_ = Bool }
+  ; Attribute { name = "poster"; jsxName = "poster"; type_ = String }
   ; Attribute
-      { name= "disablePictureInPicture"
-      ; jsxName= "disablepictureinpicture"
-      ; type_= Bool } ]
+      { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
+  ; Attribute
+      { name = "disablePictureInPicture"
+      ; jsxName = "disablepictureinpicture"
+      ; type_ = Bool
+      }
+  ]
 
 module SVG = struct
   (* "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/" *)
 
   let coreAttributes =
     (* https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/Core *)
-    [ Attribute {name= "id"; jsxName= "id"; type_= String}
-    ; Attribute {name= "lang"; jsxName= "lang"; type_= String}
-    ; Attribute {name= "tabIndex"; jsxName= "tabIndex"; type_= String}
-    ; Attribute {name= "xmlBase"; jsxName= "xmlBase"; type_= String}
-    ; Attribute {name= "xmlLang"; jsxName= "xmlLang"; type_= String}
-    ; Attribute {name= "xmlSpace"; jsxName= "xmlSpace"; type_= String} ]
+    [ Attribute { name = "id"; jsxName = "id"; type_ = String }
+    ; Attribute { name = "lang"; jsxName = "lang"; type_ = String }
+    ; Attribute { name = "tabIndex"; jsxName = "tabIndex"; type_ = String }
+    ; Attribute { name = "xmlBase"; jsxName = "xmlBase"; type_ = String }
+    ; Attribute { name = "xmlLang"; jsxName = "xmlLang"; type_ = String }
+    ; Attribute { name = "xmlSpace"; jsxName = "xmlSpace"; type_ = String }
+    ]
 
   let stylingAttributes =
     (* https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/Styling *)
-    [ Attribute {name= "className"; jsxName= "className"; type_= String}
-    ; Attribute {name= "style"; jsxName= "style"; type_= Style} ]
+    [ Attribute { name = "className"; jsxName = "className"; type_ = String }
+    ; Attribute { name = "style"; jsxName = "style"; type_ = Style }
+    ]
 
   let presentationAttributes =
     (* Presentation attributes *)
-    [ Attribute {name= "clip"; jsxName= "clip"; type_= String (* number |  *)}
-    ; Attribute {name= "clipPath"; jsxName= "clipPath"; type_= String}
+    [ Attribute
+        { name = "clip"; jsxName = "clip"; type_ = String (* number |  *) }
+    ; Attribute { name = "clipPath"; jsxName = "clipPath"; type_ = String }
     ; Attribute
-        {name= "cursor"; jsxName= "cursor"; type_= String (* number |  *)}
-    ; Attribute {name= "fill"; jsxName= "fill"; type_= String}
-    ; Attribute {name= "filter"; jsxName= "filter"; type_= String}
-    ; Attribute {name= "fontFamily"; jsxName= "fontFamily"; type_= String}
-    ; Attribute {name= "letterSpacing"; jsxName= "letterSpacing"; type_= String}
-    ; Attribute {name= "lightingColor"; jsxName= "lightingColor"; type_= String}
-    ; Attribute {name= "markerEnd"; jsxName= "markerEnd"; type_= String}
-    ; Attribute {name= "mask"; jsxName= "mask"; type_= String}
-    ; Attribute {name= "pointerEvents"; jsxName= "pointerEvents"; type_= String}
-    ; Attribute {name= "stopColor"; jsxName= "stopColor"; type_= String}
-    ; Attribute {name= "stroke"; jsxName= "stroke"; type_= String}
-    ; Attribute {name= "textAnchor"; jsxName= "textAnchor"; type_= String}
-    ; Attribute {name= "transform"; jsxName= "transform"; type_= String}
+        { name = "cursor"; jsxName = "cursor"; type_ = String (* number |  *) }
+    ; Attribute { name = "fill"; jsxName = "fill"; type_ = String }
+    ; Attribute { name = "filter"; jsxName = "filter"; type_ = String }
+    ; Attribute { name = "fontFamily"; jsxName = "fontFamily"; type_ = String }
     ; Attribute
-        {name= "transformOrigin"; jsxName= "transformOrigin"; type_= String}
+        { name = "letterSpacing"; jsxName = "letterSpacing"; type_ = String }
     ; Attribute
-        { name= "alignmentBaseline"
-        ; jsxName= "alignmentBaseline"
-        ; type_=
+        { name = "lightingColor"; jsxName = "lightingColor"; type_ = String }
+    ; Attribute { name = "markerEnd"; jsxName = "markerEnd"; type_ = String }
+    ; Attribute { name = "mask"; jsxName = "mask"; type_ = String }
+    ; Attribute
+        { name = "pointerEvents"; jsxName = "pointerEvents"; type_ = String }
+    ; Attribute { name = "stopColor"; jsxName = "stopColor"; type_ = String }
+    ; Attribute { name = "stroke"; jsxName = "stroke"; type_ = String }
+    ; Attribute { name = "textAnchor"; jsxName = "textAnchor"; type_ = String }
+    ; Attribute { name = "transform"; jsxName = "transform"; type_ = String }
+    ; Attribute
+        { name = "transformOrigin"
+        ; jsxName = "transformOrigin"
+        ; type_ = String
+        }
+    ; Attribute
+        { name = "alignmentBaseline"
+        ; jsxName = "alignmentBaseline"
+        ; type_ =
             String
             (* "auto" | "baseline" | "before-edge" | "text-before-edge" | "middle" | "central" | "after-edge" "text-after-edge" | "ideographic" | "alphabetic" | "hanging" | "mathematical" | "inherit" *)
         }
     ; Attribute
-        { name= "clipRule"
-        ; jsxName= "clipRule"
-        ; type_= (* number | "linearRGB" | "inherit" *) String }
+        { name = "clipRule"
+        ; jsxName = "clipRule"
+        ; type_ = (* number | "linearRGB" | "inherit" *) String
+        }
     ; Attribute
-        { name= "colorProfile"
-        ; jsxName= "colorProfile"
-        ; type_= String (* number |  *) }
+        { name = "colorProfile"
+        ; jsxName = "colorProfile"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "direction"; jsxName= "direction"; type_= String (* number |  *)}
+        { name = "direction"
+        ; jsxName = "direction"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "display"; jsxName= "display"; type_= String (* number |  *)}
+        { name = "display"
+        ; jsxName = "display"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "divisor"; jsxName= "divisor"; type_= String (* number |  *)}
+        { name = "divisor"
+        ; jsxName = "divisor"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "fillOpacity"
-        ; jsxName= "fillOpacity"
-        ; type_= String (* number |  *) }
+        { name = "fillOpacity"
+        ; jsxName = "fillOpacity"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "fillRule"
-        ; jsxName= "fillRule"
-        ; type_= String (* type_= "nonzero" | "evenodd" | "inherit" *) }
+        { name = "fillRule"
+        ; jsxName = "fillRule"
+        ; type_ = String (* type_= "nonzero" | "evenodd" | "inherit" *)
+        }
     ; Attribute
-        { name= "floodColor"
-        ; jsxName= "floodColor"
-        ; type_= String (* number |  *) }
+        { name = "floodColor"
+        ; jsxName = "floodColor"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "floodOpacity"
-        ; jsxName= "floodOpacity"
-        ; type_= String (* number |  *) }
+        { name = "floodOpacity"
+        ; jsxName = "floodOpacity"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "fontSize"; jsxName= "fontSize"; type_= String (* number |  *)}
+        { name = "fontSize"
+        ; jsxName = "fontSize"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "fontStretch"
-        ; jsxName= "fontStretch"
-        ; type_= String (* number |  *) }
+        { name = "fontStretch"
+        ; jsxName = "fontStretch"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "fontStyle"; jsxName= "fontStyle"; type_= String (* number |  *)}
+        { name = "fontStyle"
+        ; jsxName = "fontStyle"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "fontVariant"
-        ; jsxName= "fontVariant"
-        ; type_= String (* number |  *) }
+        { name = "fontVariant"
+        ; jsxName = "fontVariant"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "fontWeight"
-        ; jsxName= "fontWeight"
-        ; type_= String (* number |  *) }
+        { name = "fontWeight"
+        ; jsxName = "fontWeight"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "glyphOrientationHorizontal"
-        ; jsxName= "glyphOrientationHorizontal"
-        ; type_= String (* number |  *) }
+        { name = "glyphOrientationHorizontal"
+        ; jsxName = "glyphOrientationHorizontal"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "glyphOrientationVertical"
-        ; jsxName= "glyphOrientationVertical"
-        ; type_= String (* number |  *) }
+        { name = "glyphOrientationVertical"
+        ; jsxName = "glyphOrientationVertical"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "kerning"; jsxName= "kerning"; type_= String (* number |  *)}
+        { name = "kerning"
+        ; jsxName = "kerning"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "keyPoints"; jsxName= "keyPoints"; type_= String (* number |  *)}
+        { name = "keyPoints"
+        ; jsxName = "keyPoints"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "opacity"; jsxName= "opacity"; type_= String (* number |  *)}
+        { name = "opacity"
+        ; jsxName = "opacity"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "operator"; jsxName= "operator"; type_= String (* number |  *)}
+        { name = "operator"
+        ; jsxName = "operator"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "overflow"; jsxName= "overflow"; type_= String (* number |  *)}
+        { name = "overflow"
+        ; jsxName = "overflow"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "stopOpacity"
-        ; jsxName= "stopOpacity"
-        ; type_= String (* number |  *) }
+        { name = "stopOpacity"
+        ; jsxName = "stopOpacity"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "strokeLinecap"
-        ; jsxName= "strokeLinecap"
-        ; type_= String (* type_= "butt" | "round" | "square" | "inherit" *) }
+        { name = "strokeLinecap"
+        ; jsxName = "strokeLinecap"
+        ; type_ = String (* type_= "butt" | "round" | "square" | "inherit" *)
+        }
     ; Attribute
-        { name= "unicodeBidi"
-        ; jsxName= "unicodeBidi"
-        ; type_= String (* number |  *) }
+        { name = "unicodeBidi"
+        ; jsxName = "unicodeBidi"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "vectorEffect"
-        ; jsxName= "vectorEffect"
-        ; type_= String (* number |  *) }
+        { name = "vectorEffect"
+        ; jsxName = "vectorEffect"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "wordSpacing"
-        ; jsxName= "wordSpacing"
-        ; type_= String (* number |  *) }
+        { name = "wordSpacing"
+        ; jsxName = "wordSpacing"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "writingMode"
-        ; jsxName= "writingMode"
-        ; type_= String (* number |  *) } ]
+        { name = "writingMode"
+        ; jsxName = "writingMode"
+        ; type_ = String (* number |  *)
+        }
+    ]
 
   let filtersAttributes =
     (* https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute#filters_attributes *)
     [ (* Filter primitive attributes *)
       Attribute
-        {name= "height"; jsxName= "height"; type_= String (* number |  *)}
-    ; Attribute {name= "width"; jsxName= "width"; type_= String (* number |  *)}
-    ; Attribute {name= "result"; jsxName= "result"; type_= String}
-    ; Attribute {name= "x"; jsxName= "x"; type_= String (* number |  *)}
-    ; Attribute {name= "y"; jsxName= "y"; type_= String (* number |  *)}
+        { name = "height"; jsxName = "height"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "width"; jsxName = "width"; type_ = String (* number |  *) }
+    ; Attribute { name = "result"; jsxName = "result"; type_ = String }
+    ; Attribute { name = "x"; jsxName = "x"; type_ = String (* number |  *) }
+    ; Attribute { name = "y"; jsxName = "y"; type_ = String (* number |  *) }
       (* Transfer function attributes
          type, tableValues, slope, intercept, amplitude, exponent, offset
       *)
-    ; Attribute {name= "type_"; jsxName= "type"; type_= String}
+    ; Attribute { name = "type_"; jsxName = "type"; type_ = String }
     ; Attribute
-        {name= "exponent"; jsxName= "exponent"; type_= String (* number |  *)}
-    ; Attribute {name= "slope"; jsxName= "slope"; type_= String (* number |  *)}
+        { name = "exponent"
+        ; jsxName = "exponent"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "amplitude"; jsxName= "amplitude"; type_= String (* number |  *)}
+        { name = "slope"; jsxName = "slope"; type_ = String (* number |  *) }
     ; Attribute
-        {name= "intercept"; jsxName= "intercept"; type_= String (* number |  *)}
+        { name = "amplitude"
+        ; jsxName = "amplitude"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "tableValues"
-        ; jsxName= "tableValues"
-        ; type_= String (* number |  *) }
+        { name = "intercept"
+        ; jsxName = "intercept"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "tableValues"
+        ; jsxName = "tableValues"
+        ; type_ = String (* number |  *)
+        }
       (* Animation target element attributes
          *)
-    ; Attribute {name= "href"; jsxName= "href"; type_= String}
+    ; Attribute { name = "href"; jsxName = "href"; type_ = String }
       (* Animation attribute target attributes*)
-    ; Attribute {name= "attributeName"; jsxName= "attributeName"; type_= String}
-    ; Attribute {name= "attributeType"; jsxName= "attributeType"; type_= String}
+    ; Attribute
+        { name = "attributeName"; jsxName = "attributeName"; type_ = String }
+    ; Attribute
+        { name = "attributeType"; jsxName = "attributeType"; type_ = String }
       (* Animation timing attributes
          begin, dur, end, min, max, restart, repeatCount, repeatDur, fill *)
-    ; Attribute {name= "begin"; jsxName= "begin"; type_= String (* number |  *)}
-    ; Attribute {name= "dur"; jsxName= "dur"; type_= String (* number |  *)}
-    ; Attribute {name= "end"; jsxName= "end"; type_= String (* number |  *)}
-    ; Attribute {name= "max"; jsxName= "max"; type_= String (* number |  *)}
-    ; Attribute {name= "min"; jsxName= "min"; type_= String (* number |  *)}
     ; Attribute
-        { name= "repeatCount"
-        ; jsxName= "repeatCount"
-        ; type_= String (* number |  *) }
+        { name = "begin"; jsxName = "begin"; type_ = String (* number |  *) }
     ; Attribute
-        {name= "restart"; jsxName= "restart"; type_= String (* number |  *)}
+        { name = "dur"; jsxName = "dur"; type_ = String (* number |  *) }
     ; Attribute
-        {name= "repeatDur"; jsxName= "repeatDur"; type_= String (* number |  *)}
-    ; Attribute {name= "fill"; jsxName= "fill"; type_= String}
+        { name = "end"; jsxName = "end"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "max"; jsxName = "max"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "min"; jsxName = "min"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "repeatCount"
+        ; jsxName = "repeatCount"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "restart"
+        ; jsxName = "restart"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "repeatDur"
+        ; jsxName = "repeatDur"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute { name = "fill"; jsxName = "fill"; type_ = String }
       (* Animation value attributes *)
     ; Attribute
-        {name= "calcMode"; jsxName= "calcMode"; type_= String (* number |  *)}
-    ; Attribute {name= "values"; jsxName= "values"; type_= String}
+        { name = "calcMode"
+        ; jsxName = "calcMode"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute { name = "values"; jsxName = "values"; type_ = String }
     ; Attribute
-        { name= "keySplines"
-        ; jsxName= "keySplines"
-        ; type_= String (* number |  *) }
+        { name = "keySplines"
+        ; jsxName = "keySplines"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        {name= "keyTimes"; jsxName= "keyTimes"; type_= String (* number |  *)}
-    ; Attribute {name= "from"; jsxName= "from"; type_= String (* number |  *)}
-    ; Attribute {name= "to"; jsxName= "to"; type_= String (* number |  *)}
-    ; Attribute {name= "by"; jsxName= "by"; type_= String (* number |  *)}
+        { name = "keyTimes"
+        ; jsxName = "keyTimes"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "from"; jsxName = "from"; type_ = String (* number |  *) }
+    ; Attribute { name = "to"; jsxName = "to"; type_ = String (* number |  *) }
+    ; Attribute { name = "by"; jsxName = "by"; type_ = String (* number |  *) }
       (* Animation addition attributes *)
     ; Attribute
-        { name= "accumulate"
-        ; jsxName= "accumulate"
-        ; type_= String (* type_= "none" | "sum" *) }
+        { name = "accumulate"
+        ; jsxName = "accumulate"
+        ; type_ = String (* type_= "none" | "sum" *)
+        }
     ; Attribute
-        { name= "additive"
-        ; jsxName= "additive"
-        ; type_= String (* type_= "replace" | "sum" *) } ]
+        { name = "additive"
+        ; jsxName = "additive"
+        ; type_ = String (* type_= "replace" | "sum" *)
+        }
+    ]
 
   let htmlAttributes =
     (* These are valid SVG attributes, that are HTML Attributes as well *)
-    [ Attribute {name= "color"; jsxName= "color"; type_= String}
-    ; Attribute {name= "id"; jsxName= "id"; type_= String}
-    ; Attribute {name= "lang"; jsxName= "lang"; type_= String}
-    ; Attribute {name= "media"; jsxName= "media"; type_= String}
-    ; Attribute {name= "method"; jsxName= "method"; type_= String}
-    ; Attribute {name= "name"; jsxName= "name"; type_= String}
-    ; Attribute {name= "style"; jsxName= "style"; type_= Style}
-    ; Attribute {name= "target"; jsxName= "target"; type_= String}
+    [ Attribute { name = "color"; jsxName = "color"; type_ = String }
+    ; Attribute { name = "id"; jsxName = "id"; type_ = String }
+    ; Attribute { name = "lang"; jsxName = "lang"; type_ = String }
+    ; Attribute { name = "media"; jsxName = "media"; type_ = String }
+    ; Attribute { name = "method"; jsxName = "method"; type_ = String }
+    ; Attribute { name = "name"; jsxName = "name"; type_ = String }
+    ; Attribute { name = "style"; jsxName = "style"; type_ = Style }
+    ; Attribute { name = "target"; jsxName = "target"; type_ = String }
       (* Other HTML properties supported by SVG elements in browsers *)
-    ; Attribute {name= "role"; jsxName= "role"; type_= ariaRole}
-    ; Attribute {name= "tabIndex"; jsxName= "tabIndex"; type_= Int (* number *)}
+    ; Attribute { name = "role"; jsxName = "role"; type_ = ariaRole }
     ; Attribute
-        { name= "crossOrigin"
-        ; jsxName= "crossOrigin"
-        ; type_= String (* "anonymous" | "use-credentials" | "" *) }
+        { name = "tabIndex"; jsxName = "tabIndex"; type_ = Int (* number *) }
+    ; Attribute
+        { name = "crossOrigin"
+        ; jsxName = "crossOrigin"
+        ; type_ = String (* "anonymous" | "use-credentials" | "" *)
+        }
       (* SVG Specific attributes *)
     ; Attribute
-        { name= "accentHeight"
-        ; jsxName= "accentHeight"
-        ; type_= String (* number |  *) }
+        { name = "accentHeight"
+        ; jsxName = "accentHeight"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "allowReorder"
-        ; jsxName= "allowReorder"
-        ; type_= String (* type_= "no" | "yes" *) }
+        { name = "allowReorder"
+        ; jsxName = "allowReorder"
+        ; type_ = String (* type_= "no" | "yes" *)
+        }
     ; Attribute
-        { name= "alphabetic"
-        ; jsxName= "alphabetic"
-        ; type_= String (* number |  *) }
+        { name = "alphabetic"
+        ; jsxName = "alphabetic"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "arabicForm"
-        ; jsxName= "arabicForm"
-        ; type_=
+        { name = "arabicForm"
+        ; jsxName = "arabicForm"
+        ; type_ =
             String (* type_= "initial" | "medial" | "terminal" | "isolated" *)
         }
     ; Attribute
-        {name= "ascent"; jsxName= "ascent"; type_= String (* number |  *)}
+        { name = "ascent"; jsxName = "ascent"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "autoReverse"
+        ; jsxName = "autoReverse"
+        ; type_ = String (* Booleanish *)
+        }
+    ; Attribute
+        { name = "azimuth"
+        ; jsxName = "azimuth"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "baseProfile"
+        ; jsxName = "baseProfile"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "bbox"; jsxName = "bbox"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "bias"; jsxName = "bias"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "capHeight"
+        ; jsxName = "capHeight"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute { name = "cx"; jsxName = "cx"; type_ = String (* number |  *) }
+    ; Attribute { name = "cy"; jsxName = "cy"; type_ = String (* number |  *) }
+    ; Attribute { name = "d"; jsxName = "d"; type_ = String }
+    ; Attribute
+        { name = "decelerate"
+        ; jsxName = "decelerate"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "descent"
+        ; jsxName = "descent"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute { name = "dx"; jsxName = "dx"; type_ = String (* number |  *) }
+    ; Attribute { name = "dy"; jsxName = "dy"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "edgeMode"
+        ; jsxName = "edgeMode"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "elevation"
+        ; jsxName = "elevation"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "externalResourcesRequired"
+        ; jsxName = "externalResourcesRequired"
+        ; type_ = String (* Booleanish *)
+        }
+    ; Attribute
+        { name = "filterRes"
+        ; jsxName = "filterRes"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "filterUnits"
+        ; jsxName = "filterUnits"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "format"; jsxName = "format"; type_ = String (* number |  *) }
+    ; Attribute { name = "fr"; jsxName = "fr"; type_ = String (* number |  *) }
+    ; Attribute { name = "fx"; jsxName = "fx"; type_ = String (* number |  *) }
+    ; Attribute { name = "fy"; jsxName = "fy"; type_ = String (* number |  *) }
+    ; Attribute { name = "g1"; jsxName = "g1"; type_ = String (* number |  *) }
+    ; Attribute { name = "g2"; jsxName = "g2"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "glyphName"
+        ; jsxName = "glyphName"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "glyphRef"
+        ; jsxName = "glyphRef"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "gradientTransform"
+        ; jsxName = "gradientTransform"
+        ; type_ = String
+        }
+    ; Attribute
+        { name = "gradientUnits"; jsxName = "gradientUnits"; type_ = String }
+    ; Attribute
+        { name = "hanging"
+        ; jsxName = "hanging"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "horizAdvX"
+        ; jsxName = "horizAdvX"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "horizOriginX"
+        ; jsxName = "horizOriginX"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "ideographic"
+        ; jsxName = "ideographic"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "in2"; jsxName = "in2"; type_ = String (* number |  *) }
+    ; Attribute { name = "in"; jsxName = "in"; type_ = String }
+    ; Attribute { name = "k1"; jsxName = "k1"; type_ = String (* number |  *) }
+    ; Attribute { name = "k2"; jsxName = "k2"; type_ = String (* number |  *) }
+    ; Attribute { name = "k3"; jsxName = "k3"; type_ = String (* number |  *) }
+    ; Attribute { name = "k4"; jsxName = "k4"; type_ = String (* number |  *) }
+    ; Attribute { name = "k"; jsxName = "k"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "kernelMatrix"
+        ; jsxName = "kernelMatrix"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "limitingConeAngle"
+        ; jsxName = "limitingConeAngle"
+        ; type_ = String
+        }
+    ; Attribute
+        { name = "lengthAdjust"
+        ; jsxName = "lengthAdjust"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "local"; jsxName = "local"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "markerHeight"
+        ; jsxName = "markerHeight"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute { name = "markerMid"; jsxName = "markerMid"; type_ = String }
+    ; Attribute
+        { name = "markerStart"; jsxName = "markerStart"; type_ = String }
+    ; Attribute
+        { name = "markerUnits"
+        ; jsxName = "markerUnits"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "markerWidth"
+        ; jsxName = "markerWidth"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "maskUnits"
+        ; jsxName = "maskUnits"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "mathematical"
+        ; jsxName = "mathematical"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "mode"; jsxName = "mode"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "numOctaves"
+        ; jsxName = "numOctaves"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "offset"; jsxName = "offset"; type_ = String (* number |  *) }
     ; Attribute
-        { name= "autoReverse"
-        ; jsxName= "autoReverse"
-        ; type_= String (* Booleanish *) }
+        { name = "order"; jsxName = "order"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "orient"; jsxName = "orient"; type_ = String (* number |  *) }
     ; Attribute
-        {name= "azimuth"; jsxName= "azimuth"; type_= String (* number |  *)}
+        { name = "orientation"
+        ; jsxName = "orientation"
+        ; type_ = String (* number |  *)
+        }
     ; Attribute
-        { name= "baseProfile"
-        ; jsxName= "baseProfile"
-        ; type_= String (* number |  *) }
-    ; Attribute {name= "bbox"; jsxName= "bbox"; type_= String (* number |  *)}
-    ; Attribute {name= "bias"; jsxName= "bias"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "capHeight"; jsxName= "capHeight"; type_= String (* number |  *)}
-    ; Attribute {name= "cx"; jsxName= "cx"; type_= String (* number |  *)}
-    ; Attribute {name= "cy"; jsxName= "cy"; type_= String (* number |  *)}
-    ; Attribute {name= "d"; jsxName= "d"; type_= String}
-    ; Attribute
-        { name= "decelerate"
-        ; jsxName= "decelerate"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        {name= "descent"; jsxName= "descent"; type_= String (* number |  *)}
-    ; Attribute {name= "dx"; jsxName= "dx"; type_= String (* number |  *)}
-    ; Attribute {name= "dy"; jsxName= "dy"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "edgeMode"; jsxName= "edgeMode"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "elevation"; jsxName= "elevation"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "externalResourcesRequired"
-        ; jsxName= "externalResourcesRequired"
-        ; type_= String (* Booleanish *) }
-    ; Attribute
-        {name= "filterRes"; jsxName= "filterRes"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "filterUnits"
-        ; jsxName= "filterUnits"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        {name= "format"; jsxName= "format"; type_= String (* number |  *)}
-    ; Attribute {name= "fr"; jsxName= "fr"; type_= String (* number |  *)}
-    ; Attribute {name= "fx"; jsxName= "fx"; type_= String (* number |  *)}
-    ; Attribute {name= "fy"; jsxName= "fy"; type_= String (* number |  *)}
-    ; Attribute {name= "g1"; jsxName= "g1"; type_= String (* number |  *)}
-    ; Attribute {name= "g2"; jsxName= "g2"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "glyphName"; jsxName= "glyphName"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "glyphRef"; jsxName= "glyphRef"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "gradientTransform"; jsxName= "gradientTransform"; type_= String}
-    ; Attribute {name= "gradientUnits"; jsxName= "gradientUnits"; type_= String}
-    ; Attribute
-        {name= "hanging"; jsxName= "hanging"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "horizAdvX"; jsxName= "horizAdvX"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "horizOriginX"
-        ; jsxName= "horizOriginX"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "ideographic"
-        ; jsxName= "ideographic"
-        ; type_= String (* number |  *) }
-    ; Attribute {name= "in2"; jsxName= "in2"; type_= String (* number |  *)}
-    ; Attribute {name= "in"; jsxName= "in"; type_= String}
-    ; Attribute {name= "k1"; jsxName= "k1"; type_= String (* number |  *)}
-    ; Attribute {name= "k2"; jsxName= "k2"; type_= String (* number |  *)}
-    ; Attribute {name= "k3"; jsxName= "k3"; type_= String (* number |  *)}
-    ; Attribute {name= "k4"; jsxName= "k4"; type_= String (* number |  *)}
-    ; Attribute {name= "k"; jsxName= "k"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "kernelMatrix"
-        ; jsxName= "kernelMatrix"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        {name= "limitingConeAngle"; jsxName= "limitingConeAngle"; type_= String}
-    ; Attribute
-        { name= "lengthAdjust"
-        ; jsxName= "lengthAdjust"
-        ; type_= String (* number |  *) }
-    ; Attribute {name= "local"; jsxName= "local"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "markerHeight"
-        ; jsxName= "markerHeight"
-        ; type_= String (* number |  *) }
-    ; Attribute {name= "markerMid"; jsxName= "markerMid"; type_= String}
-    ; Attribute {name= "markerStart"; jsxName= "markerStart"; type_= String}
-    ; Attribute
-        { name= "markerUnits"
-        ; jsxName= "markerUnits"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "markerWidth"
-        ; jsxName= "markerWidth"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        {name= "maskUnits"; jsxName= "maskUnits"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "mathematical"
-        ; jsxName= "mathematical"
-        ; type_= String (* number |  *) }
-    ; Attribute {name= "mode"; jsxName= "mode"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "numOctaves"
-        ; jsxName= "numOctaves"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        {name= "offset"; jsxName= "offset"; type_= String (* number |  *)}
-    ; Attribute {name= "order"; jsxName= "order"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "orient"; jsxName= "orient"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "orientation"
-        ; jsxName= "orientation"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        {name= "origin"; jsxName= "origin"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "overlineThickness"; jsxName= "overlineThickness"; type_= Int}
-    ; Attribute
-        { name= "paintOrder"
-        ; jsxName= "paintOrder"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        {name= "panose1"; jsxName= "panose1"; type_= String (* number |  *)}
-    ; Attribute {name= "path"; jsxName= "path"; type_= String}
-    ; Attribute
-        { name= "pathLength"
-        ; jsxName= "pathLength"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "patternContentUnits"
-        ; jsxName= "patternContentUnits"
-        ; type_= String }
-    ; Attribute {name= "patternUnits"; jsxName= "patternUnits"; type_= String}
-    ; Attribute {name= "points"; jsxName= "points"; type_= String}
-    ; Attribute
-        {name= "pointsAtX"; jsxName= "pointsAtX"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "pointsAtY"; jsxName= "pointsAtY"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "pointsAtZ"; jsxName= "pointsAtZ"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "preserveAspectRatio"
-        ; jsxName= "preserveAspectRatio"
-        ; type_= String }
-    ; Attribute {name= "r"; jsxName= "r"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "radius"; jsxName= "radius"; type_= String (* number |  *)}
-    ; Attribute {name= "refX"; jsxName= "refX"; type_= String (* number |  *)}
-    ; Attribute {name= "refY"; jsxName= "refY"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "rotate"; jsxName= "rotate"; type_= String (* number |  *)}
-    ; Attribute {name= "rx"; jsxName= "rx"; type_= String (* number |  *)}
-    ; Attribute {name= "ry"; jsxName= "ry"; type_= String (* number |  *)}
-    ; Attribute {name= "scale"; jsxName= "scale"; type_= String (* number |  *)}
-    ; Attribute {name= "seed"; jsxName= "seed"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "spacing"; jsxName= "spacing"; type_= String (* number |  *)}
-    ; Attribute {name= "speed"; jsxName= "speed"; type_= String (* number |  *)}
-    ; Attribute {name= "spreadMethod"; jsxName= "spreadMethod"; type_= String}
-    ; Attribute
-        { name= "startOffset"
-        ; jsxName= "startOffset"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "stdDeviation"
-        ; jsxName= "stdDeviation"
-        ; type_= String (* number |  *) }
-    ; Attribute {name= "stemh"; jsxName= "stemh"; type_= String (* number |  *)}
-    ; Attribute {name= "stemv"; jsxName= "stemv"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "stitchTiles"
-        ; jsxName= "stitchTiles"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "strikethroughPosition"
-        ; jsxName= "strikethroughPosition"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "strikethroughThickness"
-        ; jsxName= "strikethroughThickness"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "strokeWidth"
-        ; jsxName= "strokeWidth"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "surfaceScale"
-        ; jsxName= "surfaceScale"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        {name= "targetX"; jsxName= "targetX"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "targetY"; jsxName= "targetY"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "textLength"
-        ; jsxName= "textLength"
-        ; type_= String (* number |  *) }
-    ; Attribute {name= "u1"; jsxName= "u1"; type_= String (* number |  *)}
-    ; Attribute {name= "u2"; jsxName= "u2"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "unicode"; jsxName= "unicode"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "unicodeRange"
-        ; jsxName= "unicodeRange"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "unitsPerEm"
-        ; jsxName= "unitsPerEm"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "vAlphabetic"
-        ; jsxName= "vAlphabetic"
-        ; type_= String (* number |  *) }
-    ; Attribute {name= "version"; jsxName= "version"; type_= String}
-    ; Attribute
-        {name= "vertAdvY"; jsxName= "vertAdvY"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "vertOriginX"
-        ; jsxName= "vertOriginX"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "vertOriginY"
-        ; jsxName= "vertOriginY"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        {name= "vHanging"; jsxName= "vHanging"; type_= String (* number |  *)}
-    ; Attribute
-        { name= "vIdeographic"
-        ; jsxName= "vIdeographic"
-        ; type_= String (* number |  *) }
-    ; Attribute {name= "viewBox"; jsxName= "viewBox"; type_= String}
-    ; Attribute
-        { name= "viewTarget"
-        ; jsxName= "viewTarget"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        { name= "visibility"
-        ; jsxName= "visibility"
-        ; type_= String (* number |  *) }
-    ; Attribute
-        {name= "widths"; jsxName= "widths"; type_= String (* number |  *)}
-    ; Attribute {name= "x1"; jsxName= "x1"; type_= String (* number |  *)}
-    ; Attribute {name= "x2"; jsxName= "x2"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "xChannelSelector"; jsxName= "xChannelSelector"; type_= String}
-    ; Attribute
-        {name= "xHeight"; jsxName= "xHeight"; type_= String (* number |  *)}
-    ; Attribute {name= "xlinkActuate"; jsxName= "xlinkActuate"; type_= String}
-    ; Attribute {name= "xlinkArcrole"; jsxName= "xlinkArcrole"; type_= String}
-    ; Attribute {name= "xlinkHref"; jsxName= "xlinkHref"; type_= String}
-    ; Attribute {name= "xlinkRole"; jsxName= "xlinkRole"; type_= String}
-    ; Attribute {name= "xlinkShow"; jsxName= "xlinkShow"; type_= String}
-    ; Attribute {name= "xlinkTitle"; jsxName= "xlinkTitle"; type_= String}
-    ; Attribute {name= "xlinkType"; jsxName= "xlinkType"; type_= String}
-    ; Attribute {name= "xmlBase"; jsxName= "xmlBase"; type_= String}
-    ; Attribute {name= "xmlLang"; jsxName= "xmlLang"; type_= String}
-    ; Attribute {name= "xmlns"; jsxName= "xmlns"; type_= String}
-    ; Attribute {name= "xmlnsXlink"; jsxName= "xmlnsXlink"; type_= String}
-    ; Attribute {name= "xmlSpace"; jsxName= "xmlSpace"; type_= String}
-    ; Attribute {name= "y1"; jsxName= "y1"; type_= String (* number |  *)}
-    ; Attribute {name= "y2"; jsxName= "y2"; type_= String (* number |  *)}
-    ; Attribute
-        {name= "yChannelSelector"; jsxName= "yChannelSelector"; type_= String}
-    ; Attribute {name= "z"; jsxName= "z"; type_= String (* number |  *)}
-    ; Attribute {name= "zoomAndPan"; jsxName= "zoomAndPan"; type_= String} ]
+        { name = "origin"; jsxName = "origin"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "overlineThickness"
+        ; jsxName = "overlineThickness"
+        ; type_ = Int
+        }
+    ; Attribute
+        { name = "paintOrder"
+        ; jsxName = "paintOrder"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "panose1"
+        ; jsxName = "panose1"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute { name = "path"; jsxName = "path"; type_ = String }
+    ; Attribute
+        { name = "pathLength"
+        ; jsxName = "pathLength"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "patternContentUnits"
+        ; jsxName = "patternContentUnits"
+        ; type_ = String
+        }
+    ; Attribute
+        { name = "patternUnits"; jsxName = "patternUnits"; type_ = String }
+    ; Attribute { name = "points"; jsxName = "points"; type_ = String }
+    ; Attribute
+        { name = "pointsAtX"
+        ; jsxName = "pointsAtX"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "pointsAtY"
+        ; jsxName = "pointsAtY"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "pointsAtZ"
+        ; jsxName = "pointsAtZ"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "preserveAspectRatio"
+        ; jsxName = "preserveAspectRatio"
+        ; type_ = String
+        }
+    ; Attribute { name = "r"; jsxName = "r"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "radius"; jsxName = "radius"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "refX"; jsxName = "refX"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "refY"; jsxName = "refY"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "rotate"; jsxName = "rotate"; type_ = String (* number |  *) }
+    ; Attribute { name = "rx"; jsxName = "rx"; type_ = String (* number |  *) }
+    ; Attribute { name = "ry"; jsxName = "ry"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "scale"; jsxName = "scale"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "seed"; jsxName = "seed"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "spacing"
+        ; jsxName = "spacing"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "speed"; jsxName = "speed"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "spreadMethod"; jsxName = "spreadMethod"; type_ = String }
+    ; Attribute
+        { name = "startOffset"
+        ; jsxName = "startOffset"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "stdDeviation"
+        ; jsxName = "stdDeviation"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "stemh"; jsxName = "stemh"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "stemv"; jsxName = "stemv"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "stitchTiles"
+        ; jsxName = "stitchTiles"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "strikethroughPosition"
+        ; jsxName = "strikethroughPosition"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "strikethroughThickness"
+        ; jsxName = "strikethroughThickness"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "strokeWidth"
+        ; jsxName = "strokeWidth"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "surfaceScale"
+        ; jsxName = "surfaceScale"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "targetX"
+        ; jsxName = "targetX"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "targetY"
+        ; jsxName = "targetY"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "textLength"
+        ; jsxName = "textLength"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute { name = "u1"; jsxName = "u1"; type_ = String (* number |  *) }
+    ; Attribute { name = "u2"; jsxName = "u2"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "unicode"
+        ; jsxName = "unicode"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "unicodeRange"
+        ; jsxName = "unicodeRange"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "unitsPerEm"
+        ; jsxName = "unitsPerEm"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "vAlphabetic"
+        ; jsxName = "vAlphabetic"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute { name = "version"; jsxName = "version"; type_ = String }
+    ; Attribute
+        { name = "vertAdvY"
+        ; jsxName = "vertAdvY"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "vertOriginX"
+        ; jsxName = "vertOriginX"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "vertOriginY"
+        ; jsxName = "vertOriginY"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "vHanging"
+        ; jsxName = "vHanging"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "vIdeographic"
+        ; jsxName = "vIdeographic"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute { name = "viewBox"; jsxName = "viewBox"; type_ = String }
+    ; Attribute
+        { name = "viewTarget"
+        ; jsxName = "viewTarget"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "visibility"
+        ; jsxName = "visibility"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "widths"; jsxName = "widths"; type_ = String (* number |  *) }
+    ; Attribute { name = "x1"; jsxName = "x1"; type_ = String (* number |  *) }
+    ; Attribute { name = "x2"; jsxName = "x2"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "xChannelSelector"
+        ; jsxName = "xChannelSelector"
+        ; type_ = String
+        }
+    ; Attribute
+        { name = "xHeight"
+        ; jsxName = "xHeight"
+        ; type_ = String (* number |  *)
+        }
+    ; Attribute
+        { name = "xlinkActuate"; jsxName = "xlinkActuate"; type_ = String }
+    ; Attribute
+        { name = "xlinkArcrole"; jsxName = "xlinkArcrole"; type_ = String }
+    ; Attribute { name = "xlinkHref"; jsxName = "xlinkHref"; type_ = String }
+    ; Attribute { name = "xlinkRole"; jsxName = "xlinkRole"; type_ = String }
+    ; Attribute { name = "xlinkShow"; jsxName = "xlinkShow"; type_ = String }
+    ; Attribute { name = "xlinkTitle"; jsxName = "xlinkTitle"; type_ = String }
+    ; Attribute { name = "xlinkType"; jsxName = "xlinkType"; type_ = String }
+    ; Attribute { name = "xmlBase"; jsxName = "xmlBase"; type_ = String }
+    ; Attribute { name = "xmlLang"; jsxName = "xmlLang"; type_ = String }
+    ; Attribute { name = "xmlns"; jsxName = "xmlns"; type_ = String }
+    ; Attribute { name = "xmlnsXlink"; jsxName = "xmlnsXlink"; type_ = String }
+    ; Attribute { name = "xmlSpace"; jsxName = "xmlSpace"; type_ = String }
+    ; Attribute { name = "y1"; jsxName = "y1"; type_ = String (* number |  *) }
+    ; Attribute { name = "y2"; jsxName = "y2"; type_ = String (* number |  *) }
+    ; Attribute
+        { name = "yChannelSelector"
+        ; jsxName = "yChannelSelector"
+        ; type_ = String
+        }
+    ; Attribute { name = "z"; jsxName = "z"; type_ = String (* number |  *) }
+    ; Attribute { name = "zoomAndPan"; jsxName = "zoomAndPan"; type_ = String }
+    ]
 
   let attributes =
     htmlAttributes & filtersAttributes & presentationAttributes
@@ -1621,228 +2030,260 @@ module SVG = struct
 end
 
 let webViewHTMLAttributes =
-  [ Attribute {name= "allowFullScreen"; jsxName= "allowfullcreen"; type_= Bool}
-  ; Attribute {name= "allowPopups"; jsxName= "allowPopups"; type_= Bool}
-  ; Attribute {name= "autoFocus"; jsxName= "autoFocus"; type_= Bool}
-  ; Attribute {name= "autoSize"; jsxName= "autoSize"; type_= Bool}
-  ; Attribute {name= "blinkFeatures"; jsxName= "blinkFeatures"; type_= String}
+  [ Attribute
+      { name = "allowFullScreen"; jsxName = "allowfullcreen"; type_ = Bool }
+  ; Attribute { name = "allowPopups"; jsxName = "allowPopups"; type_ = Bool }
+  ; Attribute { name = "autoFocus"; jsxName = "autoFocus"; type_ = Bool }
+  ; Attribute { name = "autoSize"; jsxName = "autoSize"; type_ = Bool }
   ; Attribute
-      { name= "disableBlinkFeatures"
-      ; jsxName= "disableBlinkFeatures"
-      ; type_= String }
+      { name = "blinkFeatures"; jsxName = "blinkFeatures"; type_ = String }
   ; Attribute
-      {name= "disableGuestResize"; jsxName= "disableGuestResize"; type_= Bool}
+      { name = "disableBlinkFeatures"
+      ; jsxName = "disableBlinkFeatures"
+      ; type_ = String
+      }
   ; Attribute
-      {name= "disableWebSecurity"; jsxName= "disableWebSecurity"; type_= Bool}
-  ; Attribute {name= "guestInstance"; jsxName= "guestInstance"; type_= String}
-  ; Attribute {name= "httpReferrer"; jsxName= "httpReferrer"; type_= String}
-  ; Attribute {name= "nodeIntegration"; jsxName= "nodeIntegration"; type_= Bool}
-  ; Attribute {name= "partition"; jsxName= "partition"; type_= String}
-  ; Attribute {name= "plugins"; jsxName= "plugins"; type_= Bool}
-  ; Attribute {name= "preload"; jsxName= "preload"; type_= String}
-  ; Attribute {name= "src"; jsxName= "src"; type_= String}
-  ; Attribute {name= "userAgent"; jsxName= "userAgent"; type_= String}
-  ; Attribute {name= "webPreferences"; jsxName= "webPreferences"; type_= String}
+      { name = "disableGuestResize"
+      ; jsxName = "disableGuestResize"
+      ; type_ = Bool
+      }
+  ; Attribute
+      { name = "disableWebSecurity"
+      ; jsxName = "disableWebSecurity"
+      ; type_ = Bool
+      }
+  ; Attribute
+      { name = "guestInstance"; jsxName = "guestInstance"; type_ = String }
+  ; Attribute
+      { name = "httpReferrer"; jsxName = "httpReferrer"; type_ = String }
+  ; Attribute
+      { name = "nodeIntegration"; jsxName = "nodeIntegration"; type_ = Bool }
+  ; Attribute { name = "partition"; jsxName = "partition"; type_ = String }
+  ; Attribute { name = "plugins"; jsxName = "plugins"; type_ = Bool }
+  ; Attribute { name = "preload"; jsxName = "preload"; type_ = String }
+  ; Attribute { name = "src"; jsxName = "src"; type_ = String }
+  ; Attribute { name = "userAgent"; jsxName = "userAgent"; type_ = String }
+  ; Attribute
+      { name = "webPreferences"; jsxName = "webPreferences"; type_ = String }
   ]
 
 let commonHtmlAttributes =
   elementAttributes & reactAttributes & globalAttributes & globalEventHandlers
 
 let htmlElements =
-  [ {tag= "a"; attributes= commonHtmlAttributes & anchorHTMLAttributes}
-  ; {tag= "abbr"; attributes= commonHtmlAttributes}
-  ; {tag= "address"; attributes= commonHtmlAttributes}
-  ; {tag= "area"; attributes= commonHtmlAttributes & areaHTMLAttributes}
-  ; {tag= "article"; attributes= commonHtmlAttributes}
-  ; {tag= "aside"; attributes= commonHtmlAttributes}
-  ; {tag= "audio"; attributes= commonHtmlAttributes & mediaHTMLAttributes}
-  ; {tag= "b"; attributes= commonHtmlAttributes}
-  ; {tag= "base"; attributes= commonHtmlAttributes & baseHTMLAttributes}
-  ; {tag= "bdi"; attributes= commonHtmlAttributes}
-  ; {tag= "bdo"; attributes= commonHtmlAttributes}
-  ; {tag= "big"; attributes= commonHtmlAttributes}
-  ; { tag= "blockquote"
-    ; attributes= commonHtmlAttributes & blockquoteHTMLAttributes }
-  ; {tag= "body"; attributes= commonHtmlAttributes}
-  ; {tag= "br"; attributes= commonHtmlAttributes}
-  ; {tag= "button"; attributes= commonHtmlAttributes & buttonHTMLAttributes}
-  ; {tag= "canvas"; attributes= commonHtmlAttributes & canvasHTMLAttributes}
-  ; {tag= "caption"; attributes= commonHtmlAttributes}
-  ; {tag= "cite"; attributes= commonHtmlAttributes}
-  ; {tag= "code"; attributes= commonHtmlAttributes}
-  ; {tag= "col"; attributes= commonHtmlAttributes & colHTMLAttributes}
-  ; {tag= "colgroup"; attributes= commonHtmlAttributes & colgroupHTMLAttributes}
-  ; {tag= "data"; attributes= commonHtmlAttributes & dataHTMLAttributes}
-  ; {tag= "datalist"; attributes= commonHtmlAttributes}
-  ; {tag= "dd"; attributes= commonHtmlAttributes}
-  ; {tag= "del"; attributes= commonHtmlAttributes & delHTMLAttributes}
-  ; {tag= "details"; attributes= commonHtmlAttributes & detailsHTMLAttributes}
-  ; {tag= "dfn"; attributes= commonHtmlAttributes}
-  ; {tag= "dialog"; attributes= commonHtmlAttributes & dialogHTMLAttributes}
-  ; {tag= "div"; attributes= commonHtmlAttributes}
-  ; {tag= "dl"; attributes= commonHtmlAttributes}
-  ; {tag= "dt"; attributes= commonHtmlAttributes}
-  ; {tag= "em"; attributes= commonHtmlAttributes}
-  ; {tag= "embed"; attributes= commonHtmlAttributes & embedHTMLAttributes}
-  ; {tag= "fieldset"; attributes= commonHtmlAttributes & fieldsetHTMLAttributes}
-  ; {tag= "figcaption"; attributes= commonHtmlAttributes}
-  ; {tag= "figure"; attributes= commonHtmlAttributes}
-  ; {tag= "footer"; attributes= commonHtmlAttributes}
-  ; {tag= "form"; attributes= commonHtmlAttributes & formHTMLAttributes}
-  ; {tag= "h1"; attributes= commonHtmlAttributes}
-  ; {tag= "h2"; attributes= commonHtmlAttributes}
-  ; {tag= "h3"; attributes= commonHtmlAttributes}
-  ; {tag= "h4"; attributes= commonHtmlAttributes}
-  ; {tag= "h5"; attributes= commonHtmlAttributes}
-  ; {tag= "h6"; attributes= commonHtmlAttributes}
-  ; {tag= "head"; attributes= commonHtmlAttributes}
-  ; {tag= "header"; attributes= commonHtmlAttributes}
-  ; {tag= "hgroup"; attributes= commonHtmlAttributes}
-  ; {tag= "hr"; attributes= commonHtmlAttributes}
-  ; {tag= "html"; attributes= commonHtmlAttributes & htmlHTMLAttributes}
-  ; {tag= "i"; attributes= commonHtmlAttributes}
-  ; {tag= "iframe"; attributes= commonHtmlAttributes & iframeHTMLAttributes}
-  ; {tag= "img"; attributes= commonHtmlAttributes & imgHTMLAttributes}
-  ; {tag= "input"; attributes= commonHtmlAttributes & inputHTMLAttributes}
-  ; {tag= "ins"; attributes= commonHtmlAttributes & insHTMLAttributes}
-  ; {tag= "kbd"; attributes= commonHtmlAttributes}
-  ; {tag= "keygen"; attributes= commonHtmlAttributes & keygenHTMLAttributes}
-  ; {tag= "label"; attributes= commonHtmlAttributes & labelHTMLAttributes}
-  ; {tag= "legend"; attributes= commonHtmlAttributes}
-  ; {tag= "li"; attributes= commonHtmlAttributes & liHTMLAttributes}
-  ; {tag= "link"; attributes= commonHtmlAttributes & linkHTMLAttributes}
-  ; {tag= "main"; attributes= commonHtmlAttributes}
-  ; {tag= "map"; attributes= commonHtmlAttributes & mapHTMLAttributes}
-  ; {tag= "mark"; attributes= commonHtmlAttributes}
-  ; {tag= "menu"; attributes= commonHtmlAttributes & menuHTMLAttributes}
-  ; {tag= "menuitem"; attributes= commonHtmlAttributes}
-  ; {tag= "meta"; attributes= commonHtmlAttributes & metaHTMLAttributes}
-  ; {tag= "meter"; attributes= commonHtmlAttributes & meterHTMLAttributes}
-  ; {tag= "nav"; attributes= commonHtmlAttributes}
-  ; {tag= "noindex"; attributes= commonHtmlAttributes}
-  ; {tag= "noscript"; attributes= commonHtmlAttributes}
-  ; {tag= "object"; attributes= commonHtmlAttributes & objectHTMLAttributes}
-  ; {tag= "ol"; attributes= commonHtmlAttributes & olHTMLAttributes}
-  ; {tag= "optgroup"; attributes= commonHtmlAttributes & optgroupHTMLAttributes}
-  ; {tag= "option"; attributes= commonHtmlAttributes & optionHTMLAttributes}
-  ; {tag= "output"; attributes= commonHtmlAttributes & outputHTMLAttributes}
-  ; {tag= "p"; attributes= commonHtmlAttributes}
-  ; {tag= "param"; attributes= commonHtmlAttributes & paramHTMLAttributes}
-  ; {tag= "picture"; attributes= commonHtmlAttributes}
-  ; {tag= "pre"; attributes= commonHtmlAttributes}
-  ; {tag= "progress"; attributes= commonHtmlAttributes & progressHTMLAttributes}
-  ; {tag= "q"; attributes= commonHtmlAttributes & quoteHTMLAttributes}
-  ; {tag= "rp"; attributes= commonHtmlAttributes}
-  ; {tag= "rt"; attributes= commonHtmlAttributes}
-  ; {tag= "ruby"; attributes= commonHtmlAttributes}
-  ; {tag= "s"; attributes= commonHtmlAttributes}
-  ; {tag= "samp"; attributes= commonHtmlAttributes}
-  ; {tag= "script"; attributes= commonHtmlAttributes & scriptHTMLAttributes}
-  ; {tag= "section"; attributes= commonHtmlAttributes}
-  ; {tag= "select"; attributes= commonHtmlAttributes & selectHTMLAttributes}
-  ; {tag= "slot"; attributes= commonHtmlAttributes & slotHTMLAttributes}
-  ; {tag= "small"; attributes= commonHtmlAttributes}
-  ; {tag= "source"; attributes= commonHtmlAttributes & sourceHTMLAttributes}
-  ; {tag= "span"; attributes= commonHtmlAttributes}
-  ; {tag= "strong"; attributes= commonHtmlAttributes}
-  ; {tag= "style"; attributes= commonHtmlAttributes & styleHTMLAttributes}
-  ; {tag= "sub"; attributes= commonHtmlAttributes}
-  ; {tag= "summary"; attributes= commonHtmlAttributes}
-  ; {tag= "sup"; attributes= commonHtmlAttributes}
-  ; {tag= "table"; attributes= commonHtmlAttributes & tableHTMLAttributes}
-  ; {tag= "tbody"; attributes= commonHtmlAttributes}
-  ; {tag= "td"; attributes= commonHtmlAttributes & tdHTMLAttributes}
-  ; {tag= "template"; attributes= commonHtmlAttributes}
-  ; {tag= "textarea"; attributes= commonHtmlAttributes & textareaHTMLAttributes}
-  ; {tag= "tfoot"; attributes= commonHtmlAttributes}
-  ; {tag= "th"; attributes= commonHtmlAttributes & thHTMLAttributes}
-  ; {tag= "thead"; attributes= commonHtmlAttributes}
-  ; {tag= "time"; attributes= commonHtmlAttributes & timeHTMLAttributes}
-  ; {tag= "title"; attributes= commonHtmlAttributes}
-  ; {tag= "tr"; attributes= commonHtmlAttributes}
-  ; {tag= "track"; attributes= commonHtmlAttributes & trackHTMLAttributes}
-  ; {tag= "u"; attributes= commonHtmlAttributes}
-  ; {tag= "ul"; attributes= commonHtmlAttributes}
-  ; {tag= "var"; attributes= commonHtmlAttributes}
-  ; {tag= "video"; attributes= commonHtmlAttributes & videoHTMLAttributes}
-  ; {tag= "wbr"; attributes= commonHtmlAttributes}
-  ; {tag= "webview"; attributes= commonHtmlAttributes & webViewHTMLAttributes}
+  [ { tag = "a"; attributes = commonHtmlAttributes & anchorHTMLAttributes }
+  ; { tag = "abbr"; attributes = commonHtmlAttributes }
+  ; { tag = "address"; attributes = commonHtmlAttributes }
+  ; { tag = "area"; attributes = commonHtmlAttributes & areaHTMLAttributes }
+  ; { tag = "article"; attributes = commonHtmlAttributes }
+  ; { tag = "aside"; attributes = commonHtmlAttributes }
+  ; { tag = "audio"; attributes = commonHtmlAttributes & mediaHTMLAttributes }
+  ; { tag = "b"; attributes = commonHtmlAttributes }
+  ; { tag = "base"; attributes = commonHtmlAttributes & baseHTMLAttributes }
+  ; { tag = "bdi"; attributes = commonHtmlAttributes }
+  ; { tag = "bdo"; attributes = commonHtmlAttributes }
+  ; { tag = "big"; attributes = commonHtmlAttributes }
+  ; { tag = "blockquote"
+    ; attributes = commonHtmlAttributes & blockquoteHTMLAttributes
+    }
+  ; { tag = "body"; attributes = commonHtmlAttributes }
+  ; { tag = "br"; attributes = commonHtmlAttributes }
+  ; { tag = "button"; attributes = commonHtmlAttributes & buttonHTMLAttributes }
+  ; { tag = "canvas"; attributes = commonHtmlAttributes & canvasHTMLAttributes }
+  ; { tag = "caption"; attributes = commonHtmlAttributes }
+  ; { tag = "cite"; attributes = commonHtmlAttributes }
+  ; { tag = "code"; attributes = commonHtmlAttributes }
+  ; { tag = "col"; attributes = commonHtmlAttributes & colHTMLAttributes }
+  ; { tag = "colgroup"
+    ; attributes = commonHtmlAttributes & colgroupHTMLAttributes
+    }
+  ; { tag = "data"; attributes = commonHtmlAttributes & dataHTMLAttributes }
+  ; { tag = "datalist"; attributes = commonHtmlAttributes }
+  ; { tag = "dd"; attributes = commonHtmlAttributes }
+  ; { tag = "del"; attributes = commonHtmlAttributes & delHTMLAttributes }
+  ; { tag = "details"
+    ; attributes = commonHtmlAttributes & detailsHTMLAttributes
+    }
+  ; { tag = "dfn"; attributes = commonHtmlAttributes }
+  ; { tag = "dialog"; attributes = commonHtmlAttributes & dialogHTMLAttributes }
+  ; { tag = "div"; attributes = commonHtmlAttributes }
+  ; { tag = "dl"; attributes = commonHtmlAttributes }
+  ; { tag = "dt"; attributes = commonHtmlAttributes }
+  ; { tag = "em"; attributes = commonHtmlAttributes }
+  ; { tag = "embed"; attributes = commonHtmlAttributes & embedHTMLAttributes }
+  ; { tag = "fieldset"
+    ; attributes = commonHtmlAttributes & fieldsetHTMLAttributes
+    }
+  ; { tag = "figcaption"; attributes = commonHtmlAttributes }
+  ; { tag = "figure"; attributes = commonHtmlAttributes }
+  ; { tag = "footer"; attributes = commonHtmlAttributes }
+  ; { tag = "form"; attributes = commonHtmlAttributes & formHTMLAttributes }
+  ; { tag = "h1"; attributes = commonHtmlAttributes }
+  ; { tag = "h2"; attributes = commonHtmlAttributes }
+  ; { tag = "h3"; attributes = commonHtmlAttributes }
+  ; { tag = "h4"; attributes = commonHtmlAttributes }
+  ; { tag = "h5"; attributes = commonHtmlAttributes }
+  ; { tag = "h6"; attributes = commonHtmlAttributes }
+  ; { tag = "head"; attributes = commonHtmlAttributes }
+  ; { tag = "header"; attributes = commonHtmlAttributes }
+  ; { tag = "hgroup"; attributes = commonHtmlAttributes }
+  ; { tag = "hr"; attributes = commonHtmlAttributes }
+  ; { tag = "html"; attributes = commonHtmlAttributes & htmlHTMLAttributes }
+  ; { tag = "i"; attributes = commonHtmlAttributes }
+  ; { tag = "iframe"; attributes = commonHtmlAttributes & iframeHTMLAttributes }
+  ; { tag = "img"; attributes = commonHtmlAttributes & imgHTMLAttributes }
+  ; { tag = "input"; attributes = commonHtmlAttributes & inputHTMLAttributes }
+  ; { tag = "ins"; attributes = commonHtmlAttributes & insHTMLAttributes }
+  ; { tag = "kbd"; attributes = commonHtmlAttributes }
+  ; { tag = "keygen"; attributes = commonHtmlAttributes & keygenHTMLAttributes }
+  ; { tag = "label"; attributes = commonHtmlAttributes & labelHTMLAttributes }
+  ; { tag = "legend"; attributes = commonHtmlAttributes }
+  ; { tag = "li"; attributes = commonHtmlAttributes & liHTMLAttributes }
+  ; { tag = "link"; attributes = commonHtmlAttributes & linkHTMLAttributes }
+  ; { tag = "main"; attributes = commonHtmlAttributes }
+  ; { tag = "map"; attributes = commonHtmlAttributes & mapHTMLAttributes }
+  ; { tag = "mark"; attributes = commonHtmlAttributes }
+  ; { tag = "menu"; attributes = commonHtmlAttributes & menuHTMLAttributes }
+  ; { tag = "menuitem"; attributes = commonHtmlAttributes }
+  ; { tag = "meta"; attributes = commonHtmlAttributes & metaHTMLAttributes }
+  ; { tag = "meter"; attributes = commonHtmlAttributes & meterHTMLAttributes }
+  ; { tag = "nav"; attributes = commonHtmlAttributes }
+  ; { tag = "noindex"; attributes = commonHtmlAttributes }
+  ; { tag = "noscript"; attributes = commonHtmlAttributes }
+  ; { tag = "object"; attributes = commonHtmlAttributes & objectHTMLAttributes }
+  ; { tag = "ol"; attributes = commonHtmlAttributes & olHTMLAttributes }
+  ; { tag = "optgroup"
+    ; attributes = commonHtmlAttributes & optgroupHTMLAttributes
+    }
+  ; { tag = "option"; attributes = commonHtmlAttributes & optionHTMLAttributes }
+  ; { tag = "output"; attributes = commonHtmlAttributes & outputHTMLAttributes }
+  ; { tag = "p"; attributes = commonHtmlAttributes }
+  ; { tag = "param"; attributes = commonHtmlAttributes & paramHTMLAttributes }
+  ; { tag = "picture"; attributes = commonHtmlAttributes }
+  ; { tag = "pre"; attributes = commonHtmlAttributes }
+  ; { tag = "progress"
+    ; attributes = commonHtmlAttributes & progressHTMLAttributes
+    }
+  ; { tag = "q"; attributes = commonHtmlAttributes & quoteHTMLAttributes }
+  ; { tag = "rp"; attributes = commonHtmlAttributes }
+  ; { tag = "rt"; attributes = commonHtmlAttributes }
+  ; { tag = "ruby"; attributes = commonHtmlAttributes }
+  ; { tag = "s"; attributes = commonHtmlAttributes }
+  ; { tag = "samp"; attributes = commonHtmlAttributes }
+  ; { tag = "script"; attributes = commonHtmlAttributes & scriptHTMLAttributes }
+  ; { tag = "section"; attributes = commonHtmlAttributes }
+  ; { tag = "select"; attributes = commonHtmlAttributes & selectHTMLAttributes }
+  ; { tag = "slot"; attributes = commonHtmlAttributes & slotHTMLAttributes }
+  ; { tag = "small"; attributes = commonHtmlAttributes }
+  ; { tag = "source"; attributes = commonHtmlAttributes & sourceHTMLAttributes }
+  ; { tag = "span"; attributes = commonHtmlAttributes }
+  ; { tag = "strong"; attributes = commonHtmlAttributes }
+  ; { tag = "style"; attributes = commonHtmlAttributes & styleHTMLAttributes }
+  ; { tag = "sub"; attributes = commonHtmlAttributes }
+  ; { tag = "summary"; attributes = commonHtmlAttributes }
+  ; { tag = "sup"; attributes = commonHtmlAttributes }
+  ; { tag = "table"; attributes = commonHtmlAttributes & tableHTMLAttributes }
+  ; { tag = "tbody"; attributes = commonHtmlAttributes }
+  ; { tag = "td"; attributes = commonHtmlAttributes & tdHTMLAttributes }
+  ; { tag = "template"; attributes = commonHtmlAttributes }
+  ; { tag = "textarea"
+    ; attributes = commonHtmlAttributes & textareaHTMLAttributes
+    }
+  ; { tag = "tfoot"; attributes = commonHtmlAttributes }
+  ; { tag = "th"; attributes = commonHtmlAttributes & thHTMLAttributes }
+  ; { tag = "thead"; attributes = commonHtmlAttributes }
+  ; { tag = "time"; attributes = commonHtmlAttributes & timeHTMLAttributes }
+  ; { tag = "title"; attributes = commonHtmlAttributes }
+  ; { tag = "tr"; attributes = commonHtmlAttributes }
+  ; { tag = "track"; attributes = commonHtmlAttributes & trackHTMLAttributes }
+  ; { tag = "u"; attributes = commonHtmlAttributes }
+  ; { tag = "ul"; attributes = commonHtmlAttributes }
+  ; { tag = "var"; attributes = commonHtmlAttributes }
+  ; { tag = "video"; attributes = commonHtmlAttributes & videoHTMLAttributes }
+  ; { tag = "wbr"; attributes = commonHtmlAttributes }
+  ; { tag = "webview"
+    ; attributes = commonHtmlAttributes & webViewHTMLAttributes
+    }
   ]
 
 let commonSvgAttributes =
   SVG.attributes & reactAttributes & globalEventHandlers & ariaAttributes
 
 let svgElements =
-  [ {tag= "svg"; attributes= commonSvgAttributes}
-  ; {tag= "animate"; attributes= commonSvgAttributes}
-  ; {tag= "animateMotion"; attributes= commonSvgAttributes}
-  ; {tag= "animateTransform"; attributes= commonSvgAttributes}
-  ; {tag= "circle"; attributes= commonSvgAttributes}
-  ; {tag= "clipPath"; attributes= commonSvgAttributes}
-  ; {tag= "defs"; attributes= commonSvgAttributes}
-  ; {tag= "desc"; attributes= commonSvgAttributes}
-  ; {tag= "ellipse"; attributes= commonSvgAttributes}
-  ; {tag= "feBlend"; attributes= commonSvgAttributes}
-  ; {tag= "feColorMatrix"; attributes= commonSvgAttributes}
-  ; {tag= "feComponentTransfer"; attributes= commonSvgAttributes}
-  ; {tag= "feComposite"; attributes= commonSvgAttributes}
-  ; {tag= "feConvolveMatrix"; attributes= commonSvgAttributes}
-  ; {tag= "feDiffuseLighting"; attributes= commonSvgAttributes}
-  ; {tag= "feDisplacementMap"; attributes= commonSvgAttributes}
-  ; {tag= "feDistantLight"; attributes= commonSvgAttributes}
-  ; {tag= "feDropShadow"; attributes= commonSvgAttributes}
-  ; {tag= "feFlood"; attributes= commonSvgAttributes}
-  ; {tag= "feFuncA"; attributes= commonSvgAttributes}
-  ; {tag= "feFuncB"; attributes= commonSvgAttributes}
-  ; {tag= "feFuncG"; attributes= commonSvgAttributes}
-  ; {tag= "feFuncR"; attributes= commonSvgAttributes}
-  ; {tag= "feGaussianBlur"; attributes= commonSvgAttributes}
-  ; {tag= "feImage"; attributes= commonSvgAttributes}
-  ; {tag= "feMerge"; attributes= commonSvgAttributes}
-  ; {tag= "feMergeNode"; attributes= commonSvgAttributes}
-  ; {tag= "feMorphology"; attributes= commonSvgAttributes}
-  ; {tag= "feOffset"; attributes= commonSvgAttributes}
-  ; {tag= "fePointLight"; attributes= commonSvgAttributes}
-  ; {tag= "feSpecularLighting"; attributes= commonSvgAttributes}
-  ; {tag= "feSpotLight"; attributes= commonSvgAttributes}
-  ; {tag= "feTile"; attributes= commonSvgAttributes}
-  ; {tag= "feTurbulence"; attributes= commonSvgAttributes}
-  ; {tag= "filter"; attributes= commonSvgAttributes}
-  ; {tag= "foreignObject"; attributes= commonSvgAttributes}
-  ; {tag= "g"; attributes= commonSvgAttributes}
-  ; {tag= "image"; attributes= commonSvgAttributes}
-  ; {tag= "line"; attributes= commonSvgAttributes}
-  ; {tag= "linearGradient"; attributes= commonSvgAttributes}
-  ; {tag= "marker"; attributes= commonSvgAttributes}
-  ; {tag= "mask"; attributes= commonSvgAttributes}
-  ; {tag= "metadata"; attributes= commonSvgAttributes}
-  ; {tag= "mpath"; attributes= commonSvgAttributes}
-  ; {tag= "path"; attributes= commonSvgAttributes}
-  ; {tag= "pattern"; attributes= commonSvgAttributes}
-  ; {tag= "polygon"; attributes= commonSvgAttributes}
-  ; {tag= "polyline"; attributes= commonSvgAttributes}
-  ; {tag= "radialGradient"; attributes= commonSvgAttributes}
-  ; {tag= "rect"; attributes= commonSvgAttributes}
-  ; {tag= "stop"; attributes= commonSvgAttributes}
-  ; {tag= "switch"; attributes= commonSvgAttributes}
-  ; {tag= "symbol"; attributes= commonSvgAttributes}
-  ; {tag= "text"; attributes= commonSvgAttributes}
-  ; {tag= "textPath"; attributes= commonSvgAttributes}
-  ; {tag= "tspan"; attributes= commonSvgAttributes}
-  ; {tag= "use"; attributes= commonSvgAttributes}
-  ; {tag= "view"; attributes= commonSvgAttributes} ]
+  [ { tag = "svg"; attributes = commonSvgAttributes }
+  ; { tag = "animate"; attributes = commonSvgAttributes }
+  ; { tag = "animateMotion"; attributes = commonSvgAttributes }
+  ; { tag = "animateTransform"; attributes = commonSvgAttributes }
+  ; { tag = "circle"; attributes = commonSvgAttributes }
+  ; { tag = "clipPath"; attributes = commonSvgAttributes }
+  ; { tag = "defs"; attributes = commonSvgAttributes }
+  ; { tag = "desc"; attributes = commonSvgAttributes }
+  ; { tag = "ellipse"; attributes = commonSvgAttributes }
+  ; { tag = "feBlend"; attributes = commonSvgAttributes }
+  ; { tag = "feColorMatrix"; attributes = commonSvgAttributes }
+  ; { tag = "feComponentTransfer"; attributes = commonSvgAttributes }
+  ; { tag = "feComposite"; attributes = commonSvgAttributes }
+  ; { tag = "feConvolveMatrix"; attributes = commonSvgAttributes }
+  ; { tag = "feDiffuseLighting"; attributes = commonSvgAttributes }
+  ; { tag = "feDisplacementMap"; attributes = commonSvgAttributes }
+  ; { tag = "feDistantLight"; attributes = commonSvgAttributes }
+  ; { tag = "feDropShadow"; attributes = commonSvgAttributes }
+  ; { tag = "feFlood"; attributes = commonSvgAttributes }
+  ; { tag = "feFuncA"; attributes = commonSvgAttributes }
+  ; { tag = "feFuncB"; attributes = commonSvgAttributes }
+  ; { tag = "feFuncG"; attributes = commonSvgAttributes }
+  ; { tag = "feFuncR"; attributes = commonSvgAttributes }
+  ; { tag = "feGaussianBlur"; attributes = commonSvgAttributes }
+  ; { tag = "feImage"; attributes = commonSvgAttributes }
+  ; { tag = "feMerge"; attributes = commonSvgAttributes }
+  ; { tag = "feMergeNode"; attributes = commonSvgAttributes }
+  ; { tag = "feMorphology"; attributes = commonSvgAttributes }
+  ; { tag = "feOffset"; attributes = commonSvgAttributes }
+  ; { tag = "fePointLight"; attributes = commonSvgAttributes }
+  ; { tag = "feSpecularLighting"; attributes = commonSvgAttributes }
+  ; { tag = "feSpotLight"; attributes = commonSvgAttributes }
+  ; { tag = "feTile"; attributes = commonSvgAttributes }
+  ; { tag = "feTurbulence"; attributes = commonSvgAttributes }
+  ; { tag = "filter"; attributes = commonSvgAttributes }
+  ; { tag = "foreignObject"; attributes = commonSvgAttributes }
+  ; { tag = "g"; attributes = commonSvgAttributes }
+  ; { tag = "image"; attributes = commonSvgAttributes }
+  ; { tag = "line"; attributes = commonSvgAttributes }
+  ; { tag = "linearGradient"; attributes = commonSvgAttributes }
+  ; { tag = "marker"; attributes = commonSvgAttributes }
+  ; { tag = "mask"; attributes = commonSvgAttributes }
+  ; { tag = "metadata"; attributes = commonSvgAttributes }
+  ; { tag = "mpath"; attributes = commonSvgAttributes }
+  ; { tag = "path"; attributes = commonSvgAttributes }
+  ; { tag = "pattern"; attributes = commonSvgAttributes }
+  ; { tag = "polygon"; attributes = commonSvgAttributes }
+  ; { tag = "polyline"; attributes = commonSvgAttributes }
+  ; { tag = "radialGradient"; attributes = commonSvgAttributes }
+  ; { tag = "rect"; attributes = commonSvgAttributes }
+  ; { tag = "stop"; attributes = commonSvgAttributes }
+  ; { tag = "switch"; attributes = commonSvgAttributes }
+  ; { tag = "symbol"; attributes = commonSvgAttributes }
+  ; { tag = "text"; attributes = commonSvgAttributes }
+  ; { tag = "textPath"; attributes = commonSvgAttributes }
+  ; { tag = "tspan"; attributes = commonSvgAttributes }
+  ; { tag = "use"; attributes = commonSvgAttributes }
+  ; { tag = "view"; attributes = commonSvgAttributes }
+  ]
 
 let elements = svgElements & htmlElements
 
-let getName = function Attribute {name; _} -> name | Event {name; _} -> name
+let getName = function
+  | Attribute { name; _ } -> name
+  | Event { name; _ } -> name
 
 let getJSXName = function
-  | Attribute {jsxName; _} ->
-      jsxName
-  | Event {name; _} ->
-      name
+  | Attribute { jsxName; _ } -> jsxName
+  | Event { name; _ } -> name
 
-type errors = [`ElementNotFound | `AttributeNotFound]
+type errors =
+  [ `ElementNotFound
+  | `AttributeNotFound
+  ]
 
 let getAttributes tag =
   List.find_opt (fun element -> element.tag = tag) elements
@@ -1851,8 +2292,7 @@ let getAttributes tag =
 let findByName tag name =
   let byName p = getName p = name in
   match getAttributes tag with
-  | Ok {attributes} ->
+  | Ok { attributes } ->
       List.find_opt byName attributes
       |> Option.to_result ~none:`AttributeNotFound
-  | Error err ->
-      Error err
+  | Error err -> Error err

--- a/ppx/html.mli
+++ b/ppx/html.mli
@@ -1,4 +1,11 @@
-type attributeType = String | Int | Float | Bool | Style | Ref | InnerHtml
+type attributeType =
+  | String
+  | Int
+  | Float
+  | Bool
+  | Style
+  | Ref
+  | InnerHtml
 
 type eventType =
   | Clipboard
@@ -18,14 +25,25 @@ type eventType =
   | Pointer
   | Drag
 
-type attribute = {type_: attributeType; name: string; jsxName: string}
+type attribute =
+  { type_ : attributeType
+  ; name : string
+  ; jsxName : string
+  }
 
-type event = {type_: eventType; name: string}
+type event =
+  { type_ : eventType
+  ; name : string
+  }
 
-type prop = Attribute of attribute | Event of event
+type prop =
+  | Attribute of attribute
+  | Event of event
 
-type errors = [`ElementNotFound | `AttributeNotFound]
+type errors =
+  [ `ElementNotFound
+  | `AttributeNotFound
+  ]
 
 val getJSXName : prop -> string
-
 val findByName : string -> string -> (prop, errors) result

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -23,33 +23,27 @@ open Ppxlib
 open Ast_helper
 
 module Str_label = struct
-  type t = Labelled of string | Optional of string
+  type t =
+    | Labelled of string
+    | Optional of string
 
   let of_arg_label : arg_label -> t = function
-    | Labelled s ->
-        Labelled s
-    | Optional s ->
-        Optional s
-    | Nolabel ->
-        failwith "invariant failed: Str_label called with Nolabel"
+    | Labelled s -> Labelled s
+    | Optional s -> Optional s
+    | Nolabel -> failwith "invariant failed: Str_label called with Nolabel"
 
   let to_arg_label : t -> arg_label = function
-    | Labelled s ->
-        Labelled s
-    | Optional s ->
-        Optional s
+    | Labelled s -> Labelled s
+    | Optional s -> Optional s
 
   let str = function Labelled s -> s | Optional s -> s
 end
 
 let rec find_opt p = function
-  | [] ->
-      None
-  | x :: l ->
-      if p x then Some x else find_opt p l
+  | [] -> None
+  | x :: l -> if p x then Some x else find_opt p l
 
 let nolabel = Nolabel
-
 let labelled str = Labelled str
 
 let getLabel str =
@@ -62,10 +56,8 @@ let optionIdent = Lident "option"
 
 let isUnit expr =
   match expr.pexp_desc with
-  | Pexp_construct ({txt= Lident "()"; _}, _) ->
-      true
-  | _ ->
-      false
+  | Pexp_construct ({ txt = Lident "()"; _ }, _) -> true
+  | _ -> false
 
 let constantString ~loc str = Ast_helper.Exp.constant ~loc (Const.string str)
 
@@ -74,26 +66,25 @@ let safeTypeFromValue label =
   match String.sub str 0 1 with "_" -> "T" ^ str | _ -> str
 
 let keyType loc =
-  Typ.constr ~loc {loc; txt= optionIdent}
-    [Typ.constr ~loc {loc; txt= Lident "string"} []]
+  Typ.constr ~loc { loc; txt = optionIdent }
+    [ Typ.constr ~loc { loc; txt = Lident "string" } [] ]
 
 let refType loc = [%type: React.Dom.dom_ref]
 
-type componentConfig = {propsName: string}
+type componentConfig = { propsName : string }
 
 let extractChildren ?(removeLastPositionUnit = false) ~loc propsAndChildren =
   let rec allButLast_ lst acc =
     match lst with
-    | [] ->
-        []
-    | [(Nolabel, {pexp_desc= Pexp_construct ({txt= Lident "()"}, None)})] ->
+    | [] -> []
+    | [ (Nolabel, { pexp_desc = Pexp_construct ({ txt = Lident "()" }, None) })
+      ] ->
         acc
     | (Nolabel, _) :: _rest ->
         raise
           (Invalid_argument
-             "JSX: found non-labelled argument before the last position" )
-    | arg :: rest ->
-        allButLast_ rest (arg :: acc)
+             "JSX: found non-labelled argument before the last position")
+    | arg :: rest -> allButLast_ rest (arg :: acc)
   in
   let allButLast lst = allButLast_ lst [] |> List.rev in
   match
@@ -103,87 +94,91 @@ let extractChildren ?(removeLastPositionUnit = false) ~loc propsAndChildren =
   with
   | [], props ->
       (* no children provided? Place a placeholder list *)
-      ( Exp.construct ~loc {loc; txt= Lident "[]"} None
+      ( Exp.construct ~loc { loc; txt = Lident "[]" } None
       , if removeLastPositionUnit then allButLast props else props )
-  | [(_, childrenExpr)], props ->
+  | [ (_, childrenExpr) ], props ->
       (childrenExpr, if removeLastPositionUnit then allButLast props else props)
   | _ ->
       raise
         (Invalid_argument "JSX: somehow there's more than one `children` label")
 
 let unerasableIgnore loc =
-  { attr_name= {txt= "warning"; loc}
-  ; attr_payload= PStr [Str.eval (Exp.constant (Const.string "-16"))]
-  ; attr_loc= loc }
+  { attr_name = { txt = "warning"; loc }
+  ; attr_payload = PStr [ Str.eval (Exp.constant (Const.string "-16")) ]
+  ; attr_loc = loc
+  }
 
 (* [merlin_hide] tells merlin to not look at a node, or at any of its
    descendants. *)
 let merlin_hide =
-  { attr_name= {txt= "merlin.hide"; loc= Location.none}
-  ; attr_payload= PStr []
-  ; attr_loc= Location.none }
+  { attr_name = { txt = "merlin.hide"; loc = Location.none }
+  ; attr_payload = PStr []
+  ; attr_loc = Location.none
+  }
 
 (* Helper method to look up the [@react.component] attribute *)
-let hasAttr {attr_name; _} = attr_name.txt = "react.component"
+let hasAttr { attr_name; _ } = attr_name.txt = "react.component"
 
 (* Helper method to filter out any attribute that isn't [@react.component] *)
-let otherAttrsPure {attr_name; _} = attr_name.txt <> "react.component"
+let otherAttrsPure { attr_name; _ } = attr_name.txt <> "react.component"
 
 (* Iterate over the attributes and try to find the [@react.component] attribute *)
-let has_attr_on_binding {pvb_attributes} =
+let has_attr_on_binding { pvb_attributes } =
   find_opt hasAttr pvb_attributes <> None
 
 let used_attributes_tbl = Hashtbl.create 16
 
 let register_loc attr =
-  Ppxlib.Attribute.mark_as_handled_manually attr ;
+  Ppxlib.Attribute.mark_as_handled_manually attr;
   Hashtbl.replace used_attributes_tbl attr.attr_name.loc ()
 
 let filter_attr_name key attr =
-  if attr.attr_name.txt = key then (register_loc attr ; true) else false
+  if attr.attr_name.txt = key then (
+    register_loc attr;
+    true)
+  else false
 
 (* Finds the name of the variable the binding is assigned to, otherwise raises Invalid_argument *)
 let getFnName binding =
   match binding with
-  | {pvb_pat= {ppat_desc= Ppat_var {txt}}} ->
-      txt
+  | { pvb_pat = { ppat_desc = Ppat_var { txt } } } -> txt
   | _ ->
       raise (Invalid_argument "react.component calls cannot be destructured.")
 
 (* Lookup the value of `props` otherwise raise Invalid_argument error *)
 let getPropsNameValue _acc (loc, exp) =
   match (loc, exp) with
-  | {txt= Lident "props"}, {pexp_desc= Pexp_ident {txt= Lident str}} ->
-      {propsName= str}
-  | {txt}, _ ->
+  | { txt = Lident "props" }, { pexp_desc = Pexp_ident { txt = Lident str } } ->
+      { propsName = str }
+  | { txt }, _ ->
       raise
         (Invalid_argument
-           ( "react.component only accepts props as an option, given: "
-           ^ Longident.last_exn txt ) )
+           ("react.component only accepts props as an option, given: "
+          ^ Longident.last_exn txt))
 
 (* Lookup the `props` record or string as part of [@react.component] and store the name for use when rewriting *)
 let get_props_attr payload =
-  let default_props = {propsName= "Props"} in
+  let default_props = { propsName = "Props" } in
   match payload with
   | Some
       (PStr
-        ({ pstr_desc=
-             Pstr_eval ({pexp_desc= Pexp_record (recordFields, None)}, _) }
-        :: _rest ) ) ->
+        ({ pstr_desc =
+             Pstr_eval ({ pexp_desc = Pexp_record (recordFields, None) }, _)
+         }
+        :: _rest)) ->
       List.fold_left getPropsNameValue default_props recordFields
   | Some
       (PStr
-        ({ pstr_desc=
-             Pstr_eval ({pexp_desc= Pexp_ident {txt= Lident "props"}}, _) }
-        :: _rest ) ) ->
-      {propsName= "props"}
-  | Some (PStr ({pstr_desc= Pstr_eval (_, _)} :: _rest)) ->
+        ({ pstr_desc =
+             Pstr_eval ({ pexp_desc = Pexp_ident { txt = Lident "props" } }, _)
+         }
+        :: _rest)) ->
+      { propsName = "props" }
+  | Some (PStr ({ pstr_desc = Pstr_eval (_, _) } :: _rest)) ->
       raise
         (Invalid_argument
-           "react.component accepts a record config with props as an options."
-        )
-  | _ ->
-      default_props
+           "react.component accepts a record config with props as an options.")
+  | _ -> default_props
 
 (* Plucks the label, loc, and type_ from an AST node *)
 let pluckLabelDefaultLocType (label, default, _, _, loc, type_) =
@@ -206,11 +201,13 @@ let rec makeArgsForMakePropsType list args =
         | label, None, Some _ ->
             Typ.mk ~loc (Ptyp_var (safeTypeFromValue label))
         (* ~foo: int=1 *)
-        | _label, Some type_, Some _ ->
-            type_
+        | _label, Some type_, Some _ -> type_
         (* ~foo: option(int)=? *)
         | ( (Optional _ as _label)
-          , Some {ptyp_desc= Ptyp_constr ({txt= Lident "option"; _}, [type_]); _}
+          , Some
+              { ptyp_desc = Ptyp_constr ({ txt = Lident "option"; _ }, [ type_ ])
+              ; _
+              }
           , _ )
         (* ~foo: int=? - note this isnt valid. but we want to get a type error *)
         | (Optional _ as _label), Some type_, _ ->
@@ -219,36 +216,35 @@ let rec makeArgsForMakePropsType list args =
         | (Optional _ as label), None, _ ->
             Typ.mk ~loc (Ptyp_var (safeTypeFromValue label))
         (* ~foo *)
-        | label, None, _ ->
-            Typ.mk ~loc (Ptyp_var (safeTypeFromValue label))
-        | _label, Some type_, _ ->
-            type_
+        | label, None, _ -> Typ.mk ~loc (Ptyp_var (safeTypeFromValue label))
+        | _label, Some type_, _ -> type_
       in
       makeArgsForMakePropsType tl
         (Typ.arrow ~loc (to_arg_label label) coreType args)
-  | [] ->
-      args
+  | [] -> args
 
 let make_props_name fnName = fnName ^ "_props"
 
 (* Build an AST node for the props name when converted to a Js.t inside the function signature  *)
-let makePropsName ~loc name = Pat.mk ~loc (Ppat_var {txt= name; loc})
+let makePropsName ~loc name = Pat.mk ~loc (Ppat_var { txt = name; loc })
 
 let makeObjectField loc (label, _attrs, propType) =
   let type_ = [%type: [%t propType] Js_of_ocaml.Js.readonly_prop] in
-  { pof_desc=
-      Otag ({loc; txt= Str_label.str label}, {type_ with ptyp_attributes= []})
-  ; pof_loc= loc
-  ; pof_attributes= [] }
+  { pof_desc =
+      Otag
+        ({ loc; txt = Str_label.str label }, { type_ with ptyp_attributes = [] })
+  ; pof_loc = loc
+  ; pof_attributes = []
+  }
 
 (* Build an AST node representing a "closed" Js_of_ocaml.Js.t object representing a component's props *)
 let makePropsType ~loc namedTypeList =
   Typ.mk ~loc
     (Ptyp_constr
-       ( {txt= Ldot (Ldot (Lident "Js_of_ocaml", "Js"), "t"); loc}
+       ( { txt = Ldot (Ldot (Lident "Js_of_ocaml", "Js"), "t"); loc }
        , [ Typ.mk ~loc
              (Ptyp_object (List.map (makeObjectField loc) namedTypeList, Closed))
-         ] ) )
+         ] ))
 
 let rec make_funs_for_make_props_body list args =
   match list with
@@ -257,40 +253,29 @@ let rec make_funs_for_make_props_body list args =
         (Exp.fun_ ~loc
            (Str_label.to_arg_label label)
            None
-           { ppat_desc= Ppat_var {txt= Str_label.str label; loc}
-           ; ppat_loc= loc
-           ; ppat_attributes= []
-           ; ppat_loc_stack= [] }
-           args )
-  | [] ->
-      args
+           { ppat_desc = Ppat_var { txt = Str_label.str label; loc }
+           ; ppat_loc = loc
+           ; ppat_attributes = []
+           ; ppat_loc_stack = []
+           }
+           args)
+  | [] -> args
 
 let makeAttributeValue ~loc ~isOptional (type_ : Html.attributeType) value =
   match (type_, isOptional) with
   | String, true ->
       [%expr Option.map Js_of_ocaml.Js.string ([%e value] : string option)]
-  | String, false ->
-      [%expr Js_of_ocaml.Js.string ([%e value] : string)]
-  | Int, false ->
-      [%expr ([%e value] : int)]
-  | Int, true ->
-      [%expr ([%e value] : int option)]
-  | Float, false ->
-      [%expr ([%e value] : float)]
-  | Float, true ->
-      [%expr ([%e value] : float option)]
-  | Bool, false ->
-      [%expr ([%e value] : bool)]
-  | Bool, true ->
-      [%expr ([%e value] : bool option)]
-  | Style, false ->
-      [%expr ([%e value] : React.Dom.Style.t)]
-  | Style, true ->
-      [%expr ([%e value] : React.Dom.Style.t option)]
-  | Ref, false ->
-      [%expr ([%e value] : React.Dom.dom_ref)]
-  | Ref, true ->
-      [%expr ([%e value] : React.Dom.dom_ref option)]
+  | String, false -> [%expr Js_of_ocaml.Js.string ([%e value] : string)]
+  | Int, false -> [%expr ([%e value] : int)]
+  | Int, true -> [%expr ([%e value] : int option)]
+  | Float, false -> [%expr ([%e value] : float)]
+  | Float, true -> [%expr ([%e value] : float option)]
+  | Bool, false -> [%expr ([%e value] : bool)]
+  | Bool, true -> [%expr ([%e value] : bool option)]
+  | Style, false -> [%expr ([%e value] : React.Dom.Style.t)]
+  | Style, true -> [%expr ([%e value] : React.Dom.Style.t option)]
+  | Ref, false -> [%expr ([%e value] : React.Dom.dom_ref)]
+  | Ref, true -> [%expr ([%e value] : React.Dom.dom_ref option)]
   | InnerHtml, false ->
       [%expr ([%e value] : React.Dom.DangerouslySetInnerHTML.t)]
   | InnerHtml, true ->
@@ -298,89 +283,64 @@ let makeAttributeValue ~loc ~isOptional (type_ : Html.attributeType) value =
 
 let makeEventValue ~loc ~isOptional (type_ : Html.eventType) value =
   match (type_, isOptional) with
-  | Clipboard, false ->
-      [%expr ([%e value] : React.Event.Clipboard.t -> unit)]
+  | Clipboard, false -> [%expr ([%e value] : React.Event.Clipboard.t -> unit)]
   | Clipboard, true ->
       [%expr ([%e value] : (React.Event.Clipboard.t -> unit) option)]
   | Composition, false ->
       [%expr ([%e value] : React.Event.Composition.t -> unit)]
   | Composition, true ->
       [%expr ([%e value] : (React.Event.Composition.t -> unit) option)]
-  | Keyboard, false ->
-      [%expr ([%e value] : React.Event.Keyboard.t -> unit)]
+  | Keyboard, false -> [%expr ([%e value] : React.Event.Keyboard.t -> unit)]
   | Keyboard, true ->
       [%expr ([%e value] : (React.Event.Keyboard.t -> unit) option)]
-  | Focus, false ->
-      [%expr ([%e value] : React.Event.Focus.t -> unit)]
-  | Focus, true ->
-      [%expr ([%e value] : (React.Event.Focus.t -> unit) option)]
-  | Form, false ->
-      [%expr ([%e value] : React.Event.Form.t -> unit)]
-  | Form, true ->
-      [%expr ([%e value] : (React.Event.Form.t -> unit) option)]
-  | Mouse, false ->
-      [%expr ([%e value] : React.Event.Mouse.t -> unit)]
-  | Mouse, true ->
-      [%expr ([%e value] : (React.Event.Mouse.t -> unit) option)]
-  | Selection, false ->
-      [%expr ([%e value] : React.Event.Selection.t -> unit)]
+  | Focus, false -> [%expr ([%e value] : React.Event.Focus.t -> unit)]
+  | Focus, true -> [%expr ([%e value] : (React.Event.Focus.t -> unit) option)]
+  | Form, false -> [%expr ([%e value] : React.Event.Form.t -> unit)]
+  | Form, true -> [%expr ([%e value] : (React.Event.Form.t -> unit) option)]
+  | Mouse, false -> [%expr ([%e value] : React.Event.Mouse.t -> unit)]
+  | Mouse, true -> [%expr ([%e value] : (React.Event.Mouse.t -> unit) option)]
+  | Selection, false -> [%expr ([%e value] : React.Event.Selection.t -> unit)]
   | Selection, true ->
       [%expr ([%e value] : (React.Event.Selection.t -> unit) option)]
-  | Touch, false ->
-      [%expr ([%e value] : React.Event.Touch.t -> unit)]
-  | Touch, true ->
-      [%expr ([%e value] : (React.Event.Touch.t -> unit) option)]
-  | UI, false ->
-      [%expr ([%e value] : React.Event.UI.t -> unit)]
-  | UI, true ->
-      [%expr ([%e value] : (React.Event.UI.t -> unit) option)]
-  | Wheel, false ->
-      [%expr ([%e value] : React.Event.Wheel.t -> unit)]
-  | Wheel, true ->
-      [%expr ([%e value] : (React.Event.Wheel.t -> unit) option)]
-  | Media, false ->
-      [%expr ([%e value] : React.Event.Media.t -> unit)]
-  | Media, true ->
-      [%expr ([%e value] : (React.Event.Media.t -> unit) option)]
-  | Image, false ->
-      [%expr ([%e value] : React.Event.Image.t -> unit)]
-  | Image, true ->
-      [%expr ([%e value] : (React.Event.Image.t -> unit) option)]
-  | Animation, false ->
-      [%expr ([%e value] : React.Event.Animation.t -> unit)]
+  | Touch, false -> [%expr ([%e value] : React.Event.Touch.t -> unit)]
+  | Touch, true -> [%expr ([%e value] : (React.Event.Touch.t -> unit) option)]
+  | UI, false -> [%expr ([%e value] : React.Event.UI.t -> unit)]
+  | UI, true -> [%expr ([%e value] : (React.Event.UI.t -> unit) option)]
+  | Wheel, false -> [%expr ([%e value] : React.Event.Wheel.t -> unit)]
+  | Wheel, true -> [%expr ([%e value] : (React.Event.Wheel.t -> unit) option)]
+  | Media, false -> [%expr ([%e value] : React.Event.Media.t -> unit)]
+  | Media, true -> [%expr ([%e value] : (React.Event.Media.t -> unit) option)]
+  | Image, false -> [%expr ([%e value] : React.Event.Image.t -> unit)]
+  | Image, true -> [%expr ([%e value] : (React.Event.Image.t -> unit) option)]
+  | Animation, false -> [%expr ([%e value] : React.Event.Animation.t -> unit)]
   | Animation, true ->
       [%expr ([%e value] : (React.Event.Animation.t -> unit) option)]
-  | Transition, false ->
-      [%expr ([%e value] : React.Event.Transition.t -> unit)]
+  | Transition, false -> [%expr ([%e value] : React.Event.Transition.t -> unit)]
   | Transition, true ->
       [%expr ([%e value] : (React.Event.Transition.t -> unit) option)]
-  | Pointer, false ->
-      [%expr ([%e value] : React.Event.Syntetic.t -> unit)]
+  | Pointer, false -> [%expr ([%e value] : React.Event.Syntetic.t -> unit)]
   | Pointer, true ->
       [%expr ([%e value] : (React.Event.Syntetic.t -> unit) option)]
-  | Drag, false ->
-      [%expr ([%e value] : React.Event.Syntetic.t -> unit)]
-  | Drag, true ->
-      [%expr ([%e value] : (React.Event.Syntetic.t -> unit) option)]
+  | Drag, false -> [%expr ([%e value] : React.Event.Syntetic.t -> unit)]
+  | Drag, true -> [%expr ([%e value] : (React.Event.Syntetic.t -> unit) option)]
 
 let makeValue ~loc ~isOptional prop value =
   match prop with
   | Html.Attribute attribute ->
       makeAttributeValue ~loc ~isOptional attribute.type_ value
-  | Html.Event event ->
-      makeEventValue ~loc ~isOptional event.type_ value
+  | Html.Event event -> makeEventValue ~loc ~isOptional event.type_ value
 
 let make_js_props_obj ~loc named_arg_list_with_key_and_ref =
   let label_to_tuple label =
     let label_str = Str_label.str label in
-    let id = Exp.ident ~loc {txt= Lident label_str; loc} in
+    let id = Exp.ident ~loc { txt = Lident label_str; loc } in
     match label_str with
     | "key" ->
         [%expr
           [%e Exp.constant ~loc (Const.string label_str)]
           , inject
               (Js_of_ocaml.Js.Optdef.option
-                 (Option.map Js_of_ocaml.Js.string [%e id]) )]
+                 (Option.map Js_of_ocaml.Js.string [%e id]))]
     | "ref" ->
         [%expr
           [%e Exp.constant ~loc (Const.string label_str)]
@@ -394,29 +354,27 @@ let make_js_props_obj ~loc named_arg_list_with_key_and_ref =
         Exp.array ~loc
           (List.map
              (fun (label, _, _, _) -> label_to_tuple label)
-             named_arg_list_with_key_and_ref )]]
+             named_arg_list_with_key_and_ref)]]
 
 let rec get_wrap_fn_for_type ~loc typ =
   match typ with
   | Some [%type: React.element list] ->
       Some [%expr fun v -> Js_of_ocaml.Js.array (Array.of_list v)]
-  | Some [%type: string] ->
-      Some [%expr Js_of_ocaml.Js.string]
-  | Some [%type: bool] ->
-      Some [%expr Js_of_ocaml.Js.bool]
+  | Some [%type: string] -> Some [%expr Js_of_ocaml.Js.string]
+  | Some [%type: bool] -> Some [%expr Js_of_ocaml.Js.bool]
   | Some [%type: [%t? inner_typ] array] ->
       Some
-        ( match get_wrap_fn_for_type ~loc (Some inner_typ) with
+        (match get_wrap_fn_for_type ~loc (Some inner_typ) with
         | Some inner_wrapf ->
             [%expr fun v -> Js_of_ocaml.Js.array (Array.map [%e inner_wrapf] v)]
-        | None ->
-            [%expr Js_of_ocaml.Js.array] )
-  | _ ->
-      None
+        | None -> [%expr Js_of_ocaml.Js.array])
+  | _ -> None
 
 let make_external_js_props_obj ~loc named_arg_list =
   let label_to_tuple label typ =
-    let label_ident = Exp.ident ~loc {txt= Lident (Str_label.str label); loc} in
+    let label_ident =
+      Exp.ident ~loc { txt = Lident (Str_label.str label); loc }
+    in
     let maybe_wrap_fn = get_wrap_fn_for_type ~loc typ in
     match (label, maybe_wrap_fn) with
     | Labelled l, Some wrapf ->
@@ -430,7 +388,7 @@ let make_external_js_props_obj ~loc named_arg_list =
           [%e Exp.constant ~loc (Const.string l)]
           , inject
               (Js_of_ocaml.Js.Optdef.option
-                 (Option.map [%e wrapf] [%e label_ident]) )]
+                 (Option.map [%e wrapf] [%e label_ident]))]
     | Optional l, None ->
         [%expr
           [%e Exp.constant ~loc (Const.string l)]
@@ -442,7 +400,7 @@ let make_external_js_props_obj ~loc named_arg_list =
         Exp.array ~loc
           (List.map
              (fun (label, _, _, typ) -> label_to_tuple label typ)
-             named_arg_list )]]
+             named_arg_list)]]
 
 (* Builds the function that takes labelled arguments and generates a JS object *)
 let make_make_props js_props_obj fn_name loc named_arg_list props_type rest =
@@ -453,14 +411,15 @@ let make_make_props js_props_obj fn_name loc named_arg_list props_type rest =
   Exp.mk ~loc
     (Pexp_let
        ( Nonrecursive
-       , [ Vb.mk ~loc ~attrs:[merlin_hide]
+       , [ Vb.mk ~loc ~attrs:[ merlin_hide ]
              (Pat.mk ~loc
                 (Ppat_constraint
                    ( makePropsName ~loc (make_props_name fn_name)
-                   , { ptyp_desc= Ptyp_poly ([], core_type)
-                     ; ptyp_loc= loc
-                     ; ptyp_attributes= []
-                     ; ptyp_loc_stack= [] } ) ) )
+                   , { ptyp_desc = Ptyp_poly ([], core_type)
+                     ; ptyp_loc = loc
+                     ; ptyp_attributes = []
+                     ; ptyp_loc_stack = []
+                     } )))
              (Exp.mk ~loc
                 (Pexp_constraint
                    ( make_funs_for_make_props_body named_arg_list
@@ -468,8 +427,9 @@ let make_make_props js_props_obj fn_name loc named_arg_list props_type rest =
                          fun () ->
                            let open Js_of_ocaml.Js.Unsafe in
                            [%e js_props_obj]]
-                   , core_type ) ) ) ]
-       , rest ) )
+                   , core_type )))
+         ]
+       , rest ))
 
 let rec recursivelyTransformNamedArgsForMake mapper expr list =
   let expr = mapper#expression expr in
@@ -488,140 +448,148 @@ let rec recursivelyTransformNamedArgsForMake mapper expr list =
     ->
       let () =
         match (arg, pattern, default) with
-        | Optional _, {ppat_desc= Ppat_constraint (_, {ptyp_desc})}, None -> (
-          match ptyp_desc with
-          | Ptyp_constr ({txt= Lident "option"}, [_]) ->
-              ()
-          | _ ->
-              let currentType =
-                match ptyp_desc with
-                | Ptyp_constr ({txt}, []) ->
-                    String.concat "." (Longident.flatten_exn txt)
-                | Ptyp_constr ({txt}, _innerTypeArgs) ->
-                    String.concat "." (Longident.flatten_exn txt) ^ "(...)"
-                | _ ->
-                    "..."
-              in
-              Location.raise_errorf ~loc:pattern.ppat_loc
-                "jsoo-react: optional argument annotations must have explicit \
-                 `option`. Did you mean `option(%s)=?`?"
-                currentType )
-        | _ ->
-            ()
+        | Optional _, { ppat_desc = Ppat_constraint (_, { ptyp_desc }) }, None
+          -> (
+            match ptyp_desc with
+            | Ptyp_constr ({ txt = Lident "option" }, [ _ ]) -> ()
+            | _ ->
+                let currentType =
+                  match ptyp_desc with
+                  | Ptyp_constr ({ txt }, []) ->
+                      String.concat "." (Longident.flatten_exn txt)
+                  | Ptyp_constr ({ txt }, _innerTypeArgs) ->
+                      String.concat "." (Longident.flatten_exn txt) ^ "(...)"
+                  | _ -> "..."
+                in
+                Location.raise_errorf ~loc:pattern.ppat_loc
+                  "jsoo-react: optional argument annotations must have \
+                   explicit `option`. Did you mean `option(%s)=?`?"
+                  currentType)
+        | _ -> ()
       in
       let alias =
         match pattern with
-        | {ppat_desc= Ppat_alias (_, {txt}) | Ppat_var {txt}} ->
-            txt
-        | {ppat_desc= Ppat_any} ->
-            "_"
-        | _ ->
-            label
+        | { ppat_desc = Ppat_alias (_, { txt }) | Ppat_var { txt } } -> txt
+        | { ppat_desc = Ppat_any } -> "_"
+        | _ -> label
       in
       let type_ =
         match pattern with
-        | {ppat_desc= Ppat_constraint (_, type_)} ->
-            Some type_
-        | _ ->
-            None
+        | { ppat_desc = Ppat_constraint (_, type_) } -> Some type_
+        | _ -> None
       in
       recursivelyTransformNamedArgsForMake mapper expression
-        ( ( Str_label.of_arg_label arg
-          , default
-          , pattern
-          , alias
-          , pattern.ppat_loc
-          , type_ )
-        :: list )
+        (( Str_label.of_arg_label arg
+         , default
+         , pattern
+         , alias
+         , pattern.ppat_loc
+         , type_ )
+        :: list)
   | Pexp_fun
       ( Nolabel
       , _
-      , {ppat_desc= Ppat_construct ({txt= Lident "()"}, _) | Ppat_any}
+      , { ppat_desc = Ppat_construct ({ txt = Lident "()" }, _) | Ppat_any }
       , _expression ) ->
       (list, None)
   | Pexp_fun
       ( Nolabel
       , _
-      , { ppat_desc=
-            Ppat_var {txt} | Ppat_constraint ({ppat_desc= Ppat_var {txt}}, _) }
+      , { ppat_desc =
+            ( Ppat_var { txt }
+            | Ppat_constraint ({ ppat_desc = Ppat_var { txt } }, _) )
+        }
       , _expression ) ->
       (list, Some txt)
   | Pexp_fun (Nolabel, _, pattern, _expression) ->
       Location.raise_errorf ~loc:pattern.ppat_loc
         "jsoo-react: react.component refs only support plain arguments and \
          type annotations."
-  | _ ->
-      (list, None)
+  | _ -> (list, None)
 
 let arg_to_concrete_type types (arg, loc, type_) =
   match arg with
-  | Str_label.Labelled _ ->
-      (arg, [], type_) :: types
+  | Str_label.Labelled _ -> (arg, [], type_) :: types
   | Optional _ ->
-      (arg, [], Typ.constr ~loc {loc; txt= optionIdent} [type_]) :: types
+      (arg, [], Typ.constr ~loc { loc; txt = optionIdent } [ type_ ]) :: types
 
 let argToType types (name, default, _noLabelName, _alias, loc, type_) =
   let open Str_label in
   match (type_, name, default) with
-  | ( Some {ptyp_desc= Ptyp_constr ({txt= Lident "option"}, [type_])}
+  | ( Some { ptyp_desc = Ptyp_constr ({ txt = Lident "option" }, [ type_ ]) }
     , (Optional _ as name)
     , _ ) ->
       ( name
       , []
       , { type_ with
-          ptyp_desc=
-            Ptyp_constr ({loc= type_.ptyp_loc; txt= optionIdent}, [type_]) } )
+          ptyp_desc =
+            Ptyp_constr ({ loc = type_.ptyp_loc; txt = optionIdent }, [ type_ ])
+        } )
       :: types
   | Some type_, name, Some _default ->
       ( name
       , []
-      , { ptyp_desc= Ptyp_constr ({loc; txt= optionIdent}, [type_])
-        ; ptyp_loc= loc
-        ; ptyp_attributes= []
-        ; ptyp_loc_stack= [] } )
+      , { ptyp_desc = Ptyp_constr ({ loc; txt = optionIdent }, [ type_ ])
+        ; ptyp_loc = loc
+        ; ptyp_attributes = []
+        ; ptyp_loc_stack = []
+        } )
       :: types
-  | Some type_, name, _ ->
-      (name, [], type_) :: types
+  | Some type_, name, _ -> (name, [], type_) :: types
   | None, (Optional _ as name), _ ->
       ( name
       , []
-      , { ptyp_desc=
+      , { ptyp_desc =
             Ptyp_constr
-              ( {loc; txt= optionIdent}
-              , [ { ptyp_desc= Ptyp_var (safeTypeFromValue name)
-                  ; ptyp_loc= loc
-                  ; ptyp_attributes= []
-                  ; ptyp_loc_stack= [] } ] )
-        ; ptyp_loc= loc
-        ; ptyp_attributes= []
-        ; ptyp_loc_stack= [] } )
+              ( { loc; txt = optionIdent }
+              , [ { ptyp_desc = Ptyp_var (safeTypeFromValue name)
+                  ; ptyp_loc = loc
+                  ; ptyp_attributes = []
+                  ; ptyp_loc_stack = []
+                  }
+                ] )
+        ; ptyp_loc = loc
+        ; ptyp_attributes = []
+        ; ptyp_loc_stack = []
+        } )
       :: types
   | None, (Labelled _ as name), _ ->
       ( name
       , []
-      , { ptyp_desc= Ptyp_var (safeTypeFromValue name)
-        ; ptyp_loc= loc
-        ; ptyp_attributes= []
-        ; ptyp_loc_stack= [] } )
+      , { ptyp_desc = Ptyp_var (safeTypeFromValue name)
+        ; ptyp_loc = loc
+        ; ptyp_attributes = []
+        ; ptyp_loc_stack = []
+        } )
       :: types
 
 (* Builds the function that will be passed as first param to React.create_element *)
-let make_js_comp ~loc ~fn_name ~forward_ref ~has_unit ~named_arg_list
-    ~named_type_list ~payload ~wrap rest =
+let make_js_comp
+    ~loc
+    ~fn_name
+    ~forward_ref
+    ~has_unit
+    ~named_arg_list
+    ~named_type_list
+    ~payload
+    ~wrap
+    rest =
   let props = get_props_attr payload in
   let pluck_arg (label, _, _, _, loc, _) =
     let label_str = Str_label.str label in
-    let props_name_id = Exp.ident ~loc {txt= Lident props.propsName; loc} in
+    let props_name_id = Exp.ident ~loc { txt = Lident props.propsName; loc } in
     let label_const = Exp.constant ~loc (Const.string label_str) in
     let send =
-      Exp.send ~loc (Exp.ident ~loc {txt= Lident "x"; loc}) {txt= label_str; loc}
+      Exp.send ~loc
+        (Exp.ident ~loc { txt = Lident "x"; loc })
+        { txt = label_str; loc }
     in
     (* https://github.com/ocsigen/js_of_ocaml/blob/b1c807eaa40fa17b04c7d8e7e24306a03a46681d/ppx/ppx_js/lib_internal/ppx_js_internal.ml#L322-L332 *)
     let expr =
       [%expr
         (fun (type res a0) (a0 : a0 Js_of_ocaml.Js.t)
-             (_ : a0 -> < get: res ; .. > Js_of_ocaml.Js.gen_prop) : res ->
-          Js_of_ocaml.Js.Unsafe.get a0 [%e label_const] )
+             (_ : a0 -> < get : res ; .. > Js_of_ocaml.Js.gen_prop) : res ->
+          Js_of_ocaml.Js.Unsafe.get a0 [%e label_const])
           ([%e props_name_id] : < .. > Js_of_ocaml.Js.t)
           (fun x -> [%e send])]
     in
@@ -629,60 +597,63 @@ let make_js_comp ~loc ~fn_name ~forward_ref ~has_unit ~named_arg_list
   in
   let args =
     List.map pluck_arg named_arg_list
-    @ ( match forward_ref with
-      | Some txt ->
-          [(Nolabel, Exp.ident ~loc {txt= Lident txt; loc})]
-      | None ->
-          [] )
+    @ (match forward_ref with
+      | Some txt -> [ (Nolabel, Exp.ident ~loc { txt = Lident txt; loc }) ]
+      | None -> [])
     @
-    if has_unit then [(Nolabel, Exp.construct {loc; txt= Lident "()"} None)]
+    if has_unit then
+      [ (Nolabel, Exp.construct { loc; txt = Lident "()" } None) ]
     else []
   in
-  let inner_expr = Exp.apply (Exp.ident {loc; txt= Lident fn_name}) args in
+  let inner_expr = Exp.apply (Exp.ident { loc; txt = Lident fn_name }) args in
   let inner_expr_with_ref =
     match forward_ref with
     | Some txt ->
         { inner_expr with
-          pexp_desc=
+          pexp_desc =
             Pexp_fun
               ( nolabel
               , None
-              , { ppat_desc= Ppat_var {txt; loc}
-                ; ppat_loc= loc
-                ; ppat_attributes= []
-                ; ppat_loc_stack= [] }
-              , inner_expr ) }
-    | None ->
-        inner_expr
+              , { ppat_desc = Ppat_var { txt; loc }
+                ; ppat_loc = loc
+                ; ppat_attributes = []
+                ; ppat_loc_stack = []
+                }
+              , inner_expr )
+        }
+    | None -> inner_expr
   in
-  Exp.mk ~loc ~attrs:[merlin_hide]
+  Exp.mk ~loc ~attrs:[ merlin_hide ]
     (Pexp_let
        ( Nonrecursive
        , [ Vb.mk
-             (Pat.var {loc; txt= fn_name})
+             (Pat.var { loc; txt = fn_name })
              (wrap
                 (Exp.fun_ nolabel None
-                   { ppat_desc=
+                   { ppat_desc =
                        Ppat_constraint
                          ( makePropsName ~loc props.propsName
                          , makePropsType ~loc named_type_list )
-                   ; ppat_loc= loc
-                   ; ppat_attributes= []
-                   ; ppat_loc_stack= [] }
-                   inner_expr_with_ref ) ) ]
-       , rest ) )
+                   ; ppat_loc = loc
+                   ; ppat_attributes = []
+                   ; ppat_loc_stack = []
+                   }
+                   inner_expr_with_ref))
+         ]
+       , rest ))
 
 (* Builds the intermediate function with labelled arguments that will call make_props.
    [body] is the the component implementation as originally written in source,
    but without any wrappers like React.memo or forward_ref *)
 let make_ml_comp ~loc ~fn_name ~body rest =
   Exp.mk ~loc
-    (Pexp_let (Nonrecursive, [Vb.mk (Pat.var {loc; txt= fn_name}) body], rest))
+    (Pexp_let
+       (Nonrecursive, [ Vb.mk (Pat.var { loc; txt = fn_name }) body ], rest))
 
 (* This function takes any value binding and checks if it should be processed
    in case [react.component] attr is found, or if [inside_component] is passed. *)
 let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
-  let gloc = {pstr_loc with loc_ghost= true} in
+  let gloc = { pstr_loc with loc_ghost = true } in
   if has_attr_on_binding binding || inside_component then
     let binding_loc = binding.pvb_loc in
     let binding_pat_loc = binding.pvb_pat.ppat_loc in
@@ -693,23 +664,22 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
       let rec spelunk_for_fun_expr expression =
         match expression with
         (* let make = (~prop) => ... *)
-        | {pexp_desc= Pexp_fun _} ->
-            expression
+        | { pexp_desc = Pexp_fun _ } -> expression
         (* let make = {let foo = bar in (~prop) => ...} *)
-        | {pexp_desc= Pexp_let (_recursive, _vbs, return_expr)} ->
+        | { pexp_desc = Pexp_let (_recursive, _vbs, return_expr) } ->
             (* here's where we spelunk! *)
             spelunk_for_fun_expr return_expr
         (* let make = React.forward_ref((~prop) => ...) or
            let make = React.memo(~compare, (~prop) => ...) *)
-        | { pexp_desc=
+        | { pexp_desc =
               Pexp_apply
                 ( _wrapper_expr
-                , ( [(Nolabel, inner_fun_expr)]
-                  | [(Labelled "compare", _); (Nolabel, inner_fun_expr)]
-                  | [(Nolabel, inner_fun_expr); (Labelled "compare", _)] ) ) }
-          ->
+                , ( [ (Nolabel, inner_fun_expr) ]
+                  | [ (Labelled "compare", _); (Nolabel, inner_fun_expr) ]
+                  | [ (Nolabel, inner_fun_expr); (Labelled "compare", _) ] ) )
+          } ->
             spelunk_for_fun_expr inner_fun_expr
-        | {pexp_desc= Pexp_sequence (_wrapper_expr, inner_fun_expr)} ->
+        | { pexp_desc = Pexp_sequence (_wrapper_expr, inner_fun_expr) } ->
             spelunk_for_fun_expr inner_fun_expr
         | exp ->
             Location.raise_errorf ~loc:exp.pexp_loc
@@ -726,7 +696,7 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
     let named_arg_list_with_key_and_ref =
       ( Str_label.Optional "key"
       , None
-      , Pat.var {txt= "key"; loc= gloc}
+      , Pat.var { txt = "key"; loc = gloc }
       , "key"
       , gloc
       , Some (keyType gloc) )
@@ -737,76 +707,84 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
       | Some _ ->
           ( Str_label.Optional "ref"
           , None
-          , Pat.var {txt= "ref"; loc= gloc}
+          , Pat.var { txt = "ref"; loc = gloc }
           , "ref"
           , gloc
           , Some (refType gloc) )
           :: named_arg_list_with_key_and_ref
-      | None ->
-          named_arg_list_with_key_and_ref
+      | None -> named_arg_list_with_key_and_ref
     in
     let modified_binding binding =
       let has_application = ref false in
       let expression = binding.pvb_expr in
       let unerasable_ignore_exp exp =
-        {exp with pexp_attributes= unerasableIgnore gloc :: exp.pexp_attributes}
+        { exp with
+          pexp_attributes = unerasableIgnore gloc :: exp.pexp_attributes
+        }
       in
       (* TODO: there is a long-tail of unsupported features inside of blocks - Pexp_letmodule , Pexp_letexception , Pexp_ifthenelse *)
       let rec spelunk_for_fun_expr expression =
         match expression with
         (* let make = (~prop) => ... with no final unit *)
-        | { pexp_desc=
+        | { pexp_desc =
               Pexp_fun
                 ( ((Labelled _ | Optional _) as label)
                 , default
                 , pattern
-                , ({pexp_desc= Pexp_fun _} as internalExpression) ) } ->
+                , ({ pexp_desc = Pexp_fun _ } as internalExpression) )
+          } ->
             let wrap, has_unit, exp = spelunk_for_fun_expr internalExpression in
             ( wrap
             , has_unit
             , unerasable_ignore_exp
                 { expression with
-                  pexp_desc= Pexp_fun (label, default, pattern, exp) } )
+                  pexp_desc = Pexp_fun (label, default, pattern, exp)
+                } )
         (* let make = (()) => ... *)
         (* let make = (_) => ... *)
-        | { pexp_desc=
+        | { pexp_desc =
               Pexp_fun
                 ( Nolabel
                 , default
-                , ( { ppat_desc=
-                        Ppat_construct ({txt= Lident "()"}, _) | Ppat_any } as
-                  pattern )
-                , internalExpression ) } ->
+                , ({ ppat_desc =
+                       Ppat_construct ({ txt = Lident "()" }, _) | Ppat_any
+                   } as pattern)
+                , internalExpression )
+          } ->
             let loc = expression.pexp_loc in
             ( (fun a -> a)
             , true
             , { expression with
-                pexp_desc=
+                pexp_desc =
                   Pexp_fun
                     ( Nolabel
                     , default
                     , pattern
-                    , [%expr ([%e internalExpression] : React.element)] ) } )
+                    , [%expr ([%e internalExpression] : React.element)] )
+              } )
         (* let make = (~prop) => ... *)
-        | { pexp_desc=
+        | { pexp_desc =
               Pexp_fun
                 ( ((Labelled _ | Optional _) as label)
                 , default
                 , pattern
-                , internalExpression ) } ->
+                , internalExpression )
+          } ->
             let loc = expression.pexp_loc in
             ( (fun a -> a)
             , false
             , { (unerasable_ignore_exp expression) with
-                pexp_desc=
+                pexp_desc =
                   Pexp_fun
                     ( label
                     , default
                     , pattern
-                    , [%expr ([%e internalExpression] : React.element)] ) } )
+                    , [%expr ([%e internalExpression] : React.element)] )
+              } )
         (* let make = (prop) => ... *)
-        | { pexp_desc=
-              Pexp_fun (_nolabel, _default, pattern, _internalExpression) } ->
+        | { pexp_desc =
+              Pexp_fun (_nolabel, _default, pattern, _internalExpression)
+          } ->
             if has_application.contents then
               ((fun a -> a), false, unerasable_ignore_exp expression)
             else
@@ -817,38 +795,45 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
                 \  If your component doesn't have any props use () or _ \
                  instead of a name."
         (* let make = {let foo = bar in (~prop) => ...} *)
-        | {pexp_desc= Pexp_let (recursive, vbs, internalExpression)} ->
+        | { pexp_desc = Pexp_let (recursive, vbs, internalExpression) } ->
             (* here's where we spelunk! *)
             let wrap, has_unit, exp = spelunk_for_fun_expr internalExpression in
             ( wrap
             , has_unit
-            , {expression with pexp_desc= Pexp_let (recursive, vbs, exp)} )
+            , { expression with pexp_desc = Pexp_let (recursive, vbs, exp) } )
         (* let make = React.forward_ref((~prop) => ...) *)
-        | {pexp_desc= Pexp_apply (wrapper_expr, [(Nolabel, internalExpression)])}
-          ->
+        | { pexp_desc =
+              Pexp_apply (wrapper_expr, [ (Nolabel, internalExpression) ])
+          } ->
             let () = has_application := true in
             let _, has_unit, exp = spelunk_for_fun_expr internalExpression in
-            ((fun exp -> Exp.apply wrapper_expr [(nolabel, exp)]), has_unit, exp)
+            ( (fun exp -> Exp.apply wrapper_expr [ (nolabel, exp) ])
+            , has_unit
+            , exp )
         (* let make = React.memo(~compare, (~prop) => ...) *)
-        | { pexp_desc=
+        | { pexp_desc =
               Pexp_apply
                 ( wrapper_expr
                 , ( [ (Nolabel, internalExpression)
-                    ; ((Labelled "compare", _) as compareProps) ]
+                    ; ((Labelled "compare", _) as compareProps)
+                    ]
                   | [ ((Labelled "compare", _) as compareProps)
-                    ; (Nolabel, internalExpression) ] ) ) } ->
+                    ; (Nolabel, internalExpression)
+                    ] ) )
+          } ->
             let () = has_application := true in
             let _, has_unit, exp = spelunk_for_fun_expr internalExpression in
-            ( (fun exp -> Exp.apply wrapper_expr [(nolabel, exp); compareProps])
+            ( (fun exp ->
+                Exp.apply wrapper_expr [ (nolabel, exp); compareProps ])
             , has_unit
             , exp )
-        | {pexp_desc= Pexp_sequence (wrapper_expr, internalExpression)} ->
+        | { pexp_desc = Pexp_sequence (wrapper_expr, internalExpression) } ->
             let wrap, has_unit, exp = spelunk_for_fun_expr internalExpression in
             ( wrap
             , has_unit
-            , {expression with pexp_desc= Pexp_sequence (wrapper_expr, exp)} )
-        | e ->
-            ((fun a -> a), false, e)
+            , { expression with pexp_desc = Pexp_sequence (wrapper_expr, exp) }
+            )
+        | e -> ((fun a -> a), false, e)
       in
       let wrap, has_unit, expression = spelunk_for_fun_expr expression in
       (wrap, has_unit, expression)
@@ -860,10 +845,8 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
     in
     let payload =
       match react_component_attr with
-      | Some {attr_payload} ->
-          Some attr_payload
-      | None ->
-          None
+      | Some { attr_payload } -> Some attr_payload
+      | None -> None
     in
     let named_type_list = List.fold_left argToType [] named_arg_list in
     let ml_comp = make_ml_comp ~loc:pstr_loc ~fn_name ~body:ml_comp_body in
@@ -881,7 +864,7 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
     let outer_make expression =
       Vb.mk ~loc:binding_loc
         ~attrs:(List.filter otherAttrsPure binding.pvb_attributes)
-        (Pat.var ~loc:binding_pat_loc {loc= binding_pat_loc; txt= fn_name})
+        (Pat.var ~loc:binding_pat_loc { loc = binding_pat_loc; txt = fn_name })
         (let outer =
            make_funs_for_make_props_body
              (List.map pluckLabelDefaultLocType named_arg_list_with_key_and_ref)
@@ -892,26 +875,28 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
                     [%e
                       Exp.apply ~loc
                         (Exp.ident ~loc
-                           {loc; txt= Lident (make_props_name fn_name)} )
-                        ( List.map
-                            (fun ( arg
-                                 , _default
-                                 , _pattern
-                                 , _alias
-                                 , _pattern_loc
-                                 , _type ) ->
-                              ( Str_label.to_arg_label arg
-                              , Exp.ident ~loc:gloc
-                                  {loc= gloc; txt= Lident (Str_label.str arg)}
-                              ) )
-                            named_arg_list_with_key_and_ref
-                        @ [(Nolabel, Exp.construct {loc; txt= Lident "()"} None)]
-                        )]] )
+                           { loc; txt = Lident (make_props_name fn_name) })
+                        (List.map
+                           (fun ( arg
+                                , _default
+                                , _pattern
+                                , _alias
+                                , _pattern_loc
+                                , _type ) ->
+                             ( Str_label.to_arg_label arg
+                             , Exp.ident ~loc:gloc
+                                 { loc = gloc
+                                 ; txt = Lident (Str_label.str arg)
+                                 } ))
+                           named_arg_list_with_key_and_ref
+                        @ [ ( Nolabel
+                            , Exp.construct { loc; txt = Lident "()" } None )
+                          ])]])
          in
-         make_props @@ ml_comp @@ js_comp @@ outer )
+         make_props @@ ml_comp @@ js_comp @@ outer)
     in
     let inner_make_ident =
-      Exp.ident ~loc:gloc {loc= gloc; txt= Lident fn_name}
+      Exp.ident ~loc:gloc { loc = gloc; txt = Lident fn_name }
     in
     outer_make inner_make_ident
   else binding
@@ -927,34 +912,28 @@ let uppercase_element_args ~loc callArguments =
   in
   let filtered_children =
     match children with
-    | [%expr []] ->
-        []
-    | children ->
-        [(labelled "children", children)]
+    | [%expr []] -> []
+    | children -> [ (labelled "children", children) ]
   in
   ( children
   , recursivelyTransformedArgsForMake @ filtered_children
-    @ [(nolabel, Exp.construct ~loc {loc; txt= Lident "()"} None)] )
+    @ [ (nolabel, Exp.construct ~loc { loc; txt = Lident "()" } None) ] )
 
 (* TODO: some line number might still be wrong *)
 let jsxMapper () =
   let transformLowercaseCall loc attrs callArguments id callLoc =
     let children, nonChildrenProps = extractChildren ~loc callArguments in
-    let componentNameExpr = Exp.ident {loc; txt= Lident id} in
+    let componentNameExpr = Exp.ident { loc; txt = Lident id } in
     let args =
       (* Filtering out last unit *)
       let labeled_arg (name, value) =
         match isUnit value with
-        | true ->
-            None
+        | true -> None
         | false -> (
-          match name with
-          | Optional str ->
-              Some (Str_label.Optional str, value)
-          | Labelled str ->
-              Some (Str_label.Labelled str, value)
-          | Nolabel ->
-              None )
+            match name with
+            | Optional str -> Some (Str_label.Optional str, value)
+            | Labelled str -> Some (Str_label.Labelled str, value)
+            | Nolabel -> None)
       in
       let labeledProps = List.filter_map labeled_arg nonChildrenProps in
       let makePropField (str_label, value) =
@@ -963,218 +942,236 @@ let jsxMapper () =
         | Str_label.Optional str ->
             [%expr
               maybe
-                [%e Exp.ident {loc; txt= Ldot (Lident "Prop", str)}]
+                [%e Exp.ident { loc; txt = Ldot (Lident "Prop", str) }]
                 [%e value]]
         | Labelled str ->
             [%expr
-              [%e Exp.ident {loc; txt= Ldot (Lident "Prop", str)}] [%e value]]
+              [%e Exp.ident { loc; txt = Ldot (Lident "Prop", str) }] [%e value]]
       in
       let propsArray = Exp.array ~loc (List.map makePropField labeledProps) in
       [ (* [| href "..."; target "_blank" |] *)
         (nolabel, propsArray)
-      ; (nolabel, children) ]
+      ; (nolabel, children)
+      ]
     in
     Exp.apply
       ~loc (* throw away the [@JSX] attribute and keep the others, if any *)
       ~attrs (* "div", "p" or the component name *) componentNameExpr args
   in
   let nestedModules = ref [] in
-  let rec transformComponentDefinition ?(inside_component = false) mapper
-      structure returnStructures =
+  let rec transformComponentDefinition
+      ?(inside_component = false)
+      mapper
+      structure
+      returnStructures =
     match structure with
     (* external *)
     | { pstr_loc
-      ; pstr_desc=
+      ; pstr_desc =
           Pstr_primitive
             { pval_loc
-            ; pval_name= {txt= fn_name}
+            ; pval_name = { txt = fn_name }
             ; pval_attributes
             ; pval_type
-            ; pval_prim } } -> (
-      match (inside_component, List.partition hasAttr pval_attributes) with
-      | false, ([], _) ->
-          structure :: returnStructures
-      | true, (_, rest_attrs) | _, (_ :: _, rest_attrs) -> (
-        match pval_prim with
-        | [] | _ :: _ :: _ ->
-            Location.raise_errorf ~loc:pval_loc
-              "jsoo-react: externals only allow single primitive declarations"
-        | [pval_prim] ->
-            let rec get_prop_types types {ptyp_loc; ptyp_desc} =
-              match ptyp_desc with
-              | Ptyp_arrow
-                  ( ((Labelled _ | Optional _) as arg_label)
-                  , type_
-                  , ({ptyp_desc= Ptyp_arrow _} as rest) ) ->
-                  get_prop_types
-                    ( (Str_label.of_arg_label arg_label, ptyp_loc, type_)
-                    :: types )
-                    rest
-              | Ptyp_arrow (Nolabel, {ptyp_loc}, _rest) ->
-                  Location.raise_errorf ~loc:ptyp_loc
-                    "jsoo-react: externals only allow labelled or optional \
-                     labelled arguments"
-              | Ptyp_arrow
-                  (((Labelled _ | Optional _) as arg_label), type_, returnValue)
-                ->
-                  (Str_label.of_arg_label arg_label, returnValue.ptyp_loc, type_)
-                  :: types
-              | Ptyp_any
-              | Ptyp_var _
-              | Ptyp_tuple _
-              | Ptyp_constr (_, _)
-              | Ptyp_object (_, _)
-              | Ptyp_class (_, _)
-              | Ptyp_alias (_, _)
-              | Ptyp_variant (_, _, _)
-              | Ptyp_poly (_, _)
-              | Ptyp_package _
-              | Ptyp_extension _ ->
-                  types
-            in
-            let prop_types = get_prop_types [] pval_type in
-            let named_type_list =
-              List.fold_left arg_to_concrete_type [] prop_types
-            in
-            let pluck_label_and_loc (label, loc, type_) =
-              ( label
-              , None (* default *)
-              , Pat.var {txt= Str_label.str label; loc}
-              , Str_label.str label
-              , loc
-              , Some type_ )
-            in
-            let named_arg_list_with_key =
-              let loc = pstr_loc in
-              ( Str_label.Optional "key"
-              , None
-              , Pat.var {txt= "key"; loc}
-              , "key"
-              , loc
-              , Some [%type: string] )
-              :: List.map pluck_label_and_loc prop_types
-            in
-            let make_props =
-              let named_arg_list =
-                List.map pluckLabelDefaultLocType named_arg_list_with_key
-              in
-              let js_props_obj =
-                make_external_js_props_obj ~loc:pstr_loc named_arg_list
-              in
-              make_make_props js_props_obj fn_name pstr_loc named_arg_list
-                named_type_list
-            in
-            let gloc = {pstr_loc with loc_ghost= true} in
-            let binding_pat_loc = gloc in
-            let outer_make expression =
-              Vb.mk ~loc:pstr_loc ~attrs:rest_attrs
-                (Pat.var ~loc:binding_pat_loc
-                   {loc= binding_pat_loc; txt= fn_name} )
-                (let outer =
-                   make_funs_for_make_props_body
-                     (List.map pluckLabelDefaultLocType named_arg_list_with_key)
-                     (let loc = gloc in
-                      [%expr
-                        fun () ->
-                          React.create_element [%e expression]
-                            [%e
-                              Exp.apply ~loc
-                                (Exp.ident ~loc
-                                   {loc; txt= Lident (make_props_name fn_name)} )
-                                ( List.map
-                                    (fun ( arg
-                                         , _default
-                                         , _pattern
-                                         , _alias
-                                         , _pattern_loc
-                                         , _type ) ->
-                                      ( Str_label.to_arg_label arg
-                                      , Exp.ident ~loc:gloc
-                                          { loc= gloc
-                                          ; txt= Lident (Str_label.str arg) } )
-                                      )
-                                    named_arg_list_with_key
-                                @ [ ( Nolabel
-                                    , Exp.construct {loc; txt= Lident "()"} None
-                                    ) ] )]] )
-                 in
-                 make_props outer )
-            in
-            let js_component_expr =
-              let loc = pstr_loc in
-              [%expr
-                Js_of_ocaml.Js.Unsafe.js_expr [%e constantString ~loc pval_prim]]
-            in
-            { pstr_loc
-            ; pstr_desc=
-                Pstr_value (Nonrecursive, [outer_make js_component_expr]) }
-            :: returnStructures ) )
+            ; pval_prim
+            }
+      } -> (
+        match (inside_component, List.partition hasAttr pval_attributes) with
+        | false, ([], _) -> structure :: returnStructures
+        | true, (_, rest_attrs) | _, (_ :: _, rest_attrs) -> (
+            match pval_prim with
+            | [] | _ :: _ :: _ ->
+                Location.raise_errorf ~loc:pval_loc
+                  "jsoo-react: externals only allow single primitive \
+                   declarations"
+            | [ pval_prim ] ->
+                let rec get_prop_types types { ptyp_loc; ptyp_desc } =
+                  match ptyp_desc with
+                  | Ptyp_arrow
+                      ( ((Labelled _ | Optional _) as arg_label)
+                      , type_
+                      , ({ ptyp_desc = Ptyp_arrow _ } as rest) ) ->
+                      get_prop_types
+                        ((Str_label.of_arg_label arg_label, ptyp_loc, type_)
+                        :: types)
+                        rest
+                  | Ptyp_arrow (Nolabel, { ptyp_loc }, _rest) ->
+                      Location.raise_errorf ~loc:ptyp_loc
+                        "jsoo-react: externals only allow labelled or optional \
+                         labelled arguments"
+                  | Ptyp_arrow
+                      ( ((Labelled _ | Optional _) as arg_label)
+                      , type_
+                      , returnValue ) ->
+                      ( Str_label.of_arg_label arg_label
+                      , returnValue.ptyp_loc
+                      , type_ )
+                      :: types
+                  | Ptyp_any | Ptyp_var _ | Ptyp_tuple _
+                  | Ptyp_constr (_, _)
+                  | Ptyp_object (_, _)
+                  | Ptyp_class (_, _)
+                  | Ptyp_alias (_, _)
+                  | Ptyp_variant (_, _, _)
+                  | Ptyp_poly (_, _)
+                  | Ptyp_package _ | Ptyp_extension _ ->
+                      types
+                in
+                let prop_types = get_prop_types [] pval_type in
+                let named_type_list =
+                  List.fold_left arg_to_concrete_type [] prop_types
+                in
+                let pluck_label_and_loc (label, loc, type_) =
+                  ( label
+                  , None (* default *)
+                  , Pat.var { txt = Str_label.str label; loc }
+                  , Str_label.str label
+                  , loc
+                  , Some type_ )
+                in
+                let named_arg_list_with_key =
+                  let loc = pstr_loc in
+                  ( Str_label.Optional "key"
+                  , None
+                  , Pat.var { txt = "key"; loc }
+                  , "key"
+                  , loc
+                  , Some [%type: string] )
+                  :: List.map pluck_label_and_loc prop_types
+                in
+                let make_props =
+                  let named_arg_list =
+                    List.map pluckLabelDefaultLocType named_arg_list_with_key
+                  in
+                  let js_props_obj =
+                    make_external_js_props_obj ~loc:pstr_loc named_arg_list
+                  in
+                  make_make_props js_props_obj fn_name pstr_loc named_arg_list
+                    named_type_list
+                in
+                let gloc = { pstr_loc with loc_ghost = true } in
+                let binding_pat_loc = gloc in
+                let outer_make expression =
+                  Vb.mk ~loc:pstr_loc ~attrs:rest_attrs
+                    (Pat.var ~loc:binding_pat_loc
+                       { loc = binding_pat_loc; txt = fn_name })
+                    (let outer =
+                       make_funs_for_make_props_body
+                         (List.map pluckLabelDefaultLocType
+                            named_arg_list_with_key)
+                         (let loc = gloc in
+                          [%expr
+                            fun () ->
+                              React.create_element [%e expression]
+                                [%e
+                                  Exp.apply ~loc
+                                    (Exp.ident ~loc
+                                       { loc
+                                       ; txt = Lident (make_props_name fn_name)
+                                       })
+                                    (List.map
+                                       (fun ( arg
+                                            , _default
+                                            , _pattern
+                                            , _alias
+                                            , _pattern_loc
+                                            , _type ) ->
+                                         ( Str_label.to_arg_label arg
+                                         , Exp.ident ~loc:gloc
+                                             { loc = gloc
+                                             ; txt = Lident (Str_label.str arg)
+                                             } ))
+                                       named_arg_list_with_key
+                                    @ [ ( Nolabel
+                                        , Exp.construct
+                                            { loc; txt = Lident "()" } None )
+                                      ])]])
+                     in
+                     make_props outer)
+                in
+                let js_component_expr =
+                  let loc = pstr_loc in
+                  [%expr
+                    Js_of_ocaml.Js.Unsafe.js_expr
+                      [%e constantString ~loc pval_prim]]
+                in
+                { pstr_loc
+                ; pstr_desc =
+                    Pstr_value (Nonrecursive, [ outer_make js_component_expr ])
+                }
+                :: returnStructures))
     (* let%component foo = ... or external%component foo = ... *)
-    | {pstr_desc= Pstr_extension (({txt= "component"}, PStr structure), _)} ->
+    | { pstr_desc = Pstr_extension (({ txt = "component" }, PStr structure), _)
+      } ->
         List.fold_right
           (transformComponentDefinition ~inside_component:true mapper)
           structure returnStructures
     (* let component = ... *)
-    | {pstr_loc; pstr_desc= Pstr_value (rec_flag, value_bindings)} ->
+    | { pstr_loc; pstr_desc = Pstr_value (rec_flag, value_bindings) } ->
         let bindings =
           List.map
             (process_value_binding ~pstr_loc ~inside_component ~mapper)
             value_bindings
         in
-        [{pstr_loc; pstr_desc= Pstr_value (rec_flag, bindings)}]
+        [ { pstr_loc; pstr_desc = Pstr_value (rec_flag, bindings) } ]
         @ returnStructures
-    | structure ->
-        structure :: returnStructures
+    | structure -> structure :: returnStructures
   in
   let reactComponentTransform mapper structure_items =
     List.fold_right (transformComponentDefinition mapper) structure_items []
   in
-  let transformJsxCall callExpression callArguments attrs apply_loc
+  let transformJsxCall
+      callExpression
+      callArguments
+      attrs
+      apply_loc
       apply_loc_stack =
     match callExpression.pexp_desc with
     | Pexp_ident caller -> (
-      match caller with
-      | {txt= Lident "createElement"} ->
-          raise
-            (Invalid_argument
-               "JSX: `createElement` should be preceeded by a module name." )
-      (* Foo.createElement(~prop1=foo, ~prop2=bar, ~children=[], ()) *)
-      | {loc; txt= Ldot (modulePath, "createElement")} ->
-          let _children_expr, args =
-            uppercase_element_args ~loc callArguments
-          in
-          { pexp_desc=
-              Pexp_apply
-                ( { callExpression with
-                    pexp_desc= Pexp_ident {loc; txt= Ldot (modulePath, "make")}
-                  }
-                , args )
-          ; pexp_attributes= attrs
-          ; pexp_loc= apply_loc
-          ; pexp_loc_stack= apply_loc_stack }
-      (* div(~prop1=foo, ~prop2=bar, ~children=[bla], ()) *)
-      (* turn that into
-         React.Dom.createElement(~props=React.Dom.props(~props1=foo, ~props2=bar, ()), [|bla|]) *)
-      | {loc; txt= Lident id} ->
-          transformLowercaseCall loc attrs callArguments id apply_loc
-      | {txt= Ldot (_, anythingNotCreateElementOrMake)} ->
-          raise
-            (Invalid_argument
-               ( "JSX: the JSX attribute should be attached to a \
-                  `YourModuleName.createElement` or `YourModuleName.make` \
-                  call. We saw `" ^ anythingNotCreateElementOrMake ^ "` instead"
-               ) )
-      | {txt= Lapply _} ->
-          (* don't think there's ever a case where this is reached *)
-          raise
-            (Invalid_argument
-               "JSX: encountered a weird case while processing the code. \
-                Please report this!" ) )
+        match caller with
+        | { txt = Lident "createElement" } ->
+            raise
+              (Invalid_argument
+                 "JSX: `createElement` should be preceeded by a module name.")
+        (* Foo.createElement(~prop1=foo, ~prop2=bar, ~children=[], ()) *)
+        | { loc; txt = Ldot (modulePath, "createElement") } ->
+            let _children_expr, args =
+              uppercase_element_args ~loc callArguments
+            in
+            { pexp_desc =
+                Pexp_apply
+                  ( { callExpression with
+                      pexp_desc =
+                        Pexp_ident { loc; txt = Ldot (modulePath, "make") }
+                    }
+                  , args )
+            ; pexp_attributes = attrs
+            ; pexp_loc = apply_loc
+            ; pexp_loc_stack = apply_loc_stack
+            }
+        (* div(~prop1=foo, ~prop2=bar, ~children=[bla], ()) *)
+        (* turn that into
+           React.Dom.createElement(~props=React.Dom.props(~props1=foo, ~props2=bar, ()), [|bla|]) *)
+        | { loc; txt = Lident id } ->
+            transformLowercaseCall loc attrs callArguments id apply_loc
+        | { txt = Ldot (_, anythingNotCreateElementOrMake) } ->
+            raise
+              (Invalid_argument
+                 ("JSX: the JSX attribute should be attached to a \
+                   `YourModuleName.createElement` or `YourModuleName.make` \
+                   call. We saw `" ^ anythingNotCreateElementOrMake
+                ^ "` instead"))
+        | { txt = Lapply _ } ->
+            (* don't think there's ever a case where this is reached *)
+            raise
+              (Invalid_argument
+                 "JSX: encountered a weird case while processing the code. \
+                  Please report this!"))
     | _ ->
         raise
           (Invalid_argument
              "JSX: `createElement` should be preceeded by a simple, direct \
-              module name." )
+              module name.")
   in
   object (self)
     inherit Ast_traverse.map as super
@@ -1187,10 +1184,11 @@ let jsxMapper () =
     method! expression expression =
       let expression = super#expression expression in
       match expression with
-      | { pexp_desc= Pexp_apply (callExpression, callArguments)
+      | { pexp_desc = Pexp_apply (callExpression, callArguments)
         ; pexp_attributes
-        ; pexp_loc= apply_loc
-        ; pexp_loc_stack } -> (
+        ; pexp_loc = apply_loc
+        ; pexp_loc_stack
+        } -> (
           (* Does the function application have the @JSX attribute? *)
           let jsxAttribute, nonJSXAttributes =
             List.partition
@@ -1199,19 +1197,19 @@ let jsxMapper () =
           in
           match (jsxAttribute, nonJSXAttributes) with
           (* no JSX attribute *)
-          | [], _ ->
-              expression
+          | [], _ -> expression
           | _, nonJSXAttributes ->
               transformJsxCall callExpression callArguments nonJSXAttributes
-                apply_loc pexp_loc_stack )
+                apply_loc pexp_loc_stack)
       (* is it a list with jsx attribute? Reason <>foo</> desugars to [@JSX][foo]*)
-      | { pexp_desc=
+      | { pexp_desc =
             ( Pexp_construct
-                ({txt= Lident "::"; loc}, Some {pexp_desc= Pexp_tuple _})
-            | Pexp_construct ({txt= Lident "[]"; loc}, None) )
+                ({ txt = Lident "::"; loc }, Some { pexp_desc = Pexp_tuple _ })
+            | Pexp_construct ({ txt = Lident "[]"; loc }, None) )
         ; pexp_attributes
         ; pexp_loc
-        ; pexp_loc_stack } as listItems -> (
+        ; pexp_loc_stack
+        } as listItems -> (
           let jsxAttribute, nonJSXAttributes =
             List.partition
               (fun attribute -> attribute.attr_name.txt = "JSX")
@@ -1219,24 +1217,21 @@ let jsxMapper () =
           in
           match (jsxAttribute, nonJSXAttributes) with
           (* no JSX attribute *)
-          | [], _ ->
-              expression
+          | [], _ -> expression
           | _, nonJSXAttributes ->
               let callExpression = [%expr React.Fragment.createElement] in
               transformJsxCall callExpression
-                [(Labelled "children", {listItems with pexp_attributes= []})]
-                nonJSXAttributes pexp_loc pexp_loc_stack )
+                [ (Labelled "children", { listItems with pexp_attributes = [] })
+                ]
+                nonJSXAttributes pexp_loc pexp_loc_stack)
       (* Delegate to the default mapper, a deep identity traversal *)
-      | _e ->
-          expression
+      | _e -> expression
 
     method! module_binding module_binding =
       let _ =
         match module_binding.pmb_name.txt with
-        | None ->
-            ()
-        | Some txt ->
-            nestedModules := txt :: !nestedModules
+        | None -> ()
+        | Some txt -> nestedModules := txt :: !nestedModules
       in
       let mapped = super#module_binding module_binding in
       let _ = nestedModules := List.tl !nestedModules in

--- a/ppx/test/input_ocaml.ml
+++ b/ppx/test/input_ocaml.ml
@@ -6,26 +6,24 @@ type t = string [@@foo val f : int]
 
 (* let%component *)
 
-let%component make ?(name = "") = div [||] [React.string ("Hello " ^ name)]
-
-let%component make ~children:(first, second) = div [||] [first; second]
-
+let%component make ?(name = "") = div [||] [ React.string ("Hello " ^ name) ]
+let%component make ~children:(first, second) = div [||] [ first; second ]
 let%component make ~children:kids = div [||] kids
-
-let%component make ~children:(first, second) () = div [||] [first; second]
-
-let%component make ?(name = "") = div [||] [name]
-
+let%component make ~children:(first, second) () = div [||] [ first; second ]
+let%component make ?(name = "") = div [||] [ name ]
 let%component make () = div [||] []
 
 let%component make ~(bar : int option) =
-  div [||] [React.string (string_of_int (Option.value ~default:0 bar))] ()
+  div [||] [ React.string (string_of_int (Option.value ~default:0 bar)) ] ()
 
-external%component make : name:Js.js_string Js.t -> React.element
+external%component make :
+  name:Js.js_string Js.t -> React.element
   = "require(\"my-react-library\").MyReactComponent"
 
-external%component make : ?name:Js.js_string Js.t -> React.element
+external%component make :
+  ?name:Js.js_string Js.t -> React.element
   = "require(\"my-react-library\").MyReactComponent"
 
-external%component make : names:string array -> React.element
+external%component make :
+  names:string array -> React.element
   = "require(\"my-react-library\").MyReactComponent"

--- a/test/.ocamlformat
+++ b/test/.ocamlformat
@@ -1,1 +1,0 @@
-profile = ocamlformat

--- a/test/jsdom.mli
+++ b/test/jsdom.mli
@@ -1,9 +1,7 @@
 type t = private Ojs.t
 
 val t_of_js : Ojs.t -> t
-
 val t_to_js : t -> Ojs.t
-
 val make : html:string -> t [@@js.new "__LIB__jsdom"]
 
 [@@@js.stop]
@@ -16,7 +14,6 @@ type window = Js_of_ocaml.Dom_html.window Js_of_ocaml.Js.t
 type window = Js_of_ocaml.Dom_html.window Js_of_ocaml.Js.t
 
 external window_of_js : t -> window = "%identity"
-
 external window_to_js : window -> t = "%identity"]
 
 val window : t -> window [@@js.get]
@@ -31,7 +28,6 @@ type document = Js_of_ocaml.Dom_html.document Js_of_ocaml.Js.t
 type document = Js_of_ocaml.Dom_html.document Js_of_ocaml.Js.t
 
 external document_of_js : t -> document = "%identity"
-
 external document_to_js : document -> t = "%identity"]
 
 val document : window -> document [@@js.get]

--- a/test/test_jsoo_react.ml
+++ b/test/test_jsoo_react.ml
@@ -1,5 +1,4 @@
 open Webtest.Suite
 
-let suite = "baseSuite" >::: [Test_reason.suite; Test_ml.suite]
-
+let suite = "baseSuite" >::: [ Test_reason.suite; Test_ml.suite ]
 let () = Webtest_js.Runner.run suite

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -6,46 +6,42 @@ module Html = Js_of_ocaml.Dom_html
 module Dom = Js_of_ocaml.Dom
 
 let act = ReactDOMTestUtils.act
-
 let jsdom = Jsdom.make ~html:"<!doctype html><html><body></body></html>"
-
 let doc = jsdom |> Jsdom.window |> Jsdom.document
-
 let () = Js.Unsafe.global##.document := doc
-
 let () = Js.Unsafe.global##.window := jsdom |> Jsdom.window
 
 let printTextContent container =
   print_endline
     (Js.to_string
-       (Js.Opt.get container##.textContent (fun () -> Js.string "missing")) )
+       (Js.Opt.get container##.textContent (fun () -> Js.string "missing")))
 
 let printInnerHTML (container : Html.divElement Js.t) =
   print_endline (Js.to_string container##.innerHTML)
 
 let withContainer f =
   let container = Html.createDiv doc in
-  Dom.appendChild doc##.body container ;
+  Dom.appendChild doc##.body container;
   let result = f container in
-  ignore (React.Dom.unmount_component_at_node container) ;
-  Dom.removeChild doc##.body container ;
+  ignore (React.Dom.unmount_component_at_node container);
+  Dom.removeChild doc##.body container;
   result
 
 let testDom () =
-  doc##.title := Js.string "Testing" ;
+  doc##.title := Js.string "Testing";
   let p = Html.createP doc in
-  p##.innerHTML := Js.string "Loading graph..." ;
-  Dom.appendChild doc##.body p ;
-  assert_equal doc##.title (Js.string "Testing") ;
+  p##.innerHTML := Js.string "Loading graph...";
+  Dom.appendChild doc##.body p;
+  assert_equal doc##.title (Js.string "Testing");
   assert_equal p##.innerHTML (Js.string "Loading graph...")
 
 let testReact () =
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
-            (div [||] ["Hello world!" |> string])
-            (Html.element c) ) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "Hello world!")) )
+            (div [||] [ "Hello world!" |> string ])
+            (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "Hello world!")))
 
 let testKeys () =
   withContainer (fun c ->
@@ -53,42 +49,42 @@ let testKeys () =
           React.Dom.render
             (div [||]
                (List.map
-                  (fun str -> div [|key str|] [str |> string])
-                  ["a"; "b"] ) )
-            (Html.element c) ) ;
+                  (fun str -> div [| key str |] [ str |> string ])
+                  [ "a"; "b" ]))
+            (Html.element c));
       assert_equal c##.innerHTML
-        (Js.string "<div><div>a</div><div>b</div></div>") )
+        (Js.string "<div><div>a</div><div>b</div></div>"))
 
 let testOptionalPropsUppercase () =
   let module OptProps = struct
     let%component make ?(name = "joe") =
-      div [||] [Printf.sprintf "`name` is %s" name |> string]
+      div [||] [ Printf.sprintf "`name` is %s" name |> string ]
   end in
   withContainer (fun c ->
-      act (fun () -> React.Dom.render (OptProps.make ()) (Html.element c)) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "`name` is joe")) ;
+      act (fun () -> React.Dom.render (OptProps.make ()) (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "`name` is joe"));
       act (fun () ->
-          React.Dom.render (OptProps.make ~name:"jane" ()) (Html.element c) ) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "`name` is jane")) )
+          React.Dom.render (OptProps.make ~name:"jane" ()) (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "`name` is jane")))
 
 let testOptionalPropsLowercase () =
   let module LinkWithMaybeHref = struct
     (* NOTE: collision caused by namespace pollution *)
-    let%component make ~href = a [|maybe Prop.href href|] []
+    let%component make ~href = a [| maybe Prop.href href |] []
   end in
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
             (LinkWithMaybeHref.make ~href:None ())
-            (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<a></a>") ;
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<a></a>");
       act (fun () ->
           React.Dom.render
             (LinkWithMaybeHref.make ~href:(Some "https://google.es") ())
-            (Html.element c) ) ;
-      printInnerHTML c ;
+            (Html.element c));
+      printInnerHTML c;
       assert_equal c##.innerHTML
-        (Js.string {|<a href="https://google.es"></a>|}) )
+        (Js.string {|<a href="https://google.es"></a>|}))
 
 let testContext () =
   let module DummyContext = struct
@@ -101,53 +97,61 @@ let testContext () =
     module Consumer = struct
       let%component make () =
         let value = React.use_context context in
-        div [||] [value |> string]
+        div [||] [ value |> string ]
     end
   end in
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
             (DummyContext.Provider.make ~value:"bar"
-               [DummyContext.Consumer.make ()] )
-            (Html.element c) ) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "bar")) )
+               [ DummyContext.Consumer.make () ])
+            (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "bar")))
 
 let test_use_effect_always () =
   let count = ref 0 in
   let module C = struct
     let%component make () =
-      React.use_effect_always (fun () -> incr count ; None) ;
+      React.use_effect_always (fun () ->
+          incr count;
+          None);
       div [||] []
   end in
   withContainer (fun c ->
-      act (fun () -> React.Dom.render (C.make ()) (Html.element c)) ;
-      act (fun () -> React.Dom.render (C.make ()) (Html.element c)) ;
-      assert_equal !count 2 )
+      act (fun () -> React.Dom.render (C.make ()) (Html.element c));
+      act (fun () -> React.Dom.render (C.make ()) (Html.element c));
+      assert_equal !count 2)
 
 let test_use_effect_once () =
   let count = ref 0 in
   let module C = struct
     let%component make () =
-      React.use_effect_once (fun () -> incr count ; None) ;
+      React.use_effect_once (fun () ->
+          incr count;
+          None);
       div [||] []
   end in
   withContainer (fun c ->
-      act (fun () -> React.Dom.render (C.make ()) (Html.element c)) ;
-      act (fun () -> React.Dom.render (C.make ()) (Html.element c)) ;
-      assert_equal !count 1 )
+      act (fun () -> React.Dom.render (C.make ()) (Html.element c));
+      act (fun () -> React.Dom.render (C.make ()) (Html.element c));
+      assert_equal !count 1)
 
 let test_use_effect2 () =
   let count = ref 0 in
   let module C = struct
     let%component make ~a ~b =
-      React.use_effect2 (fun () -> incr count ; None) (a, b) ;
+      React.use_effect2
+        (fun () ->
+          incr count;
+          None)
+        (a, b);
       div [||] []
   end in
   withContainer (fun c ->
-      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c)) ;
-      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c)) ;
-      act (fun () -> React.Dom.render (C.make ~a:2 ~b:3 ()) (Html.element c)) ;
-      assert_equal !count 2 )
+      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c));
+      act (fun () -> React.Dom.render (C.make ~a:1 ~b:2 ()) (Html.element c));
+      act (fun () -> React.Dom.render (C.make ~a:2 ~b:3 ()) (Html.element c));
+      assert_equal !count 2)
 
 let testUseCallback1 () =
   let module UseCallback = struct
@@ -158,26 +162,27 @@ let testUseCallback1 () =
       let f = React.use_callback1 (fun input -> input ^ " " ^ a ^ " and") a in
       React.use_effect1
         (fun () ->
-          setCountStr (fun (count, str) -> (count + 1, f str)) ;
-          None )
-        f ;
-      div [||] [Printf.sprintf "`count` is %d, `str` is %s" count str |> string]
+          setCountStr (fun (count, str) -> (count + 1, f str));
+          None)
+        f;
+      div [||]
+        [ Printf.sprintf "`count` is %d, `str` is %s" count str |> string ]
   end in
   withContainer (fun c ->
       let fooString = "foo" in
       act (fun () ->
-          React.Dom.render (UseCallback.make ~a:fooString ()) (Html.element c) ) ;
+          React.Dom.render (UseCallback.make ~a:fooString ()) (Html.element c));
       assert_equal c##.textContent
-        (Js.Opt.return (Js.string "`count` is 1, `str` is init and foo and")) ;
+        (Js.Opt.return (Js.string "`count` is 1, `str` is init and foo and"));
       act (fun () ->
-          React.Dom.render (UseCallback.make ~a:fooString ()) (Html.element c) ) ;
+          React.Dom.render (UseCallback.make ~a:fooString ()) (Html.element c));
       assert_equal c##.textContent
-        (Js.Opt.return (Js.string "`count` is 1, `str` is init and foo and")) ;
+        (Js.Opt.return (Js.string "`count` is 1, `str` is init and foo and"));
       act (fun () ->
-          React.Dom.render (UseCallback.make ~a:"bar" ()) (Html.element c) ) ;
+          React.Dom.render (UseCallback.make ~a:"bar" ()) (Html.element c));
       assert_equal c##.textContent
         (Js.Opt.return
-           (Js.string "`count` is 2, `str` is init and foo and bar and") ) )
+           (Js.string "`count` is 2, `str` is init and foo and bar and")))
 
 let testUseCallback4 () =
   let module UseCallback = struct
@@ -187,96 +192,98 @@ let testUseCallback4 () =
         React.use_callback4
           (fun _input ->
             Printf.sprintf "a: %s, b: %d, d: [%d], e: [|%d|]" a b (List.nth d 0)
-              e.(0) )
+              e.(0))
           (a, b, d, e)
       in
       React.use_effect1
         (fun () ->
-          setCountStr (fun (count, str) -> (count + 1, f str)) ;
-          None )
-        f ;
-      div [||] [Printf.sprintf "`count` is %d, `str` is %s" count str |> string]
+          setCountStr (fun (count, str) -> (count + 1, f str));
+          None)
+        f;
+      div [||]
+        [ Printf.sprintf "`count` is %d, `str` is %s" count str |> string ]
   end in
   withContainer (fun c ->
       let a = "foo" in
       let a2 = "bar" in
       let b = 2 in
-      let d = [3] in
-      let e = [|4|] in
+      let d = [ 3 ] in
+      let e = [| 4 |] in
       act (fun () ->
-          React.Dom.render (UseCallback.make ~a ~b ~d ~e ()) (Html.element c) ) ;
+          React.Dom.render (UseCallback.make ~a ~b ~d ~e ()) (Html.element c));
       assert_equal c##.textContent
         (Js.Opt.return
-           (Js.string "`count` is 1, `str` is a: foo, b: 2, d: [3], e: [|4|]") ) ;
+           (Js.string "`count` is 1, `str` is a: foo, b: 2, d: [3], e: [|4|]"));
       act (fun () ->
-          React.Dom.render (UseCallback.make ~a ~b ~d ~e ()) (Html.element c) ) ;
+          React.Dom.render (UseCallback.make ~a ~b ~d ~e ()) (Html.element c));
       assert_equal c##.textContent
         (Js.Opt.return
-           (Js.string "`count` is 1, `str` is a: foo, b: 2, d: [3], e: [|4|]") ) ;
+           (Js.string "`count` is 1, `str` is a: foo, b: 2, d: [3], e: [|4|]"));
       act (fun () ->
-          React.Dom.render (UseCallback.make ~a:a2 ~b ~d ~e ()) (Html.element c) ) ;
+          React.Dom.render (UseCallback.make ~a:a2 ~b ~d ~e ()) (Html.element c));
       assert_equal c##.textContent
         (Js.Opt.return
-           (Js.string "`count` is 2, `str` is a: bar, b: 2, d: [3], e: [|4|]") ) ;
+           (Js.string "`count` is 2, `str` is a: bar, b: 2, d: [3], e: [|4|]"));
       act (fun () ->
-          React.Dom.render (UseCallback.make ~a:a2 ~b ~d ~e ()) (Html.element c) ) ;
+          React.Dom.render (UseCallback.make ~a:a2 ~b ~d ~e ()) (Html.element c));
       assert_equal c##.textContent
         (Js.Opt.return
-           (Js.string "`count` is 2, `str` is a: bar, b: 2, d: [3], e: [|4|]") ) ;
+           (Js.string "`count` is 2, `str` is a: bar, b: 2, d: [3], e: [|4|]"));
       act (fun () ->
           React.Dom.render
             (UseCallback.make ~a:a2 ~b:3 ~d ~e ())
-            (Html.element c) ) ;
+            (Html.element c));
       assert_equal c##.textContent
         (Js.Opt.return
-           (Js.string "`count` is 3, `str` is a: bar, b: 3, d: [3], e: [|4|]") ) ;
+           (Js.string "`count` is 3, `str` is a: bar, b: 3, d: [3], e: [|4|]"));
       act (fun () ->
           React.Dom.render
-            (UseCallback.make ~a:a2 ~b:3 ~d:[4] ~e ())
-            (Html.element c) ) ;
+            (UseCallback.make ~a:a2 ~b:3 ~d:[ 4 ] ~e ())
+            (Html.element c));
       assert_equal c##.textContent
         (Js.Opt.return
-           (Js.string "`count` is 4, `str` is a: bar, b: 3, d: [4], e: [|4|]") ) )
+           (Js.string "`count` is 4, `str` is a: bar, b: 3, d: [4], e: [|4|]")))
 
 let testUseState () =
   let module DummyStateComponent = struct
     let%component make ?(initialValue = 0) () =
       let counter, setCounter = React.use_state (fun () -> initialValue) in
       fragment
-        [ div [|className "value"|] [React.int counter]
+        [ div [| className "value" |] [ React.int counter ]
         ; button
-            [|onClick (fun _ -> setCounter (fun counter -> counter + 1))|]
-            [string "Increment"]
+            [| onClick (fun _ -> setCounter (fun counter -> counter + 1)) |]
+            [ string "Increment" ]
         ; button
-            [|onClick (fun _ -> setCounter (fun counter -> counter - 1))|]
-            [string "Decrement"] ]
+            [| onClick (fun _ -> setCounter (fun counter -> counter - 1)) |]
+            [ string "Decrement" ]
+        ]
   end in
   withContainer (fun c ->
       let open ReactDOMTestUtils in
       act (fun () ->
-          React.Dom.render (DummyStateComponent.make ()) (Html.element c) ) ;
+          React.Dom.render (DummyStateComponent.make ()) (Html.element c));
       assert_equal c##.innerHTML
         (Js.string
            "<div \
-            class=\"value\">0</div><button>Increment</button><button>Decrement</button>" ) ;
+            class=\"value\">0</div><button>Increment</button><button>Decrement</button>");
       let button =
         DOM.findBySelectorAndPartialTextContent (unsafe_to_element c) "button"
           "Increment"
       in
-      act (fun () -> Simulate.click button) ;
+      act (fun () -> Simulate.click button);
       assert_equal c##.innerHTML
         (Js.string
            "<div \
-            class=\"value\">1</div><button>Increment</button><button>Decrement</button>" ) ;
+            class=\"value\">1</div><button>Increment</button><button>Decrement</button>");
       let button =
         DOM.findBySelectorAndPartialTextContent (unsafe_to_element c) "button"
           "Decrement"
       in
-      act (fun () -> Simulate.click button) ;
+      act (fun () -> Simulate.click button);
       assert_equal c##.innerHTML
         (Js.string
            "<div \
-            class=\"value\">0</div><button>Increment</button><button>Decrement</button>" ) )
+            class=\"value\">0</div><button>Increment</button><button>Decrement</button>"))
 
 let testUseStateUpdaterReference () =
   let module UseState = struct
@@ -286,107 +293,111 @@ let testUseStateUpdaterReference () =
       let _count, setCount = React.use_state (fun () -> 0) in
       let equal =
         match (setCount, !prevSetCount) with
-        | r1, Some r2 when r1 == r2 ->
-            "true"
-        | _ ->
-            "false"
+        | r1, Some r2 when r1 == r2 -> "true"
+        | _ -> "false"
       in
-      prevSetCount := Some setCount ;
-      div [||] [equal |> string]
+      prevSetCount := Some setCount;
+      div [||] [ equal |> string ]
   end in
   withContainer (fun c ->
-      act (fun () -> React.Dom.render (UseState.make ()) (Html.element c)) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "false")) ;
-      act (fun () -> React.Dom.render (UseState.make ()) (Html.element c)) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "true")) )
+      act (fun () -> React.Dom.render (UseState.make ()) (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "false"));
+      act (fun () -> React.Dom.render (UseState.make ()) (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "true")))
 
 let testUseReducer () =
   let module DummyReducerComponent = struct
-    type action = Increment | Decrement
+    type action =
+      | Increment
+      | Decrement
 
     let%component make ?(initialValue = 0) () =
       let state, send =
         React.use_reducer
           ~init:(fun () -> initialValue)
           (fun state action ->
-            match action with Increment -> state + 1 | Decrement -> state - 1 )
+            match action with Increment -> state + 1 | Decrement -> state - 1)
       in
       fragment
-        [ div [|className "value"|] [int state]
-        ; button [|onClick (fun _ -> send Increment)|] [string "Increment"]
-        ; button [|onClick (fun _ -> send Decrement)|] [string "Decrement"] ]
+        [ div [| className "value" |] [ int state ]
+        ; button [| onClick (fun _ -> send Increment) |] [ string "Increment" ]
+        ; button [| onClick (fun _ -> send Decrement) |] [ string "Decrement" ]
+        ]
   end in
   withContainer (fun c ->
       let open ReactDOMTestUtils in
       act (fun () ->
-          React.Dom.render (DummyReducerComponent.make ()) (Html.element c) ) ;
+          React.Dom.render (DummyReducerComponent.make ()) (Html.element c));
       assert_equal c##.innerHTML
         (Js.string
            "<div \
-            class=\"value\">0</div><button>Increment</button><button>Decrement</button>" ) ;
+            class=\"value\">0</div><button>Increment</button><button>Decrement</button>");
       let button =
         DOM.findBySelectorAndPartialTextContent (unsafe_to_element c) "button"
           "Increment"
       in
-      act (fun () -> Simulate.click button) ;
+      act (fun () -> Simulate.click button);
       assert_equal c##.innerHTML
         (Js.string
            "<div \
-            class=\"value\">1</div><button>Increment</button><button>Decrement</button>" ) ;
+            class=\"value\">1</div><button>Increment</button><button>Decrement</button>");
       let button =
         DOM.findBySelectorAndPartialTextContent (unsafe_to_element c) "button"
           "Decrement"
       in
-      act (fun () -> Simulate.click button) ;
+      act (fun () -> Simulate.click button);
       assert_equal c##.innerHTML
         (Js.string
            "<div \
-            class=\"value\">0</div><button>Increment</button><button>Decrement</button>" ) )
+            class=\"value\">0</div><button>Increment</button><button>Decrement</button>"))
 
 let testUseReducerWithMapState () =
   let module DummyReducerWithMapStateComponent = struct
-    type action = Increment | Decrement
+    type action =
+      | Increment
+      | Decrement
 
     let%component make ?(initialValue = 0) () =
       let state, send =
         React.use_reducer
           ~init:(fun () -> initialValue + 1)
           (fun state action ->
-            match action with Increment -> state + 1 | Decrement -> state - 1 )
+            match action with Increment -> state + 1 | Decrement -> state - 1)
       in
       fragment
-        [ div [|className "value"|] [int state]
-        ; button [|onClick (fun _ -> send Increment)|] [string "Increment"]
-        ; button [|onClick (fun _ -> send Decrement)|] [string "Decrement"] ]
+        [ div [| className "value" |] [ int state ]
+        ; button [| onClick (fun _ -> send Increment) |] [ string "Increment" ]
+        ; button [| onClick (fun _ -> send Decrement) |] [ string "Decrement" ]
+        ]
   end in
   withContainer (fun c ->
       let open ReactDOMTestUtils in
       act (fun () ->
           React.Dom.render
             (DummyReducerWithMapStateComponent.make ())
-            (Html.element c) ) ;
+            (Html.element c));
       assert_equal c##.innerHTML
         (Js.string
            "<div \
-            class=\"value\">1</div><button>Increment</button><button>Decrement</button>" ) ;
+            class=\"value\">1</div><button>Increment</button><button>Decrement</button>");
       let button =
         DOM.findBySelectorAndPartialTextContent (unsafe_to_element c) "button"
           "Increment"
       in
-      act (fun () -> Simulate.click button) ;
+      act (fun () -> Simulate.click button);
       assert_equal c##.innerHTML
         (Js.string
            "<div \
-            class=\"value\">2</div><button>Increment</button><button>Decrement</button>" ) ;
+            class=\"value\">2</div><button>Increment</button><button>Decrement</button>");
       let button =
         DOM.findBySelectorAndPartialTextContent (unsafe_to_element c) "button"
           "Decrement"
       in
-      act (fun () -> Simulate.click button) ;
+      act (fun () -> Simulate.click button);
       assert_equal c##.innerHTML
         (Js.string
            "<div \
-            class=\"value\">1</div><button>Increment</button><button>Decrement</button>" ) )
+            class=\"value\">1</div><button>Increment</button><button>Decrement</button>"))
 
 let testUseReducerDispatchReference () =
   let module UseReducer = struct
@@ -396,19 +407,17 @@ let testUseReducerDispatchReference () =
       let _, dispatch = React.use_reducer ~init:(fun () -> 2) (fun _ _ -> 2) in
       let equal =
         match (dispatch, !prevDispatch) with
-        | r1, Some r2 when r1 == r2 ->
-            "true"
-        | _ ->
-            "false"
+        | r1, Some r2 when r1 == r2 -> "true"
+        | _ -> "false"
       in
-      prevDispatch := Some dispatch ;
-      div [||] [equal |> string]
+      prevDispatch := Some dispatch;
+      div [||] [ equal |> string ]
   end in
   withContainer (fun c ->
-      act (fun () -> React.Dom.render (UseReducer.make ()) (Html.element c)) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "false")) ;
-      act (fun () -> React.Dom.render (UseReducer.make ()) (Html.element c)) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "true")) )
+      act (fun () -> React.Dom.render (UseReducer.make ()) (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "false"));
+      act (fun () -> React.Dom.render (UseReducer.make ()) (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "true")))
 
 let testUseMemo1 () =
   let module UseMemo = struct
@@ -417,47 +426,48 @@ let testUseMemo1 () =
       let result = React.use_memo1 (fun () -> a ^ "2") a in
       React.use_effect1
         (fun () ->
-          setCount (fun count -> count + 1) ;
-          None )
-        result ;
-      div [||] [Printf.sprintf "`count` is %d" count |> string]
+          setCount (fun count -> count + 1);
+          None)
+        result;
+      div [||] [ Printf.sprintf "`count` is %d" count |> string ]
   end in
   withContainer (fun c ->
       let fooString = "foo" in
       act (fun () ->
-          React.Dom.render (UseMemo.make ~a:fooString ()) (Html.element c) ) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "`count` is 1")) ;
+          React.Dom.render (UseMemo.make ~a:fooString ()) (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "`count` is 1"));
       act (fun () ->
-          React.Dom.render (UseMemo.make ~a:fooString ()) (Html.element c) ) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "`count` is 1")) ;
+          React.Dom.render (UseMemo.make ~a:fooString ()) (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "`count` is 1"));
       act (fun () ->
-          React.Dom.render (UseMemo.make ~a:"foo" ()) (Html.element c) ) ;
-      assert_equal c##.textContent (Js.Opt.return (Js.string "`count` is 2")) )
+          React.Dom.render (UseMemo.make ~a:"foo" ()) (Html.element c));
+      assert_equal c##.textContent (Js.Opt.return (Js.string "`count` is 2")))
 
 let testMemo () =
   let numRenders = ref 0 in
   let module Memoized = struct
     let%component make =
       React.memo (fun ~a ->
-          numRenders := !numRenders + 1 ;
+          numRenders := !numRenders + 1;
           div [||]
             [ Printf.sprintf "`a` is %s, `numRenders` is %d" a !numRenders
-              |> string ] )
+              |> string
+            ])
   end in
   withContainer (fun c ->
       let fooString = "foo" in
       act (fun () ->
-          React.Dom.render (Memoized.make ~a:fooString ()) (Html.element c) ) ;
+          React.Dom.render (Memoized.make ~a:fooString ()) (Html.element c));
       assert_equal c##.textContent
-        (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1")) ;
+        (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1"));
       act (fun () ->
-          React.Dom.render (Memoized.make ~a:fooString ()) (Html.element c) ) ;
+          React.Dom.render (Memoized.make ~a:fooString ()) (Html.element c));
       assert_equal c##.textContent
-        (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1")) ;
+        (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1"));
       act (fun () ->
-          React.Dom.render (Memoized.make ~a:"bar" ()) (Html.element c) ) ;
+          React.Dom.render (Memoized.make ~a:"bar" ()) (Html.element c));
       assert_equal c##.textContent
-        (Js.Opt.return (Js.string "`a` is bar, `numRenders` is 2")) )
+        (Js.Opt.return (Js.string "`a` is bar, `numRenders` is 2")))
 
 let testMemoCustomCompareProps () =
   let numRenders = ref 0 in
@@ -466,38 +476,40 @@ let testMemoCustomCompareProps () =
       React.memo
         ~compare:(fun _prevPros _nextProps -> true)
         (fun ~a ->
-          numRenders := !numRenders + 1 ;
+          numRenders := !numRenders + 1;
           div [||]
             [ Printf.sprintf "`a` is %s, `numRenders` is %d" a !numRenders
-              |> string ] )
+              |> string
+            ])
   end in
   withContainer (fun c ->
       let fooString = "foo" in
       act (fun () ->
-          React.Dom.render (Memoized.make ~a:fooString ()) (Html.element c) ) ;
+          React.Dom.render (Memoized.make ~a:fooString ()) (Html.element c));
       assert_equal c##.textContent
-        (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1")) ;
+        (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1"));
       act (fun () ->
-          React.Dom.render (Memoized.make ~a:fooString ()) (Html.element c) ) ;
+          React.Dom.render (Memoized.make ~a:fooString ()) (Html.element c));
       assert_equal c##.textContent
-        (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1")) ;
+        (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1"));
       act (fun () ->
-          React.Dom.render (Memoized.make ~a:"bar" ()) (Html.element c) ) ;
+          React.Dom.render (Memoized.make ~a:"bar" ()) (Html.element c));
       assert_equal c##.textContent
-        (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1")) )
+        (Js.Opt.return (Js.string "`a` is foo, `numRenders` is 1")))
 
 let testCreateRef () =
   let reactRef = React.Ref.make () in
-  assert_equal (React.Ref.current reactRef) Js_of_ocaml.Js.null ;
-  React.Ref.set_current reactRef (Js_of_ocaml.Js.Opt.return 1) ;
+  assert_equal (React.Ref.current reactRef) Js_of_ocaml.Js.null;
+  React.Ref.set_current reactRef (Js_of_ocaml.Js.Opt.return 1);
   assert_equal (React.Ref.current reactRef) (Js_of_ocaml.Js.Opt.return 1)
 
 let testForwardRef () =
   let module FancyButton = struct
     let make ~ref children =
       div [||]
-        [ button [|ref_ ref; className "FancyButton"|] children
-        ; button [|ref_ ref; className "FancyButton"|] children ]
+        [ button [| ref_ ref; className "FancyButton" |] children
+        ; button [| ref_ ref; className "FancyButton" |] children
+        ]
   end in
   withContainer (fun c ->
       let count = ref 0 in
@@ -506,9 +518,9 @@ let testForwardRef () =
       in
       act (fun () ->
           React.Dom.render
-            (FancyButton.make ~ref:buttonRef [div [||] []])
-            (Html.element c) ) ;
-      assert_equal !count 2 )
+            (FancyButton.make ~ref:buttonRef [ div [||] [] ])
+            (Html.element c));
+      assert_equal !count 2)
 
 let testUseRef () =
   let module DummyComponentWithRefAndEffect = struct
@@ -516,9 +528,9 @@ let testUseRef () =
       let myRef = React.use_ref 1 in
       React.use_effect_once (fun () ->
           let open React.Ref in
-          set_current myRef (current myRef + 1) ;
-          cb myRef ;
-          None ) ;
+          set_current myRef (current myRef + 1);
+          cb myRef;
+          None);
       div [||] []
   end in
   withContainer (fun c ->
@@ -527,10 +539,10 @@ let testUseRef () =
       act (fun () ->
           React.Dom.render
             (DummyComponentWithRefAndEffect.make ~cb ())
-            (Html.element c) ) ;
+            (Html.element c));
       assert_equal
         (myRef.contents |> Option.map (fun item -> item |> React.Ref.current))
-        (Some 2) )
+        (Some 2))
 
 let testChildrenMapWithIndex () =
   let module DummyComponentThatMapsChildren = struct
@@ -539,42 +551,44 @@ let testChildrenMapWithIndex () =
         [ React.Children.mapi children (fun element index ->
               React.clone_element element
                 (let open Js_of_ocaml.Js.Unsafe in
-                obj [|("key", inject index); ("data-index", inject index)|]) )
+                obj [| ("key", inject index); ("data-index", inject index) |]))
         ]
   end in
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
             (DummyComponentThatMapsChildren.make
-               ~children:[div [||] [int 1]; div [||] [int 2]; div [||] [int 3]]
-               () )
-            (Html.element c) ) ;
+               ~children:
+                 [ div [||] [ int 1 ]; div [||] [ int 2 ]; div [||] [ int 3 ] ]
+               ())
+            (Html.element c));
       assert_equal c##.innerHTML
         (Js.string
            "<div><div data-index=\"0\">1</div><div \
-            data-index=\"1\">2</div><div data-index=\"2\">3</div></div>" ) )
+            data-index=\"1\">2</div><div data-index=\"2\">3</div></div>"))
 
 let testFragment () =
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
-            (fragment [div [||] [string "Hello"]; div [||] [string "World"]])
-            (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<div>Hello</div><div>World</div>") )
+            (fragment
+               [ div [||] [ string "Hello" ]; div [||] [ string "World" ] ])
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<div>Hello</div><div>World</div>"))
 
 let testNonListChildren () =
   let module NonListChildrenComponent = struct
-    let%component make ~children:(first, second) () = div [||] [first; second]
+    let%component make ~children:(first, second) () = div [||] [ first; second ]
   end in
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
             (NonListChildrenComponent.make
-               ~children:(div [||] [int 1], div [||] [int 3])
-               () )
-            (Html.element c) ) ;
+               ~children:(div [||] [ int 1 ], div [||] [ int 3 ])
+               ())
+            (Html.element c));
       assert_equal c##.innerHTML
-        (Js.string "<div><div>1</div><div>3</div></div>") )
+        (Js.string "<div><div>1</div><div>3</div></div>"))
 
 let testDangerouslySetInnerHTML () =
   withContainer (fun c ->
@@ -582,22 +596,24 @@ let testDangerouslySetInnerHTML () =
           React.Dom.render
             (div
                [| dangerouslySetInnerHTML
-                    (React.Dom.SafeString.make_unchecked "<lol></lol>") |]
-               [] )
-            (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<div><lol></lol></div>") )
+                    (React.Dom.SafeString.make_unchecked "<lol></lol>")
+               |]
+               [])
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<div><lol></lol></div>"))
 
 let testExternals () =
   let module JsComp = struct
-    external%component make : name:Js.js_string Js.t -> React.element
+    external%component make :
+      name:Js.js_string Js.t -> React.element
       = "require(\"./external\").Greeting"
   end in
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
             (JsComp.make ~name:(Js.string "John") ())
-            (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<span>Hey John</span>") )
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<span>Hey John</span>"))
 
 let testExternalChildren () =
   let module JsComp = struct
@@ -609,22 +625,24 @@ let testExternalChildren () =
       act (fun () ->
           React.Dom.render
             (JsComp.make
-               ~children:(Js.array [|em [|key "one"|] [React.string "John"]|])
-               () )
-            (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<span>Hey <em>John</em></span>") )
+               ~children:
+                 (Js.array [| em [| key "one" |] [ React.string "John" ] |])
+               ())
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<span>Hey <em>John</em></span>"))
 
 let testExternalNonFunction () =
   let module JsComp = struct
-    external%component make : name:Js.js_string Js.t -> React.element
+    external%component make :
+      name:Js.js_string Js.t -> React.element
       = "require(\"./external\").NonFunctionGreeting"
   end in
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
             (JsComp.make ~name:(Js.string "John") ())
-            (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<span>Hey John</span>") )
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<span>Hey John</span>"))
 
 let testAliasedChildren () =
   let module AliasedChildrenComponent = struct
@@ -634,11 +652,11 @@ let testAliasedChildren () =
       act (fun () ->
           React.Dom.render
             (AliasedChildrenComponent.make
-               ~children:[div [||] [int 1]; div [||] [int 3]]
-               () )
-            (Html.element c) ) ;
+               ~children:[ div [||] [ int 1 ]; div [||] [ int 3 ] ]
+               ())
+            (Html.element c));
       assert_equal c##.innerHTML
-        (Js.string "<div><div>1</div><div>3</div></div>") )
+        (Js.string "<div><div>1</div><div>3</div></div>"))
 
 let testWithId () =
   let module WithTestId = struct
@@ -646,76 +664,80 @@ let testWithId () =
       React.Children.map children (fun child ->
           React.clone_element child
             (Js.Unsafe.obj
-               [|("data-testid", Js.Unsafe.inject (Js.string id))|] ) )
+               [| ("data-testid", Js.Unsafe.inject (Js.string id)) |]))
   end in
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
-            (WithTestId.make ~id:"feed-toggle" ~children:[div [||] []] ())
-            (Html.element c) ) ;
+            (WithTestId.make ~id:"feed-toggle" ~children:[ div [||] [] ] ())
+            (Html.element c));
       assert_equal c##.innerHTML
-        (Js.string "<div data-testid=\"feed-toggle\"></div>") )
+        (Js.string "<div data-testid=\"feed-toggle\"></div>"))
 
 let testPropMaybeNone () =
   withContainer (fun c ->
       act (fun () ->
-          React.Dom.render (div [|maybe className None|] []) (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<div></div>") )
+          React.Dom.render (div [| maybe className None |] []) (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<div></div>"))
 
 let testPropMaybeSome () =
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
-            (div [|maybe className (Some "foo")|] [])
-            (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<div class=\"foo\"></div>") )
+            (div [| maybe className (Some "foo") |] [])
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<div class=\"foo\"></div>"))
 
 let testPropCustomString () =
   withContainer (fun c ->
       act (fun () ->
-          React.Dom.render (div [|Prop.string "foo" "bar"|] []) (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<div foo=\"bar\"></div>") )
+          React.Dom.render
+            (div [| Prop.string "foo" "bar" |] [])
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<div foo=\"bar\"></div>"))
 
 let testPropCustomBool () =
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
-            (div [|Prop.bool "disabled" true|] [])
-            (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<div disabled=\"\"></div>") )
+            (div [| Prop.bool "disabled" true |] [])
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<div disabled=\"\"></div>"))
 
 let testPropCustomInt () =
   withContainer (fun c ->
       act (fun () ->
-          React.Dom.render (div [|Prop.int "foo" 42|] []) (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<div foo=\"42\"></div>") )
+          React.Dom.render (div [| Prop.int "foo" 42 |] []) (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<div foo=\"42\"></div>"))
 
 let testPropCustomFloat () =
   withContainer (fun c ->
       act (fun () ->
-          React.Dom.render (div [|Prop.float_ "foo" 42.5|] []) (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<div foo=\"42.5\"></div>") )
+          React.Dom.render
+            (div [| Prop.float_ "foo" 42.5 |] [])
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<div foo=\"42.5\"></div>"))
 
 let testPropCustomAny () =
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
-            (div [|Prop.any "foo" (Js.array [|"bar"; "baz"|])|] [])
-            (Html.element c) ) ;
-      assert_equal c##.innerHTML (Js.string "<div foo=\"bar,baz\"></div>") )
+            (div [| Prop.any "foo" (Js.array [| "bar"; "baz" |]) |] [])
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<div foo=\"bar,baz\"></div>"))
 
 let testCustomElement () =
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
             (h "cool-element"
-               [|Prop.string "coolness" "max"|]
-               [h "chill" [|Prop.bool "data-out" true|] []] )
-            (Html.element c) ) ;
+               [| Prop.string "coolness" "max" |]
+               [ h "chill" [| Prop.bool "data-out" true |] [] ])
+            (Html.element c));
       assert_equal c##.innerHTML
         (Js.string
            "<cool-element coolness=\"max\"><chill \
-            data-out=\"true\"></chill></cool-element>" ) )
+            data-out=\"true\"></chill></cool-element>"))
 
 let testSvg () =
   withContainer (fun c ->
@@ -723,20 +745,22 @@ let testSvg () =
           React.Dom.render
             Svg.(
               svg
-                [|width "100"; height "100"|]
+                [| width "100"; height "100" |]
                 [ circle
                     [| cx "50"
                      ; cy "50"
                      ; strokeWidth "2"
                      ; stroke "magenta"
-                     ; fill "pink" |]
-                    [] ])
-            (Html.element c) ) ;
+                     ; fill "pink"
+                    |]
+                    []
+                ])
+            (Html.element c));
       assert_equal c##.innerHTML
         (Js.string
            "<svg width=\"100\" height=\"100\"><circle cx=\"50\" cy=\"50\" \
             stroke-width=\"2\" stroke=\"magenta\" \
-            fill=\"pink\"></circle></svg>" ) )
+            fill=\"pink\"></circle></svg>"))
 
 let basic =
   "basic"
@@ -744,61 +768,70 @@ let basic =
        ; "testReact" >:: testReact
        ; "testKey" >:: testKeys
        ; "testOptionalPropsUppercase" >:: testOptionalPropsUppercase
-       ; "testOptionalPropsLowercase" >:: testOptionalPropsLowercase ]
+       ; "testOptionalPropsLowercase" >:: testOptionalPropsLowercase
+       ]
 
-let context = "context" >::: ["testContext" >:: testContext]
+let context = "context" >::: [ "testContext" >:: testContext ]
 
 let use_effect =
   "use_effect"
   >::: [ "use_effect_always" >:: test_use_effect_always
        ; "use_effect_once" >:: test_use_effect_once
-       ; "use_effect2" >:: test_use_effect2 ]
+       ; "use_effect2" >:: test_use_effect2
+       ]
 
 let use_callback =
   "use_callback"
   >::: [ "use_callback1" >:: testUseCallback1
-       ; "use_callback4" >:: testUseCallback4 ]
+       ; "use_callback4" >:: testUseCallback4
+       ]
 
 let use_state =
   "use_state"
   >::: [ "use_state" >:: testUseState
-       ; "useStateUpdaterReference" >:: testUseStateUpdaterReference ]
+       ; "useStateUpdaterReference" >:: testUseStateUpdaterReference
+       ]
 
 let use_reducer =
   "use_reducer"
   >::: [ "use_reducer" >:: testUseReducer
        ; "use_reducer_with_map_state" >:: testUseReducerWithMapState
-       ; "use_reducerDispatchReference" >:: testUseReducerDispatchReference ]
+       ; "use_reducerDispatchReference" >:: testUseReducerDispatchReference
+       ]
 
 let memoization =
   "memo"
   >::: [ "use_memo1" >:: testUseMemo1
        ; "memo" >:: testMemo
-       ; "memoCustomCompareProps" >:: testMemoCustomCompareProps ]
+       ; "memoCustomCompareProps" >:: testMemoCustomCompareProps
+       ]
 
 let refs =
   "refs"
   >::: [ "create_ref" >:: testCreateRef
        ; "forward_ref" >:: testForwardRef
-       ; "use_ref" >:: testUseRef ]
+       ; "use_ref" >:: testUseRef
+       ]
 
 let children =
   "children"
   >::: [ "mapWithIndex" >:: testChildrenMapWithIndex
        ; "nonListChildren" >:: testNonListChildren
        ; "aliasedChildren" >:: testAliasedChildren
-       ; "testWithId" >:: testWithId ]
+       ; "testWithId" >:: testWithId
+       ]
 
-let fragments = "fragments" >::: ["basic" >:: testFragment]
+let fragments = "fragments" >::: [ "basic" >:: testFragment ]
 
 let dangerouslySetInnerHTML =
-  "dangerouslySetInnerHTML" >::: ["basic" >:: testDangerouslySetInnerHTML]
+  "dangerouslySetInnerHTML" >::: [ "basic" >:: testDangerouslySetInnerHTML ]
 
 let externals =
   "externals"
   >::: [ "basic" >:: testExternals
        ; "children" >:: testExternalChildren
-       ; "non-function" >:: testExternalNonFunction ]
+       ; "non-function" >:: testExternalNonFunction
+       ]
 
 let props =
   "props"
@@ -808,11 +841,11 @@ let props =
        ; "custom-bool" >:: testPropCustomBool
        ; "custom-int" >:: testPropCustomInt
        ; "custom-float" >:: testPropCustomFloat
-       ; "custom-any" >:: testPropCustomAny ]
+       ; "custom-any" >:: testPropCustomAny
+       ]
 
-let elements = "elements" >::: ["custom" >:: testCustomElement]
-
-let svg = "svg" >::: ["basic" >:: testSvg]
+let elements = "elements" >::: [ "custom" >:: testCustomElement ]
+let svg = "svg" >::: [ "basic" >:: testSvg ]
 
 let suite =
   "ocaml"
@@ -830,4 +863,5 @@ let suite =
        ; externals
        ; props
        ; elements
-       ; svg ]
+       ; svg
+       ]


### PR DESCRIPTION
This started with me wanting to pin `ocamlformat` to a specific version because #154 failed CI despite not failing locally because of a new version introducing a different. Then I went on to unify all the `.ocamlformat` files into one project-wide configuration, and finally added some tweaks to it that I've found to work well, because I found the code I added in #154 got absolutely butchered compared to the version I have in my own project.

For comparison:

```ml
let use_effect ~on f =
  let last_value = React.use_ref on in

  (* runs initially *)
  React.use_effect0 (fun () ->
      f ();
      None);

  (* runs always *)
  React.use_effect (fun () ->
      if on <> React.Ref.current last_value then begin
        React.Ref.set_current last_value on;
        f ()
      end;
      None)

```

```ml
let use_effect ~on f =
  let last_value = Core.use_ref on in
  Core.use_effect_once (fun () -> f () ; None) ;
  Core.use_effect_always (fun () ->
      if on <> Core.Ref.current last_value then (
        Core.Ref.set_current last_value on ;
        f () ) ;
      None )
```

The reasoning for the configuration choices is as follows:

- `profile = default` - I find both `default` and `ocamlformat` to be pretty inconsistent, `ocamlformat` more so than `default`, and actually prefer `janestreet` I think, if not for one notable exception: that it doesn't preserve single blank lines in function definitions, which I find absolutely essential for grouping. And there's unfortunately no configuration option for that. Therefore `default` seems like the more sensible baseline.
- `break-separators = before` and `dock-collection-brackets = false` - These put the delimiters and separators of lists, records etc. in front of the items, and in the same column, i.e. Haskell/Elm-style. This makes line-based editing easier while also being more compact, and arguably more readable (once familiar with the style). The downside is that it's quite unfamiliar to people coming from JavaScript and similar languages.
- `exp-grouping = preserve` - Simply enables the use of `begin/end` instead of parentheses, in rare cases where that's more readable.
- `type-decl = sparse` - Always formats variants and records with each item on a separate line instead of trying to fit them on a single line. This is more consistent, easier to read, and makes line-based editing much easier.
- `break-fun-decl = fit-or-vertical` and `break-fun-sig = fit-or-vertical` - Puts function arguments on separate lines if they can't all fit on a single line, instead of trying to fit as much as possible on each line. Easier to read and makes line-based editing easier.

Feel free to disagree though! I find all of these add value individually, and would rather have either one of them than none at all.

Also, this obviously can't be merged unless all other PRs have already been merged, or it would create a huge mess. So Draft for now.