### PR TITLE
dsl: add classNames helper to Html and Svg props

### DIFF
--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -16,6 +16,7 @@ module Prop = struct
   let accessKey = string "accessKey"
   let className = string "className" (* substitute for "class" *)
 
+  let classNames names = className (String.concat " " names)
   let contentEditable = bool "contentEditable"
   let contextMenu = string "contextMenu"
   let dir = string "dir" (* "ltr", "rtl" or "auto" *)

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -22,6 +22,7 @@ module Prop : sig
   val defaultValue : string -> t
   val accessKey : string -> t
   val className : string -> t
+  val classNames : string list -> t
   val contentEditable : bool -> t
   val contextMenu : string -> t
   val dir : string -> t

--- a/lib/dom_svg.ml
+++ b/lib/dom_svg.ml
@@ -31,6 +31,7 @@ module Prop = struct
   let capHeight = string_prop "capHeight"
   let className = string_prop "className" (* substitute for "class" *)
 
+  let classNames names = className (String.concat " " names)
   let clip = string_prop "clip"
   let clipPath = string_prop "clipPath"
   let clipPathUnits = string_prop "clipPathUnits"

--- a/lib/dom_svg.mli
+++ b/lib/dom_svg.mli
@@ -40,6 +40,7 @@ module Prop : sig
   val calcMode : string -> t
   val capHeight : string -> t
   val className : string -> t
+  val classNames : string list -> t
   val clip : string -> t
   val clipPath : string -> t
   val clipPathUnits : string -> t


### PR DESCRIPTION
I've found it very useful to be able to pass a list of class names, rather than having to build a class string manually. This is the simplest version of that, but I could imagine something more sophisticated to support optional class names for example.

Currently, to pass an optional class name you'd have to do something like:

```ml
div [| classNames [ "widget"; if disabled then "disabled" else "" ] |] [ ... ]
```

but could perhaps instead be:

```ml
div [| classNames [ "widget"; class_if disabled "disabled" ] |] [ ... ]
```

But this could be added in a way that maintains backwards-compatibility, so not all that important to do now I think.