### PR TITLE
dsl: expose ARIA attributes

### DIFF
--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -1,4 +1,6 @@
 module Prop : sig
+  include module type of Dom_aria_attributes
+
   type t = Dom_dsl_core.Prop.t
 
   (** Common *)

--- a/lib/dom_svg.mli
+++ b/lib/dom_svg.mli
@@ -1,4 +1,6 @@
 module Prop : sig
+  include module type of Dom_aria_attributes
+
   type t = Dom_dsl_core.Prop.t
 
   (** Common *)


### PR DESCRIPTION
Includes the ARIA attributes that were added in #145 in the `Dom_html` and `Dom_svg` module interfaces, so that they can actually be used! :wink: 