### PR TITLE
Relax upper bounds to allow OCaml 4.14 and dune 3

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,8 +20,8 @@
  (synopsis "Bindings to ReactJS for js_of_ocaml, including JSX ppx")
  (depends
   ;; General system dependencies
-  (dune (and (>= 2) (< 3)))
-  (ocaml (and (>= 4.10.0) (< 4.14.0)))
+  (dune (and (>= 2) (< 4)))
+  (ocaml (and (>= 4.10.0) (< 5.0.0)))
 
   (js_of_ocaml (and (>= 4.0.0) (<= 5.0.0)))
   (gen_js_api (and (>= 1.0.8) (< 1.1.0)))

--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -7,8 +7,8 @@ license: "MIT"
 homepage: "https://github.com/ml-in-barcelona/jsoo-react"
 bug-reports: "https://github.com/ml-in-barcelona/jsoo-react/issues"
 depends: [
-  "dune" {>= "2.7" & >= "2" & < "3"}
-  "ocaml" {>= "4.10.0" & < "4.14.0"}
+  "dune" {>= "2.7" & >= "2" & < "4"}
+  "ocaml" {>= "4.10.0" & < "5.0.0"}
   "js_of_ocaml" {>= "4.0.0" & <= "5.0.0"}
   "gen_js_api" {>= "1.0.8" & < "1.1.0"}
   "ppxlib" {>= "0.23.0"}


### PR DESCRIPTION
We've yet to adapt our Gobview project to all the other changes in jsoo-react in the meanwhile, but jsoo-react seems to build fine on OCaml 4.14 and dune 3.