### PR TITLE
A few ergonomic additions for dealing with conditional rendering

### DIFF
--- a/lib/dom_dsl_core.ml
+++ b/lib/dom_dsl_core.ml
@@ -36,4 +36,5 @@ module Common = struct
   let string = Core.string
   let int = Core.int
   let float = Core.float
+  let maybe f = function Some value -> f value | None -> none
 end

--- a/lib/dom_dsl_core.ml
+++ b/lib/dom_dsl_core.ml
@@ -32,6 +32,7 @@ module Common = struct
   end
 
   let fragment children = Core.Fragment.make ~children ()
+  let none = fragment []
   let string = Core.string
   let int = Core.int
   let float = Core.float

--- a/lib/dom_dsl_core.mli
+++ b/lib/dom_dsl_core.mli
@@ -25,6 +25,7 @@ module Common : sig
   end
 
   val fragment : Core.element list -> Core.element
+  val none : Core.element
   val string : string -> Core.element
   val int : int -> Core.element
   val float : float -> Core.element

--- a/lib/dom_dsl_core.mli
+++ b/lib/dom_dsl_core.mli
@@ -29,4 +29,5 @@ module Common : sig
   val string : string -> Core.element
   val int : int -> Core.element
   val float : float -> Core.element
+  val maybe : ('a -> Core.element) -> 'a option -> Core.element
 end

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -232,6 +232,7 @@ module Context : sig
 end
 
 val fragment : Core.element list -> Core.element
+val none : Core.element
 val string : string -> Core.element
 val int : int -> Core.element
 val float : float -> Core.element

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -236,6 +236,7 @@ val none : Core.element
 val string : string -> Core.element
 val int : int -> Core.element
 val float : float -> Core.element
+val maybe : ('a -> Core.element) -> 'a option -> Core.element
 val h : string -> Prop.t array -> Core.element list -> Core.element
 
 (** HTML elements *)

--- a/lib/dom_svg.mli
+++ b/lib/dom_svg.mli
@@ -281,6 +281,7 @@ module Context : sig
 end
 
 val fragment : Core.element list -> Core.element
+val none : Core.element
 val string : string -> Core.element
 val int : int -> Core.element
 val float : float -> Core.element

--- a/lib/dom_svg.mli
+++ b/lib/dom_svg.mli
@@ -285,6 +285,7 @@ val none : Core.element
 val string : string -> Core.element
 val int : int -> Core.element
 val float : float -> Core.element
+val maybe : ('a -> Core.element) -> 'a option -> Core.element
 val h : string -> Prop.t array -> Core.element list -> Core.element
 
 (** SVG elements *)

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -943,9 +943,7 @@ let jsxMapper () =
         match str_label with
         | Str_label.Optional str ->
             [%expr
-              maybe
-                [%e Exp.ident { loc; txt = Ldot (Lident "Prop", str) }]
-                [%e value]]
+              Prop.(maybe [%e Exp.ident { loc; txt = Lident str }]) [%e value]]
         | Labelled str ->
             [%expr
               [%e Exp.ident { loc; txt = Ldot (Lident "Prop", str) }] [%e value]]

--- a/ppx/test/pp_reason.expected
+++ b/ppx/test/pp_reason.expected
@@ -778,8 +778,9 @@ let make =
         ((fun ?isDisabled ->
             ((fun ?onClick ->
                 (((button
-                     [|(Prop.name name);(maybe Prop.onClick onClick);(
-                       Prop.disabled isDisabled)|] [])
+                     [|(Prop.name name);(((let open Prop in maybe onClick))
+                                           onClick);(Prop.disabled isDisabled)|]
+                     [])
                 [@reason.preserve_braces ]) : React.element))
             [@warning "-16"]))
         [@warning "-16"]))

--- a/test/test_ml.ml
+++ b/test/test_ml.ml
@@ -99,7 +99,7 @@ let testOptionalPropsUppercase () =
 let testOptionalPropsLowercase () =
   let module LinkWithMaybeHref = struct
     (* NOTE: collision caused by namespace pollution *)
-    let%component make ~href = a [| maybe Prop.href href |] []
+    let%component make ~href = a [| Prop.(maybe href) href |] []
   end in
   withContainer (fun c ->
       act (fun () ->
@@ -821,14 +821,16 @@ let testWithId () =
 let testPropMaybeNone () =
   withContainer (fun c ->
       act (fun () ->
-          React.Dom.render (div [| maybe className None |] []) (Html.element c));
+          React.Dom.render
+            (div [| Prop.(maybe className) None |] [])
+            (Html.element c));
       assert_equal c##.innerHTML (Js.string "<div></div>"))
 
 let testPropMaybeSome () =
   withContainer (fun c ->
       act (fun () ->
           React.Dom.render
-            (div [| maybe className (Some "foo") |] [])
+            (div [| Prop.(maybe className) (Some "foo") |] [])
             (Html.element c));
       assert_equal c##.innerHTML (Js.string "<div class=\"foo\"></div>"))
 
@@ -882,6 +884,22 @@ let testCustomElement () =
         (Js.string
            "<cool-element coolness=\"max\"><chill \
             data-out=\"true\"></chill></cool-element>"))
+
+let testElementMaybeNone () =
+  withContainer (fun c ->
+      act (fun () ->
+          React.Dom.render
+            (maybe (fun cls -> div [| className cls |] []) None)
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string ""))
+
+let testElementMaybeSome () =
+  withContainer (fun c ->
+      act (fun () ->
+          React.Dom.render
+            (maybe (fun cls -> div [| className cls |] []) (Some "foo"))
+            (Html.element c));
+      assert_equal c##.innerHTML (Js.string "<div class=\"foo\"></div>"))
 
 let testSvg () =
   withContainer (fun c ->
@@ -1000,7 +1018,13 @@ let props =
        ; "custom-any" >:: testPropCustomAny
        ]
 
-let elements = "elements" >::: [ "custom" >:: testCustomElement ]
+let elements =
+  "elements"
+  >::: [ "custom" >:: testCustomElement
+       ; "maybe-none" >:: testElementMaybeNone
+       ; "maybe-some" >:: testElementMaybeSome
+       ]
+
 let svg = "svg" >::: [ "basic" >:: testSvg ]
 
 let suite =


### PR DESCRIPTION
The addition of `maybe` for elements is a slightly breaking change, as it shadows `maybe` for `Prop`. It's a very low effort fix though.

Another ergonomic addition I've considered is making the attributes optional with an `~a` labeled argument, as in tyxml, and the addition of short-hand labeled arguments for `id` and `className` attributes, as I've noticed that I very rarely use any attributes other than `className`, which is used quite often. But I'm thinking it might be better to keep the DSL simple and add a ppx layer for even better ergonomics instead without any runtime cost.