### PR TITLE
ppx: set display name on let%component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,4 @@ $(opam_file): dune-project ## Update the package dependencies when new deps are 
 
 init: ## Create a local opam switch and setups githooks
 	git config core.hooksPath .githooks
-	opam switch create . 4.10.0 --deps-only --with-test
+	opam switch create . --deps-only --with-test

--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
  (depends
   ;; General system dependencies
   (dune (and (>= 2) (< 4)))
-  (ocaml (and (>= 4.10.0) (< 5.0.0)))
+  (ocaml (and (>= 4.12.0) (< 5.0.0)))
 
   (js_of_ocaml (and (>= 4.0.0) (<= 5.0.0)))
   (gen_js_api (and (>= 1.0.8) (< 1.1.0)))

--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ml-in-barcelona/jsoo-react"
 bug-reports: "https://github.com/ml-in-barcelona/jsoo-react/issues"
 depends: [
   "dune" {>= "2.7" & >= "2" & < "4"}
-  "ocaml" {>= "4.10.0" & < "5.0.0"}
+  "ocaml" {>= "4.12.0" & < "5.0.0"}
   "js_of_ocaml" {>= "4.0.0" & <= "5.0.0"}
   "gen_js_api" {>= "1.0.8" & < "1.1.0"}
   "ppxlib" {>= "0.23.0"}

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -873,6 +873,7 @@ let process_value_binding ~pstr_loc ~inside_component ~mapper binding =
              (let loc = gloc in
               [%expr
                 fun () ->
+                  React.set_display_name [%e expression] __FUNCTION__;
                   React.create_element [%e expression]
                     [%e
                       Exp.apply ~loc

--- a/ppx/test/pp_ocaml.expected
+++ b/ppx/test/pp_ocaml.expected
@@ -41,7 +41,9 @@ let make =
                  (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
     fun ?name ->
       fun ?key ->
-        fun () -> React.create_element make (make_props ?key ?name ()))
+        fun () ->
+          React.set_display_name make __FUNCTION__;
+          React.create_element make (make_props ?key ?name ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -87,7 +89,9 @@ let make =
                      (fun x -> x#children)) in
     fun ~children ->
       fun ?key ->
-        fun () -> React.create_element make (make_props ?key ~children ()))
+        fun () ->
+          React.set_display_name make __FUNCTION__;
+          React.create_element make (make_props ?key ~children ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -131,7 +135,9 @@ let make =
                      (fun x -> x#children)) in
     fun ~children ->
       fun ?key ->
-        fun () -> React.create_element make (make_props ?key ~children ()))
+        fun () ->
+          React.set_display_name make __FUNCTION__;
+          React.create_element make (make_props ?key ~children ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -177,7 +183,9 @@ let make =
                      (fun x -> x#children)) () in
     fun ~children ->
       fun ?key ->
-        fun () -> React.create_element make (make_props ?key ~children ()))
+        fun () ->
+          React.set_display_name make __FUNCTION__;
+          React.create_element make (make_props ?key ~children ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -218,7 +226,9 @@ let make =
                  (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
     fun ?name ->
       fun ?key ->
-        fun () -> React.create_element make (make_props ?key ?name ()))
+        fun () ->
+          React.set_display_name make __FUNCTION__;
+          React.create_element make (make_props ?key ?name ()))
     [@merlin.hide ])
 let make =
   let make_props : ?key:string -> unit -> <  >  Js_of_ocaml.Js.t =
@@ -233,7 +243,10 @@ let make =
                                                                    ] in
   let make () = (div [||] [] : React.element) in
   ((let make (Props : <  >  Js_of_ocaml.Js.t) = make () in
-    fun ?key -> fun () -> React.create_element make (make_props ?key ()))
+    fun ?key ->
+      fun () ->
+        React.set_display_name make __FUNCTION__;
+        React.create_element make (make_props ?key ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -268,7 +281,9 @@ let make =
                 (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#foo)) in
     fun ~foo ->
       fun ?key ->
-        fun () -> React.create_element make (make_props ?key ~foo ()))
+        fun () ->
+          React.set_display_name make __FUNCTION__;
+          React.create_element make (make_props ?key ~foo ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -306,7 +321,9 @@ let make =
                 (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#foo)) in
     fun ~foo ->
       fun ?key ->
-        fun () -> React.create_element make (make_props ?key ~foo ()))
+        fun () ->
+          React.set_display_name make __FUNCTION__;
+          React.create_element make (make_props ?key ~foo ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -350,7 +367,9 @@ let make =
                 (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#bar)) in
     fun ~bar ->
       fun ?key ->
-        fun () -> React.create_element make (make_props ?key ~bar ()))
+        fun () ->
+          React.set_display_name make __FUNCTION__;
+          React.create_element make (make_props ?key ~bar ()))
     [@merlin.hide ])
 let make =
   let make_props

--- a/ppx/test/pp_reason.expected
+++ b/ppx/test/pp_reason.expected
@@ -51,7 +51,9 @@ let make =
                  (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
     fun ?name ->
       fun ?key ->
-        fun () -> React.create_element make (make_props ?key ?name ()))
+        fun () ->
+          React.set_display_name make __FUNCTION__;
+          React.create_element make (make_props ?key ?name ()))
     [@merlin.hide ])
 let make =
   let make_props
@@ -114,7 +116,9 @@ let make =
     fun ~a ->
       fun ~b ->
         fun ?key ->
-          fun () -> React.create_element make (make_props ?key ~b ~a ()))
+          fun () ->
+            React.set_display_name make __FUNCTION__;
+            React.create_element make (make_props ?key ~b ~a ()))
     [@merlin.hide ])
 module External =
   struct
@@ -220,7 +224,9 @@ module Bar =
         fun ~a ->
           fun ~b ->
             fun ?key ->
-              fun () -> React.create_element make (make_props ?key ~b ~a ()))
+              fun () ->
+                React.set_display_name make __FUNCTION__;
+                React.create_element make (make_props ?key ~b ~a ()))
         [@merlin.hide ])
     let component =
       let component_props
@@ -286,6 +292,7 @@ module Bar =
           fun ~b ->
             fun ?key ->
               fun () ->
+                React.set_display_name component __FUNCTION__;
                 React.create_element component
                   (component_props ?key ~b ~a ()))
         [@merlin.hide ])
@@ -357,7 +364,9 @@ module Func(M:X_int) =
         fun ~a ->
           fun ~b ->
             fun ?key ->
-              fun () -> React.create_element make (make_props ?key ~b ~a ()))
+              fun () ->
+                React.set_display_name make __FUNCTION__;
+                React.create_element make (make_props ?key ~b ~a ()))
         [@merlin.hide ])
   end
 module ForwardRef =
@@ -393,7 +402,9 @@ module ForwardRef =
                fun theRef -> make theRef) in
         fun ?key ->
           fun ?ref ->
-            fun () -> React.create_element make (make_props ?ref ?key ()))
+            fun () ->
+              React.set_display_name make __FUNCTION__;
+              React.create_element make (make_props ?ref ?key ()))
         [@merlin.hide ])
   end
 module Memo =
@@ -443,7 +454,9 @@ module Memo =
                        (fun x -> x#a))) in
         fun ~a ->
           fun ?key ->
-            fun () -> React.create_element make (make_props ?key ~a ()))
+            fun () ->
+              React.set_display_name make __FUNCTION__;
+              React.create_element make (make_props ?key ~a ()))
         [@merlin.hide ])
   end
 module MemoCustomCompareProps =
@@ -494,7 +507,9 @@ module MemoCustomCompareProps =
             ~compare:(fun prevPros -> fun nextProps -> false) in
         fun ~a ->
           fun ?key ->
-            fun () -> React.create_element make (make_props ?key ~a ()))
+            fun () ->
+              React.set_display_name make __FUNCTION__;
+              React.create_element make (make_props ?key ~a ()))
         [@merlin.hide ])
   end
 let fragment foo = ((React.Fragment.make ~children:[foo] ())[@bla ])
@@ -650,6 +665,7 @@ let make =
       fun ~children ->
         fun ?key ->
           fun () ->
+            React.set_display_name make __FUNCTION__;
             React.create_element make (make_props ?key ~children ~title ()))
     [@merlin.hide ])
 let t = FancyButton.make ~ref:buttonRef ~children:[div [||] []] ()
@@ -715,6 +731,7 @@ let make =
       fun ?key ->
         fun ?ref ->
           fun () ->
+            React.set_display_name make __FUNCTION__;
             React.create_element make (make_props ?ref ?key ~children ()))
     [@merlin.hide ])
 let testAttributes =
@@ -831,6 +848,7 @@ let make =
         fun ?onClick ->
           fun ?key ->
             fun () ->
+              React.set_display_name make __FUNCTION__;
               React.create_element make
                 (make_props ?key ?onClick ?isDisabled ~name ()))
     [@merlin.hide ])
@@ -880,5 +898,7 @@ let make =
                  (Props : < .. >  Js_of_ocaml.Js.t) (fun x -> x#name)) in
     fun ?name ->
       fun ?key ->
-        fun () -> React.create_element make (make_props ?key ?name ()))
+        fun () ->
+          React.set_display_name make __FUNCTION__;
+          React.create_element make (make_props ?key ?name ()))
     [@merlin.hide ])


### PR DESCRIPTION
Not sure how to test it, but this produces react stack traces such as this:

```
The above error occurred in the <Dune__exe__HelloWorldOCaml.Foo.make.(fun)> component:
    in Dune__exe__HelloWorldOCaml.Foo.make.(fun)
    in div (created by Dune__exe__Main.make.(fun))
    in div (created by Dune__exe__Main.make.(fun))
    in div (created by Dune__exe__Main.make.(fun))
    in div (created by Dune__exe__Main.make.(fun))
    in Dune__exe__Main.make.(fun)
```

Also note that the lower bound on OCaml was bumped to 4.12 to be able to use `__FUNCTION__`