### PR TITLE
chore(deps): relax `gen_js_api` constraint to allow ^1.1.0

### DIFF
--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "2.7" & >= "2" & < "4"}
   "ocaml" {>= "4.10.0" & < "5.0.0"}
   "js_of_ocaml" {>= "4.0.0" & <= "5.0.0"}
-  "gen_js_api" {>= "1.0.8" & < "1.1.0"}
+  "gen_js_api" {>= "1.0.8" & < "1.2.0"}
   "ppxlib" {>= "0.23.0"}
   "webtest" {with-test}
   "webtest-js" {with-test}


### PR DESCRIPTION
I tested it with 1.1.0 and everything seemed to build correctly -- let me know if there's anything else you want me to do!