### PR TITLE
OPAM: upgrade Js_of_ocaml to 5.1.0

### DIFF
--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ml-in-barcelona/jsoo-react/issues"
 depends: [
   "dune" {>= "2.7" & >= "2" & < "4"}
   "ocaml" {>= "4.12.0" & < "5.0.0"}
-  "js_of_ocaml" {>= "4.0.0" & <= "5.0.0"}
+  "js_of_ocaml" {>= "4.0.0" & < "5.2.0"}
   "gen_js_api" {>= "1.0.8" & < "1.2.0"}
   "ppxlib" {>= "0.23.0"}
   "webtest" {with-test}


### PR DESCRIPTION
5.0.0 was previously "supported", and [it doesn't look like there are any breaking changes in 5.1.0](https://github.com/ocsigen/js_of_ocaml/blob/master/CHANGES.md).

It does look like [there might be an issue with using jsoo-react with OCaml 5 and `--effects` with JSOO](https://discuss.ocaml.org/t/dealing-with-joo-tramp-joo-args/11630/6), but the OPAM file restricts the compiler be between 4.12 and 5.0 (exclusive), so that can be fixed in another PR.