### PR TITLE
Prefix Option and Array with Stdlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,4 @@ $(opam_file): dune-project ## Update the package dependencies when new deps are 
 
 init: ## Create a local opam switch and setups githooks
 	git config core.hooksPath .githooks
-	opam switch create . --deps-only --with-test
+	opam switch create . 4.12.1 --deps-only --with-test

--- a/dune-project
+++ b/dune-project
@@ -23,8 +23,8 @@
   (dune (and (>= 2) (< 4)))
   (ocaml (and (>= 4.12.0) (< 5.0.0)))
 
-  (js_of_ocaml (and (>= 4.0.0) (<= 5.0.0)))
-  (gen_js_api (and (>= 1.0.8) (< 1.1.0)))
+  (js_of_ocaml (and (>= 4.0.0) (< 5.2.0)))
+  (gen_js_api (and (>= 1.0.8) (< 1.2.0)))
   (ppxlib (>= 0.23.0))
 
   ;; Test dependencies
@@ -35,10 +35,9 @@
 
   ;; Dev dependencies, using with-test so that consumers don't install them (until package is released in opam)
   (ocamlformat (and (= 0.21.0) :with-test))
-  (reason :with-test)
+  (reason (and (= 3.8.2) :with-test))
 
   ;; Example dependencies, using with-test so that consumers don't install them (until package is released in opam)
   (ppx_blob :with-test)
   (js_of_ocaml-lwt :with-test)
-
 ))

--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -17,7 +17,7 @@ depends: [
   "js_of_ocaml-ppx" {with-test}
   "conf-npm" {with-test}
   "ocamlformat" {= "0.21.0" & with-test}
-  "reason" {with-test}
+  "reason" {= "3.8.2" & with-test}
   "ppx_blob" {with-test}
   "js_of_ocaml-lwt" {with-test}
   "odoc" {with-doc}

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -264,7 +264,8 @@ let rec make_funs_for_make_props_body list args =
 let makeAttributeValue ~loc ~isOptional (type_ : Html.attributeType) value =
   match (type_, isOptional) with
   | String, true ->
-      [%expr Option.map Js_of_ocaml.Js.string ([%e value] : string option)]
+      [%expr
+        Stdlib.Option.map Js_of_ocaml.Js.string ([%e value] : string option)]
   | String, false -> [%expr Js_of_ocaml.Js.string ([%e value] : string)]
   | Int, false -> [%expr ([%e value] : int)]
   | Int, true -> [%expr ([%e value] : int option)]
@@ -340,7 +341,7 @@ let make_js_props_obj ~loc named_arg_list_with_key_and_ref =
           [%e Exp.constant ~loc (Const.string label_str)]
           , inject
               (Js_of_ocaml.Js.Optdef.option
-                 (Option.map Js_of_ocaml.Js.string [%e id]))]
+                 (Stdlib.Option.map Js_of_ocaml.Js.string [%e id]))]
     | "ref" ->
         [%expr
           [%e Exp.constant ~loc (Const.string label_str)]
@@ -359,14 +360,16 @@ let make_js_props_obj ~loc named_arg_list_with_key_and_ref =
 let rec get_wrap_fn_for_type ~loc typ =
   match typ with
   | Some [%type: React.element list] ->
-      Some [%expr fun v -> Js_of_ocaml.Js.array (Array.of_list v)]
+      Some [%expr fun v -> Js_of_ocaml.Js.array (Stdlib.Array.of_list v)]
   | Some [%type: string] -> Some [%expr Js_of_ocaml.Js.string]
   | Some [%type: bool] -> Some [%expr Js_of_ocaml.Js.bool]
   | Some [%type: [%t? inner_typ] array] ->
       Some
         (match get_wrap_fn_for_type ~loc (Some inner_typ) with
         | Some inner_wrapf ->
-            [%expr fun v -> Js_of_ocaml.Js.array (Array.map [%e inner_wrapf] v)]
+            [%expr
+              fun v ->
+                Js_of_ocaml.Js.array (Stdlib.Array.map [%e inner_wrapf] v)]
         | None -> [%expr Js_of_ocaml.Js.array])
   | _ -> None
 
@@ -388,7 +391,7 @@ let make_external_js_props_obj ~loc named_arg_list =
           [%e Exp.constant ~loc (Const.string l)]
           , inject
               (Js_of_ocaml.Js.Optdef.option
-                 (Option.map [%e wrapf] [%e label_ident]))]
+                 (Stdlib.Option.map [%e wrapf] [%e label_ident]))]
     | Optional l, None ->
         [%expr
           [%e Exp.constant ~loc (Const.string l)]

--- a/ppx/test/pp_ocaml.expected
+++ b/ppx/test/pp_ocaml.expected
@@ -16,11 +16,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("name",
-                                                                    (
-                                                                    inject
-                                                                    name))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("name", (inject name))|][@@merlin.hide ] in
   let make =
     ((fun ?(name= "") ->
         (div [||] [React.string ("Hello " ^ name)] : React.element))
@@ -59,11 +56,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("children",
-                                                                    (
-                                                                    inject
-                                                                    children))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("children", (inject children))|][@@merlin.hide ] in
   let make =
     ((fun ~children:(first, second) ->
         (div [||] [first; second] : React.element))
@@ -105,11 +99,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("children",
-                                                                    (
-                                                                    inject
-                                                                    children))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("children", (inject children))|][@@merlin.hide ] in
   let make = ((fun ~children:kids -> (div [||] kids : React.element))
     [@warning "-16"]) in
   ((let make
@@ -149,11 +140,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("children",
-                                                                    (
-                                                                    inject
-                                                                    children))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("children", (inject children))|][@@merlin.hide ] in
   let make =
     ((fun ~children:(first, second) ->
         fun () -> (div [||] [first; second] : React.element))
@@ -195,11 +183,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("name",
-                                                                    (
-                                                                    inject
-                                                                    name))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("name", (inject name))|][@@merlin.hide ] in
   let make = ((fun ?(name= "") -> (div [||] [name] : React.element))
     [@warning "-16"]) in
   ((let make
@@ -229,8 +214,8 @@ let make =
             [|("key",
                 (inject
                    (Js_of_ocaml.Js.Optdef.option
-                      (Option.map Js_of_ocaml.Js.string key))))|][@@merlin.hide
-                                                                   ] in
+                      (Stdlib.Option.map Js_of_ocaml.Js.string key))))|]
+    [@@merlin.hide ] in
   let make () = (div [||] [] : React.element) in
   ((let make (Props : <  >  Js_of_ocaml.Js.t) = make () in
     fun ?key -> fun () -> React.create_element make (make_props ?key ()))
@@ -249,11 +234,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("foo",
-                                                                    (
-                                                                    inject
-                                                                    foo))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("foo", (inject foo))|][@@merlin.hide ] in
   let make (type a) ~foo:(foo : a)  = (div [||] [] : _) in
   ((let make
       (Props : < foo: a Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t) =
@@ -285,11 +267,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("foo",
-                                                                    (
-                                                                    inject
-                                                                    foo))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("foo", (inject foo))|][@@merlin.hide ] in
   let make (type a) = (fun ~foo:_ -> div [||] [] : foo:a -> _) in
   ((let make
       (Props :
@@ -324,11 +303,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("bar",
-                                                                    (
-                                                                    inject
-                                                                    bar))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("bar", (inject bar))|][@@merlin.hide ] in
   let make =
     ((fun ~bar:(bar : int option) ->
         (div [||]
@@ -368,11 +344,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("name",
-                                                                    (
-                                                                    inject
-                                                                    name))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("name", (inject name))|][@@merlin.hide ] in
   fun ~name ->
     fun ?key ->
       fun () ->
@@ -396,11 +369,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("name",
-                                                                    (
-                                                                    inject
-                                                                    (Js_of_ocaml.Js.Optdef.option
-                                                                    name)))|]
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("name", (inject (Js_of_ocaml.Js.Optdef.option name)))|]
     [@@merlin.hide ] in
   fun ?name ->
     fun ?key ->
@@ -425,15 +395,12 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("names",
-                                                                    (
-                                                                    inject
-                                                                    ((fun v
-                                                                    ->
-                                                                    Js_of_ocaml.Js.array
-                                                                    (Array.map
-                                                                    Js_of_ocaml.Js.string
-                                                                    v)) names)))|]
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("names",
+                  (inject
+                     ((fun v ->
+                         Js_of_ocaml.Js.array
+                           (Stdlib.Array.map Js_of_ocaml.Js.string v)) names)))|]
     [@@merlin.hide ] in
   fun ~names ->
     fun ?key ->

--- a/ppx/test/pp_ocaml_dev.expected
+++ b/ppx/test/pp_ocaml_dev.expected
@@ -16,11 +16,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("name",
-                                                                    (
-                                                                    inject
-                                                                    name))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("name", (inject name))|][@@merlin.hide ] in
   let make =
     ((fun ?(name= "") ->
         (div [||] [React.string ("Hello " ^ name)] : React.element))
@@ -60,11 +57,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("children",
-                                                                    (
-                                                                    inject
-                                                                    children))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("children", (inject children))|][@@merlin.hide ] in
   let make =
     ((fun ~children:(first, second) ->
         (div [||] [first; second] : React.element))
@@ -107,11 +101,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("children",
-                                                                    (
-                                                                    inject
-                                                                    children))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("children", (inject children))|][@@merlin.hide ] in
   let make = ((fun ~children:kids -> (div [||] kids : React.element))
     [@warning "-16"]) in
   ((let make
@@ -152,11 +143,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("children",
-                                                                    (
-                                                                    inject
-                                                                    children))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("children", (inject children))|][@@merlin.hide ] in
   let make =
     ((fun ~children:(first, second) ->
         fun () -> (div [||] [first; second] : React.element))
@@ -199,11 +187,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("name",
-                                                                    (
-                                                                    inject
-                                                                    name))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("name", (inject name))|][@@merlin.hide ] in
   let make = ((fun ?(name= "") -> (div [||] [name] : React.element))
     [@warning "-16"]) in
   ((let make
@@ -234,8 +219,8 @@ let make =
             [|("key",
                 (inject
                    (Js_of_ocaml.Js.Optdef.option
-                      (Option.map Js_of_ocaml.Js.string key))))|][@@merlin.hide
-                                                                   ] in
+                      (Stdlib.Option.map Js_of_ocaml.Js.string key))))|]
+    [@@merlin.hide ] in
   let make () = (div [||] [] : React.element) in
   ((let make (Props : <  >  Js_of_ocaml.Js.t) = make () in
     React.set_display_name make __FUNCTION__;
@@ -255,11 +240,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("foo",
-                                                                    (
-                                                                    inject
-                                                                    foo))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("foo", (inject foo))|][@@merlin.hide ] in
   let make (type a) ~foo:(foo : a)  = (div [||] [] : _) in
   ((let make
       (Props : < foo: a Js_of_ocaml.Js.readonly_prop   >  Js_of_ocaml.Js.t) =
@@ -292,11 +274,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("foo",
-                                                                    (
-                                                                    inject
-                                                                    foo))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("foo", (inject foo))|][@@merlin.hide ] in
   let make (type a) = (fun ~foo:_ -> div [||] [] : foo:a -> _) in
   ((let make
       (Props :
@@ -332,11 +311,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("bar",
-                                                                    (
-                                                                    inject
-                                                                    bar))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("bar", (inject bar))|][@@merlin.hide ] in
   let make =
     ((fun ~bar:(bar : int option) ->
         (div [||]
@@ -377,11 +353,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("name",
-                                                                    (
-                                                                    inject
-                                                                    name))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("name", (inject name))|][@@merlin.hide ] in
   fun ~name ->
     fun ?key ->
       fun () ->
@@ -405,11 +378,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("name",
-                                                                    (
-                                                                    inject
-                                                                    (Js_of_ocaml.Js.Optdef.option
-                                                                    name)))|]
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("name", (inject (Js_of_ocaml.Js.Optdef.option name)))|]
     [@@merlin.hide ] in
   fun ?name ->
     fun ?key ->
@@ -434,15 +404,12 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("names",
-                                                                    (
-                                                                    inject
-                                                                    ((fun v
-                                                                    ->
-                                                                    Js_of_ocaml.Js.array
-                                                                    (Array.map
-                                                                    Js_of_ocaml.Js.string
-                                                                    v)) names)))|]
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("names",
+                  (inject
+                     ((fun v ->
+                         Js_of_ocaml.Js.array
+                           (Stdlib.Array.map Js_of_ocaml.Js.string v)) names)))|]
     [@@merlin.hide ] in
   fun ~names ->
     fun ?key ->

--- a/ppx/test/pp_reason.expected
+++ b/ppx/test/pp_reason.expected
@@ -14,11 +14,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("name",
-                                                                    (
-                                                                    inject
-                                                                    name))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("name", (inject name))|][@@merlin.hide ] in
   let make =
     ((fun ?(name= (("")[@reason.raw_literal ""])) ->
         (((React.Fragment.make
@@ -74,9 +71,8 @@ let make =
                 [|("key",
                     (inject
                        (Js_of_ocaml.Js.Optdef.option
-                          (Option.map Js_of_ocaml.Js.string key))));("b",
-                                                                    (inject b));
-                  ("a", (inject a))|][@@merlin.hide ] in
+                          (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                  ("b", (inject b));("a", (inject a))|][@@merlin.hide ] in
   let make =
     ((fun ~a ->
         ((fun ~b ->
@@ -139,7 +135,7 @@ module External =
                     [|("key",
                         (inject
                            (Js_of_ocaml.Js.Optdef.option
-                              (Option.map Js_of_ocaml.Js.string key))));
+                              (Stdlib.Option.map Js_of_ocaml.Js.string key))));
                       ("b", (inject (Js_of_ocaml.Js.string b)));("a",
                                                                   (inject a))|]
         [@@merlin.hide ] in
@@ -178,7 +174,7 @@ module Bar =
                     [|("key",
                         (inject
                            (Js_of_ocaml.Js.Optdef.option
-                              (Option.map Js_of_ocaml.Js.string key))));
+                              (Stdlib.Option.map Js_of_ocaml.Js.string key))));
                       ("b", (inject b));("a", (inject a))|][@@merlin.hide ] in
       let make =
         ((fun ~a ->
@@ -243,7 +239,7 @@ module Bar =
                     [|("key",
                         (inject
                            (Js_of_ocaml.Js.Optdef.option
-                              (Option.map Js_of_ocaml.Js.string key))));
+                              (Stdlib.Option.map Js_of_ocaml.Js.string key))));
                       ("b", (inject b));("a", (inject a))|][@@merlin.hide ] in
       let component =
         ((fun ~a ->
@@ -315,7 +311,7 @@ module Func(M:X_int) =
                     [|("key",
                         (inject
                            (Js_of_ocaml.Js.Optdef.option
-                              (Option.map Js_of_ocaml.Js.string key))));
+                              (Stdlib.Option.map Js_of_ocaml.Js.string key))));
                       ("b", (inject b));("a", (inject a))|][@@merlin.hide ] in
       let make =
         ((fun ~a ->
@@ -376,7 +372,7 @@ module ForwardRef =
                     ("key",
                       (inject
                          (Js_of_ocaml.Js.Optdef.option
-                            (Option.map Js_of_ocaml.Js.string key))))|]
+                            (Stdlib.Option.map Js_of_ocaml.Js.string key))))|]
         [@@merlin.hide ] in
       let make =
         ((fun theRef ->
@@ -413,7 +409,7 @@ module Memo =
                   [|("key",
                       (inject
                          (Js_of_ocaml.Js.Optdef.option
-                            (Option.map Js_of_ocaml.Js.string key))));
+                            (Stdlib.Option.map Js_of_ocaml.Js.string key))));
                     ("a", (inject a))|][@@merlin.hide ] in
       let make =
         ((fun ~a ->
@@ -463,7 +459,7 @@ module MemoCustomCompareProps =
                   [|("key",
                       (inject
                          (Js_of_ocaml.Js.Optdef.option
-                            (Option.map Js_of_ocaml.Js.string key))));
+                            (Stdlib.Option.map Js_of_ocaml.Js.string key))));
                     ("a", (inject a))|][@@merlin.hide ] in
       let make =
         ((fun ~a ->
@@ -605,10 +601,9 @@ let make =
                 [|("key",
                     (inject
                        (Js_of_ocaml.Js.Optdef.option
-                          (Option.map Js_of_ocaml.Js.string key))));("children",
-                                                                    (inject
-                                                                    children));
-                  ("title", (inject title))|][@@merlin.hide ] in
+                          (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                  ("children", (inject children));("title", (inject title))|]
+    [@@merlin.hide ] in
   let make =
     ((fun ~title ->
         ((fun ~children ->
@@ -676,10 +671,8 @@ let make =
                   ("key",
                     (inject
                        (Js_of_ocaml.Js.Optdef.option
-                          (Option.map Js_of_ocaml.Js.string key))));("children",
-                                                                    (inject
-                                                                    children))|]
-    [@@merlin.hide ] in
+                          (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                  ("children", (inject children))|][@@merlin.hide ] in
   let make =
     ((fun ~children ->
         ((fun ref ->
@@ -769,7 +762,7 @@ let make =
                   [|("key",
                       (inject
                          (Js_of_ocaml.Js.Optdef.option
-                            (Option.map Js_of_ocaml.Js.string key))));
+                            (Stdlib.Option.map Js_of_ocaml.Js.string key))));
                     ("onClick", (inject onClick));("isDisabled",
                                                     (inject isDisabled));
                     ("name", (inject name))|][@@merlin.hide ] in
@@ -851,11 +844,8 @@ let make =
               [|("key",
                   (inject
                      (Js_of_ocaml.Js.Optdef.option
-                        (Option.map Js_of_ocaml.Js.string key))));("name",
-                                                                    (
-                                                                    inject
-                                                                    name))|]
-    [@@merlin.hide ] in
+                        (Stdlib.Option.map Js_of_ocaml.Js.string key))));
+                ("name", (inject name))|][@@merlin.hide ] in
   let make =
     ((fun ?(name= (("joe")[@reason.raw_literal "joe"])) ->
         (((div [||]


### PR DESCRIPTION
- Prefix Stdlib modules with Stdlib so core/container users won't shadow
- Update dune-project to match with recent opam updates (https://github.com/ml-in-barcelona/jsoo-react/pull/177). Maybe we could add a check for this in CI?
- I had the switch very outdated and had a hard time pushing broken formatting, I did the following to avoid this issue
  - Specified 4.12 in Makefile
  - Specified Reason version 3.8.2 (with test)
  - Specified ocamlformat version 0.21.0 (with test)