### PR TITLE
Add an upper ppxlib bound

### DIFF
--- a/jsoo-react.opam
+++ b/jsoo-react.opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.12.0" & < "5.0.0"}
   "js_of_ocaml" {>= "4.0.0" & < "5.2.0"}
   "gen_js_api" {>= "1.0.8" & < "1.2.0"}
-  "ppxlib" {>= "0.23.0"}
+  "ppxlib" {>= "0.23.0" & < "0.26.0"}
   "webtest" {with-test}
   "webtest-js" {with-test}
   "js_of_ocaml-ppx" {with-test}


### PR DESCRIPTION
Hi there,

Thanks for writing this nice PPXs, it looks very interesting!

I'm following up on https://discuss.ocaml.org/t/why-is-building-ocaml-projects-still-so-hard/11812: The PPX is incompatible with ppxlib's AST bump to OCaml 4.14/5.0 in 0.26.0. A better solution than mine here would be to make it compatible and have a `>= 0.26.0` constraint instead.
